### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@
 kapt.incremental.apt=false
 
 # WebAuthn4J CTAP version
-webAuthn4JCTAPVersion=0.1.7
+webAuthn4JCTAPVersion=0.2.0
 isSnapshot=true


### PR DESCRIPTION
## Summary

- Bump `webAuthn4JCTAPVersion` from 0.1.7 to 0.2.0