### PR TITLE
Fix CTAPHID protocol spec compliance issues

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDMessageBuilderBase.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDMessageBuilderBase.kt
@@ -3,6 +3,7 @@ package com.webauthn4j.ctap.authenticator.transport.hid
 import com.webauthn4j.ctap.core.data.hid.HIDChannelId
 import com.webauthn4j.ctap.core.data.hid.HIDCommand
 import com.webauthn4j.ctap.core.data.hid.HIDContinuationPacket
+import com.webauthn4j.ctap.core.data.hid.HIDErrorCode
 import com.webauthn4j.ctap.core.data.hid.HIDInitializationPacket
 import com.webauthn4j.ctap.core.data.hid.HIDMessage
 import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.MAX_CONT_PACKET_DATA_SIZE
@@ -12,10 +13,15 @@ import kotlin.math.min
 
 abstract class HIDMessageBuilderBase<T : HIDMessage> {
 
+    companion object {
+        private const val MESSAGE_TIMEOUT_MS = 500L
+    }
+
     private var buffer = ByteBuffer.allocate(0)
     private var counter: Byte = 0
     private var channelId: HIDChannelId? = null
     private var command: HIDCommand? = null
+    private var messageStartTimeMs: Long = 0
 
     fun initialize(initializationPacket: HIDInitializationPacket) {
         buffer = ByteBuffer.allocate(initializationPacket.length.toInt())
@@ -29,14 +35,15 @@ abstract class HIDMessageBuilderBase<T : HIDMessage> {
         )
         channelId = initializationPacket.channelId
         command = initializationPacket.command
+        messageStartTimeMs = System.currentTimeMillis()
     }
 
     fun append(continuationPacket: HIDContinuationPacket) {
         if (!isInitialized) {
-            throw IllegalStateException("Builder is not initialized. It seems initialization packet haven't arrived.")
+            throw HIDProtocolException(HIDErrorCode.INVALID_SEQ, "Builder is not initialized. It seems initialization packet haven't arrived.")
         }
         if (counter != continuationPacket.sec) {
-            throw IllegalStateException("ContinuationPacket with an unexpected sequence number arrived.")
+            throw HIDProtocolException(HIDErrorCode.INVALID_SEQ, "ContinuationPacket with an unexpected sequence number arrived.")
         }
         buffer.put(
             continuationPacket.data,
@@ -52,6 +59,10 @@ abstract class HIDMessageBuilderBase<T : HIDMessage> {
     val isCompleted: Boolean
         get() = !buffer.hasRemaining()
 
+    val isTimedOut: Boolean
+        get() = isInitialized && !isCompleted &&
+                (System.currentTimeMillis() - messageStartTimeMs) > MESSAGE_TIMEOUT_MS
+
     fun build(): T {
         if (!isCompleted) {
             throw IllegalStateException("HID message not completed")
@@ -64,6 +75,7 @@ abstract class HIDMessageBuilderBase<T : HIDMessage> {
         counter = 0
         channelId = null
         command = null
+        messageStartTimeMs = 0
     }
 
     protected abstract fun createMessage(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDProtocolException.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDProtocolException.kt
@@ -1,0 +1,5 @@
+package com.webauthn4j.ctap.authenticator.transport.hid
+
+import com.webauthn4j.ctap.core.data.hid.HIDErrorCode
+
+class HIDProtocolException(val errorCode: HIDErrorCode, message: String) : RuntimeException(message)

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
@@ -15,7 +15,7 @@ import com.webauthn4j.ctap.core.data.nfc.ResponseAPDU
 import com.webauthn4j.util.HexUtil
 import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
-import kotlin.experimental.or
+import java.security.SecureRandom
 
 class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
 
@@ -26,7 +26,7 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
         private const val MINOR_DEVICE_VERSION_NUMBER: Byte = 1
         private const val BUILD_DEVICE_VERSION_NUMBER: Byte = 0
         private val CAPABILITIES =
-            HIDCapability((HIDCapability.CBOR.value or HIDCapability.NMSG.value))
+            HIDCapability((HIDCapability.WINK.value.toInt() or HIDCapability.CBOR.value.toInt()).toByte())
 
         private const val CTAP_REQUEST_HID_PACKET_LOGGING_TEMPLATE = "CTAP Request HID Packet: {}"
         private const val CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE = "CTAP Response HID Packet: {}"
@@ -46,11 +46,21 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
 
     private val hidPacketConverter = HIDPacketConverter()
     private val hidChannels: MutableMap<HIDChannelId, HIDChannel> = HashMap()
-    private var lastAllocatedChannelId: HIDChannelId = HIDChannelId(0)
+    private val secureRandom = SecureRandom()
+
+    @Volatile
+    private var activeTransactionChannelId: HIDChannelId? = null
 
     @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     private val u2fConfirmationWorker = newSingleThreadContext("u2f-confirmation-worker")
 
+    private fun sendError(channelId: HIDChannelId, errorCode: HIDErrorCode, hidPacketHandler: HIDPacketHandler) {
+        HIDERRORResponseMessage(channelId, errorCode).toHIDPackets()
+            .forEach {
+                logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, it.toString())
+                hidPacketHandler.onResponse(it.toBytes())
+            }
+    }
 
     suspend fun onHIDDataReceived(bytes: ByteArray, hidPacketHandler: HIDPacketHandler) {
         try {
@@ -61,36 +71,52 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
             }
             val packetBytes = bytes.copyOfRange(packetOffset, bytes.size)
 
-
             val hidPacket = hidPacketConverter.convert(packetBytes)
             try {
                 logger.debug(CTAP_REQUEST_HID_PACKET_LOGGING_TEMPLATE, hidPacket.toString())
+                val channelId = hidPacket.channelId
 
-                var hidChannel = hidChannels[hidPacket.channelId]
+                if (channelId == HIDChannelId.BROADCAST) {
+                    if (hidPacket !is HIDInitializationPacket || hidPacket.command != HIDCommand.CTAPHID_INIT) {
+                        sendError(channelId, HIDErrorCode.INVALID_CHANNEL, hidPacketHandler)
+                        return
+                    }
+                    val tempChannel = HIDChannel(channelId)
+                    tempChannel.handlePacket(hidPacket) { responsePacket ->
+                        logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, responsePacket.toString())
+                        hidPacketHandler.onResponse(hidPacketConverter.convert(responsePacket))
+                    }
+                    return
+                }
+
+                var hidChannel = hidChannels[channelId]
                 if (hidChannel == null) {
                     if (hidPacket is HIDContinuationPacket) {
-                        logger.debug("Unexpected continuation packet is received. Skipped.")
+                        logger.debug("Unexpected continuation packet on unknown channel. Skipped.")
                         return
-                    } else {
-                        hidChannel = HIDChannel(hidPacket.channelId)
-                        hidChannels[hidPacket.channelId] = hidChannel
+                    }
+                    sendError(channelId, HIDErrorCode.INVALID_CHANNEL, hidPacketHandler)
+                    return
+                }
+
+                if (hidPacket is HIDInitializationPacket) {
+                    val activeChannel = activeTransactionChannelId
+                    if (activeChannel != null && activeChannel != channelId) {
+                        sendError(channelId, HIDErrorCode.CHANNEL_BUSY, hidPacketHandler)
+                        return
                     }
                 }
+
                 hidChannel.handlePacket(hidPacket) { responsePacket ->
-                    logger.debug(
-                        CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE,
-                        responsePacket.toString()
-                    )
-                    val responseBytes = hidPacketConverter.convert(responsePacket)
-                    hidPacketHandler.onResponse(responseBytes)
+                    logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, responsePacket.toString())
+                    hidPacketHandler.onResponse(hidPacketConverter.convert(responsePacket))
                 }
+            } catch (e: HIDProtocolException) {
+                logger.warn("HID protocol error: {}", e.message)
+                sendError(hidPacket.channelId, e.errorCode, hidPacketHandler)
             } catch (e: RuntimeException) {
                 logger.error("Unexpected exception is thrown while processing HID packet", e)
-                HIDERRORResponseMessage(hidPacket.channelId, HIDErrorCode.OTHER).toHIDPackets()
-                    .forEach {
-                        logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, it.toString())
-                        hidPacketHandler.onResponse(it.toBytes())
-                    }
+                sendError(hidPacket.channelId, HIDErrorCode.OTHER, hidPacketHandler)
             }
         } catch (e: RuntimeException) {
             logger.error("Unexpected exception is thrown while processing HID packet", e)
@@ -98,14 +124,19 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
     }
 
     private fun allocateNewChannelId(): HIDChannelId {
-        lastAllocatedChannelId = lastAllocatedChannelId.next()
-        return lastAllocatedChannelId
+        while (true) {
+            val bytes = ByteArray(4)
+            secureRandom.nextBytes(bytes)
+            val id = HIDChannelId(bytes)
+            if (id != HIDChannelId.BROADCAST && !hidChannels.containsKey(id)) {
+                return id
+            }
+        }
     }
 
-    private inner class HIDChannel(channelId: HIDChannelId) {
+    private inner class HIDChannel(private val channelId: HIDChannelId) {
 
         private val hidRequestMessageBuilder = HIDRequestMessageBuilder()
-
 
         @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
         private val hidKeepAliveWorker =
@@ -115,10 +146,25 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
             hidPacket: HIDPacket,
             responseCallback: ResponseCallback<HIDPacket>
         ) {
+            if (hidPacket is HIDInitializationPacket && hidRequestMessageBuilder.isTimedOut) {
+                logger.debug("Message assembly timed out, resetting builder")
+                hidRequestMessageBuilder.clear()
+            }
+
             when (hidPacket) {
-                is HIDInitializationPacket -> hidRequestMessageBuilder.initialize(hidPacket)
-                is HIDContinuationPacket -> hidRequestMessageBuilder.append(hidPacket)
-                else -> throw IllegalStateException("Unknown HIDPacket subclass")
+                is HIDInitializationPacket -> {
+                    activeTransactionChannelId = channelId
+                    hidRequestMessageBuilder.initialize(hidPacket)
+                }
+                is HIDContinuationPacket -> {
+                    if (hidRequestMessageBuilder.isTimedOut) {
+                        hidRequestMessageBuilder.clear()
+                        activeTransactionChannelId = null
+                        throw HIDProtocolException(HIDErrorCode.MSG_TIMEOUT, "Message assembly timed out")
+                    }
+                    hidRequestMessageBuilder.append(hidPacket)
+                }
+                else -> throw HIDProtocolException(HIDErrorCode.OTHER, "Unknown HIDPacket subclass")
             }
             if (hidRequestMessageBuilder.isCompleted) {
                 val hidMessage = hidRequestMessageBuilder.build()
@@ -129,12 +175,16 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
                             responseCallback.onResponse(parameter)
                         }
                     }
+                } catch (e: HIDProtocolException) {
+                    throw e
                 } catch (e: RuntimeException) {
                     logger.error("Unexpected exception is thrown while processing HID message", e)
                     HIDERRORResponseMessage(hidMessage.channelId, HIDErrorCode.OTHER).toHIDPackets()
                         .forEach { packet ->
                             responseCallback.onResponse(packet)
                         }
+                } finally {
+                    activeTransactionChannelId = null
                 }
             }
         }
@@ -170,7 +220,7 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
                     logger.debug(CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE, it.toString())
                     responseCallback.onResponse(it)
                 }
-                else -> throw IllegalArgumentException("%s is not supported".format(hidMessage.command))
+                else -> throw HIDProtocolException(HIDErrorCode.INVALID_CMD, "%s is not supported".format(hidMessage.command))
             }
         }
 


### PR DESCRIPTION
Fix CTAPHID protocol layer issues found during CTAP 2.0 spec compliance audit.

- **Capability flags**: Remove NMSG flag (MSG/U2F is implemented), add WINK flag
- **Random channel IDs**: Use SecureRandom instead of sequential allocation (spec 11.2.9.1.3)
- **Broadcast channel control**: Only allow CTAPHID_INIT on broadcast channel, return INVALID_CHANNEL for unknown channels
- **BUSY detection**: Detect cross-channel transaction conflicts and return CHANNEL_BUSY
- **Transaction timeout**: Add 500ms message assembly timeout with ERR_MSG_TIMEOUT
- **Specific error codes**: Return INVALID_CMD, INVALID_SEQ instead of generic OTHER