### PR TITLE
[Not for merge][POC] Add ML-DSA (FIPS 204) post-quantum signature support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.3.21"
 
 kotlinx-coroutines = "1.11.0"
 
-webauthn4j = "0.31.5.RELEASE"
+webauthn4j = "pqc-ml-dsa-support-SNAPSHOT"
 
 slf4j = "2.0.18"
 
@@ -37,8 +37,8 @@ jreleaser = "1.24.0"
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
 # WebAuthn4J
-webauthn4j-core = { module = "com.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
-webauthn4j-test = { module = "com.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
+webauthn4j-core = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
+webauthn4j-test = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
 
 # Third-party libraries
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktor = "3.5.2"
 
 quarkus = "3.38.1"
 
-webauthn4j = "0.31.9.RELEASE"
+webauthn4j = "pqc-ml-dsa-support-SNAPSHOT"
 
 slf4j = "2.0.18"
 
@@ -44,9 +44,9 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
 
 # WebAuthn4J
-webauthn4j-core = { module = "com.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
-webauthn4j-metadata = { module = "com.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
-webauthn4j-test = { module = "com.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
+webauthn4j-core = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
+webauthn4j-metadata = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
+webauthn4j-test = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
 
 # Third-party libraries
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/AttestationStatementRequest.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/AttestationStatementRequest.kt
@@ -2,6 +2,7 @@ package com.webauthn4j.ctap.authenticator.attestation
 
 import com.webauthn4j.ctap.authenticator.data.credential.CredentialKey
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData
+import com.webauthn4j.data.attestation.authenticator.AKPCOSEKey
 import com.webauthn4j.data.attestation.authenticator.COSEKey
 import com.webauthn4j.data.attestation.authenticator.EC2COSEKey
 import com.webauthn4j.data.attestation.authenticator.RSACOSEKey
@@ -56,6 +57,10 @@ class AttestationStatementRequest(
                     )
                     "RSA" -> RSACOSEKey.create(
                         (it.public as RSAPublicKey),
+                        COSEAlgorithmIdentifier.create(this.credentialKey.alg!!)
+                    )
+                    "ML-DSA" -> AKPCOSEKey.create(
+                        it.public,
                         COSEAlgorithmIdentifier.create(this.credentialKey.alg!!)
                     )
                     else -> throw IllegalArgumentException(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedAttestationStatementProviderBase.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedAttestationStatementProviderBase.kt
@@ -26,7 +26,7 @@ abstract class PackedAttestationStatementProviderBase(
         val toBeSigned = ByteBuffer.allocate(authenticatorDataBytes.size + clientDataHash.size)
             .put(authenticatorDataBytes).put(clientDataHash).array()
         val alg: COSEAlgorithmIdentifier = attestationStatementRequest.alg
-        val sig = sign(attestationStatementRequest.credentialKey.keyPair!!, toBeSigned)
+        val sig = sign(attestationStatementRequest.credentialKey.keyPair!!, toBeSigned, alg)
         return PackedAttestationStatement(
             alg,
             sig,
@@ -34,7 +34,7 @@ abstract class PackedAttestationStatementProviderBase(
         )
     }
 
-    protected abstract fun sign(credentialKey: KeyPair, toBeSigned: ByteArray): ByteArray
+    protected abstract fun sign(credentialKey: KeyPair, toBeSigned: ByteArray, alg: COSEAlgorithmIdentifier): ByteArray
     protected abstract fun createAttestationCertificatePath(attestationStatementRequest: AttestationStatementRequest): AttestationCertificatePath
 
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedAttestationStatementProviderBase.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedAttestationStatementProviderBase.kt
@@ -26,7 +26,7 @@ abstract class PackedAttestationStatementProviderBase(
         val toBeSigned = ByteBuffer.allocate(authenticatorDataBytes.size + clientDataHash.size)
             .put(authenticatorDataBytes).put(clientDataHash).array()
         val alg: COSEAlgorithmIdentifier = attestationStatementRequest.alg
-        val sig = sign(attestationStatementRequest.credentialKey.keyPair!!, toBeSigned)
+        val sig = sign(attestationStatementRequest.credentialKey.keyPair!!, toBeSigned, alg)
         return PackedAttestationStatement(
             alg,
             sig,
@@ -34,7 +34,7 @@ abstract class PackedAttestationStatementProviderBase(
         )
     }
 
-    protected abstract fun sign(credentialKey: KeyPair, toBeSigned: ByteArray): ByteArray
+    protected abstract fun sign(credentialKey: KeyPair, toBeSigned: ByteArray, alg: COSEAlgorithmIdentifier): ByteArray
     protected abstract fun createAttestationCertificatePath(attestationStatementRequest: AttestationStatementRequest): AttestationCertificatePath?
 
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedBasicAttestationStatementProvider.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedBasicAttestationStatementProvider.kt
@@ -4,6 +4,7 @@ import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.ctap.authenticator.SignatureCalculator
 import com.webauthn4j.data.SignatureAlgorithm
 import com.webauthn4j.data.attestation.statement.AttestationCertificatePath
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
@@ -17,9 +18,9 @@ class PackedBasicAttestationStatementProvider(
     objectConverter: ObjectConverter
 ) : PackedAttestationStatementProviderBase(objectConverter) {
 
-    override fun sign(credentialKey: KeyPair, toBeSigned: ByteArray): ByteArray {
+    override fun sign(credentialKey: KeyPair, toBeSigned: ByteArray, alg: COSEAlgorithmIdentifier): ByteArray {
         return SignatureCalculator.calculate(
-            SignatureAlgorithm.ES256,
+            signatureAlgorithm,
             attestationKeyPair.private,
             toBeSigned
         )

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedSelfAttestationStatementProvider.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedSelfAttestationStatementProvider.kt
@@ -2,8 +2,8 @@ package com.webauthn4j.ctap.authenticator.attestation
 
 import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.ctap.authenticator.SignatureCalculator
-import com.webauthn4j.data.SignatureAlgorithm
 import com.webauthn4j.data.attestation.statement.AttestationCertificatePath
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import java.security.KeyPair
 
 class PackedSelfAttestationStatementProvider(
@@ -11,21 +11,22 @@ class PackedSelfAttestationStatementProvider(
     objectConverter: ObjectConverter
 ) : PackedAttestationStatementProviderBase(objectConverter) {
 
-    override fun sign(credentialKey: KeyPair, toBeSigned: ByteArray): ByteArray {
+    override fun sign(credentialKey: KeyPair, toBeSigned: ByteArray, alg: COSEAlgorithmIdentifier): ByteArray {
         return SignatureCalculator.calculate(
-            SignatureAlgorithm.ES256,
+            alg.toSignatureAlgorithm(),
             credentialKey.private,
             toBeSigned
         )
     }
 
     override fun createAttestationCertificatePath(attestationStatementRequest: AttestationStatementRequest): AttestationCertificatePath {
+        val signatureAlgorithm = attestationStatementRequest.alg.toSignatureAlgorithm()
         val x509Certificate = AttestationCertificateBuilder(
             subjectDN,
             attestationStatementRequest.credentialKey.keyPair!!.public,
             subjectDN,
             attestationStatementRequest.credentialKey.keyPair!!.private,
-            SignatureAlgorithm.ES256
+            signatureAlgorithm
         )
             .aaguid(attestationStatementRequest.authenticatorData.attestedCredentialData!!.aaguid)
             .build()

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedSelfAttestationStatementProvider.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedSelfAttestationStatementProvider.kt
@@ -2,17 +2,17 @@ package com.webauthn4j.ctap.authenticator.attestation
 
 import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.ctap.authenticator.SignatureCalculator
-import com.webauthn4j.data.SignatureAlgorithm
 import com.webauthn4j.data.attestation.statement.AttestationCertificatePath
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import java.security.KeyPair
 
 class PackedSelfAttestationStatementProvider(
     objectConverter: ObjectConverter
 ) : PackedAttestationStatementProviderBase(objectConverter) {
 
-    override fun sign(credentialKey: KeyPair, toBeSigned: ByteArray): ByteArray {
+    override fun sign(credentialKey: KeyPair, toBeSigned: ByteArray, alg: COSEAlgorithmIdentifier): ByteArray {
         return SignatureCalculator.calculate(
-            SignatureAlgorithm.ES256,
+            alg.toSignatureAlgorithm(),
             credentialKey.private,
             toBeSigned
         )

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -342,7 +342,7 @@ internal class MakeCredentialExecution :
     private suspend fun execStep9to11GenerateAttestedCredential(): AuthenticatorMakeCredentialResponse {
         val userCredential = createUserCredential()
         val rpIdHash = MessageDigestUtil.createSHA256().digest(rpId!!.toByteArray())
-        val alg = COSEAlgorithmIdentifier.ES256 // Attestation statement is fixed to ES256 for now
+        val alg = COSEAlgorithmIdentifier.create(userCredential.credentialKey.alg!!)
         val authenticatorDataProvider: AttestationStatementRequest.AuthenticatorDataProvider =
             object : AttestationStatementRequest.AuthenticatorDataProvider {
                 override fun provide(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -836,7 +836,7 @@ internal class MakeCredentialExecution :
         //spec|   generate an attestation statement for the newly-created credential using
         //spec|   clientDataHash, taking into account the value of the enterpriseAttestation parameter, if present, as described above in Step 9.
         val rpIdHash = MessageDigestUtil.createSHA256().digest(rpId.toByteArray())
-        val alg = COSEAlgorithmIdentifier.ES256
+        val alg = COSEAlgorithmIdentifier.create(userCredential.credentialKey.alg!!)
         val authenticatorDataProvider: AttestationStatementRequest.AuthenticatorDataProvider =
             object : AttestationStatementRequest.AuthenticatorDataProvider {
                 override fun provide(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/internal/KeyPairUtil.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/internal/KeyPairUtil.kt
@@ -4,6 +4,7 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.util.ECUtil
 import com.webauthn4j.util.RSAUtil
 import java.security.KeyPair
+import java.security.KeyPairGenerator
 
 object KeyPairUtil {
     @JvmStatic
@@ -13,6 +14,8 @@ object KeyPairUtil {
             COSEAlgorithmIdentifier.ES384 -> ECUtil.createKeyPair(null, ECUtil.P_384_SPEC)
             COSEAlgorithmIdentifier.ES512 -> ECUtil.createKeyPair(null, ECUtil.P_521_SPEC)
             COSEAlgorithmIdentifier.RS1, COSEAlgorithmIdentifier.RS256, COSEAlgorithmIdentifier.RS384, COSEAlgorithmIdentifier.RS512 -> RSAUtil.createKeyPair()
+            COSEAlgorithmIdentifier.ML_DSA_44, COSEAlgorithmIdentifier.ML_DSA_65, COSEAlgorithmIdentifier.ML_DSA_87 ->
+                KeyPairGenerator.getInstance(alg.toSignatureAlgorithm().jcaName).generateKeyPair()
             else -> throw IllegalArgumentException("algorithmIdentifier is not valid.")
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/internal/KeyPairUtil.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/internal/KeyPairUtil.kt
@@ -4,6 +4,7 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.util.ECUtil
 import com.webauthn4j.util.RSAUtil
 import java.security.KeyPair
+import java.security.KeyPairGenerator
 
 object KeyPairUtil {
     @JvmStatic
@@ -13,6 +14,8 @@ object KeyPairUtil {
             COSEAlgorithmIdentifier.ES384 -> ECUtil.createKeyPair(ECUtil.P_384_SPEC)
             COSEAlgorithmIdentifier.ES512 -> ECUtil.createKeyPair(ECUtil.P_521_SPEC)
             COSEAlgorithmIdentifier.RS1, COSEAlgorithmIdentifier.RS256, COSEAlgorithmIdentifier.RS384, COSEAlgorithmIdentifier.RS512 -> RSAUtil.createKeyPair()
+            COSEAlgorithmIdentifier.ML_DSA_44, COSEAlgorithmIdentifier.ML_DSA_65, COSEAlgorithmIdentifier.ML_DSA_87 ->
+                KeyPairGenerator.getInstance(alg.toSignatureAlgorithm().jcaName).generateKeyPair()
             else -> throw IllegalArgumentException("algorithmIdentifier is not valid.")
         }
     }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AlgorithmsTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AlgorithmsTest.kt
@@ -3,6 +3,7 @@ package integration.setting.authenticator
 import com.webauthn4j.ctap.client.exception.CtapErrorException
 import com.webauthn4j.data.PublicKeyCredentialParameters
 import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.data.attestation.authenticator.AKPCOSEKey
 import com.webauthn4j.data.attestation.authenticator.EC2COSEKey
 import com.webauthn4j.data.attestation.authenticator.RSACOSEKey
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
@@ -12,6 +13,8 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE
 
 @Suppress("EXPERIMENTAL_API_USAGE", "ClassName")
 class AlgorithmsTest {
@@ -84,6 +87,32 @@ class AlgorithmsTest {
             val registrationData = passwordlessTestCase.step2_validateCredentialForRegistration()
             Assertions.assertThat(registrationData.attestationObject!!.authenticatorData.attestedCredentialData!!.coseKey)
                 .isInstanceOf(RSACOSEKey::class.java)
+            passwordlessTestCase.step3_getCredential()
+            passwordlessTestCase.step4_validateCredentialForAuthentication()
+        }
+    }
+
+    @Nested
+    @EnabledForJreRange(min = JRE.JAVA_24)
+    internal inner class rp_requests_ML_DSA_65 {
+        @BeforeEach
+        fun setup() {
+            passwordlessTestCase.relyingParty.registration.frontend.pubKeyCredParams =
+                listOf(
+                    PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ML_DSA_65
+                    )
+                )
+        }
+
+        @Test
+        fun authenticator_supports_ML_DSA_65_test() = runTest {
+            passwordlessTestCase.authenticator.algorithms = setOf(COSEAlgorithmIdentifier.ML_DSA_65)
+            passwordlessTestCase.step1_createCredential()
+            val registrationData = passwordlessTestCase.step2_validateCredentialForRegistration()
+            Assertions.assertThat(registrationData.attestationObject!!.authenticatorData.attestedCredentialData!!.coseKey)
+                .isInstanceOf(AKPCOSEKey::class.java)
             passwordlessTestCase.step3_getCredential()
             passwordlessTestCase.step4_validateCredentialForAuthentication()
         }


### PR DESCRIPTION
- Add ML-DSA-44/65/87 key pair generation in KeyPairUtil
- Add AKPCOSEKey support in AttestationStatementRequest for PQC keys
- Remove ES256 hardcoding in MakeCredentialExecution attestation alg
- Make PackedSelfAttestationStatementProvider algorithm-agnostic (sign and certificate creation use credential algorithm)
- Add alg parameter to PackedAttestationStatementProviderBase.sign()
- Update webauthn4j dependency to JitPack pqc-ml-dsa-support branch
- Add ML-DSA-65 integration test (full registration + authentication flow with self-attestation)

ML-DSA requires JDK 24+ at runtime.