### PR TITLE
Add UHID and USB-IP bridge modules for virtual FIDO2 devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ nbdist/
 
 ### Project Files ###
 
+.claude/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ plugins {
     id(libs.plugins.sonarqube.get().pluginId) version libs.versions.sonarqube
     id(libs.plugins.jreleaser.get().pluginId) version libs.versions.jreleaser
     id(libs.plugins.ksp.get().pluginId) version libs.versions.ksp apply false
+    id(libs.plugins.kotlin.plugin.allopen.get().pluginId) version libs.versions.kotlin apply false
+    id(libs.plugins.quarkus.get().pluginId) version libs.versions.quarkus apply false
 }
 
 private val webAuthn4JCTAPVersion: String by project
@@ -39,14 +41,16 @@ repositories {
 
 
 subprojects {
+    if (name.endsWith("-sample") || name.startsWith("unifidokey-")) return@subprojects
+
     apply(plugin = "signing")
     apply(plugin = "maven-publish")
-
     apply(plugin = "java-library")
+    apply(plugin = "org.jreleaser")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "jacoco")
-    apply(plugin = "org.jreleaser")
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
         maven(url = "https://jitpack.io")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,11 @@
 [versions]
 kotlin = "2.4.0"
 
-kotlinx-coroutines = "1.11.0"
+kotlinx-coroutines = "1.10.2"
+
+ktor = "3.1.3"
+
+quarkus = "3.35.4"
 
 webauthn4j = "0.31.6.RELEASE"
 
@@ -36,8 +40,12 @@ jreleaser = "1.24.0"
 # Kotlin
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
+# Ktor
+ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
+
 # WebAuthn4J
 webauthn4j-core = { module = "com.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
+webauthn4j-metadata = { module = "com.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
 webauthn4j-test = { module = "com.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
 
 # Third-party libraries
@@ -71,3 +79,4 @@ asciidoctor = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor"}
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+quarkus = { id = "io.quarkus", version.ref = "quarkus" }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,40 @@
+{
+  "aaguid" : "33c1642b-b5e9-423d-9add-5a0119c2a8b8",
+  "description" : "UniFIDOKey USB-IP Virtual FIDO2 Authenticator",
+  "authenticatorVersion" : 2,
+  "protocolFamily" : "fido2",
+  "schema" : 3,
+  "upv" : [ {
+    "major" : 1,
+    "minor" : 0
+  } ],
+  "authenticationAlgorithms" : [ "secp256r1_ecdsa_sha256_raw" ],
+  "publicKeyAlgAndEncodings" : [ "cose" ],
+  "attestationTypes" : [ "basic_full" ],
+  "userVerificationDetails" : [ [ {
+    "userVerificationMethod" : "presence_internal"
+  } ], [ {
+    "userVerificationMethod" : "passcode_internal"
+  } ], [ {
+    "userVerificationMethod" : "passcode_external"
+  } ] ],
+  "keyProtection" : [ "software" ],
+  "matcherProtection" : [ "on_chip" ],
+  "attachmentHint" : [ "external" ],
+  "tcDisplay" : [ ],
+  "attestationRootCertificates" : [ "MIIBkzCCATmgAwIBAgIBATAKBggqhkjOPQQDAjBJMQswCQYDVQQGEwJVUzEbMBkGA1UEChMSV2ViQXV0aG40SiBQcm9qZWN0MR0wGwYDVQQDExRVbmlmaWRvS2V5RGVtb1Jvb3RDQTAgFw0wMDAxMDEwMDAwMDBaGA8yOTk5MTIzMTIzNTk1OVowSTELMAkGA1UEBhMCVVMxGzAZBgNVBAoTEldlYkF1dGhuNEogUHJvamVjdDEdMBsGA1UEAxMUVW5pZmlkb0tleURlbW9Sb290Q0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATNdy65xbpUNeEzQcq1CgF6yGpGw8eUD3+Udlv5yjjraC26D+ZViUqYKPrBOnWNFxk5F7zpHlZlRowzQUCE3f8ioxAwDjAMBgNVHRMEBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIDEGs0M2wfwKoYlIcySks1x8ijv5pEvAC1nvFxnmbtjHAiEA0aOqrO4DwseP8i0XLPsw+uJYTgaP6+hBTLVGANws7LI" ],
+  "authenticatorGetInfo" : {
+    "versions" : [ "U2F_V2", "FIDO_2_0" ],
+    "extensions" : [ ],
+    "aaguid" : "33c1642bb5e9423d9add5a0119c2a8b8",
+    "options" : {
+      "plat" : false,
+      "rk" : true,
+      "clientPin" : false,
+      "up" : true,
+      "uv" : true
+    },
+    "maxMsgSize" : 2048,
+    "pinUvAuthProtocols" : [ 1 ]
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
 include(":webauthn4j-ctap-core")
 include(":webauthn4j-ctap-authenticator")
 include(":webauthn4j-ctap-client")
+include(":webauthn4j-ctap-authenticator-uhid")
+include(":unifidokey-uhid")
+include(":webauthn4j-ctap-authenticator-usbip")
+include(":unifidokey-usbip")

--- a/unifidokey-uhid/README.md
+++ b/unifidokey-uhid/README.md
@@ -1,0 +1,40 @@
+# unifidokey-uhid
+
+CLI application that creates a virtual FIDO2 security key on Linux via UHID.
+
+## Quick Start
+
+```bash
+# Build
+./gradlew :unifidokey-uhid:quarkusBuild
+
+# Run (requires root or udev rules for /dev/uhid access)
+sudo java -jar unifidokey-uhid/build/unifidokey-uhid.jar
+```
+
+## CLI Options
+
+```
+Usage: webauthn4j-uhid [-hV] [-d=<devicePath>]
+  -d, --device=<devicePath>   UHID device path (default: /dev/uhid)
+  -h, --help                  Show this help message and exit.
+  -V, --version               Print version information and exit.
+```
+
+## Verifying the Device
+
+```bash
+ls /dev/hidraw*
+fido2-token -L
+```
+
+## Permissions
+
+Run with `sudo`, or create a udev rule:
+
+```bash
+sudo usermod -a -G input $USER
+echo 'KERNEL=="uhid", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/99-uhid.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+# Log out and back in
+```

--- a/unifidokey-uhid/build.gradle.kts
+++ b/unifidokey-uhid/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+    id(libs.plugins.kotlin.plugin.allopen.get().pluginId)
+    id(libs.plugins.quarkus.get().pluginId)
+}
+
+description = "Sample application demonstrating CTAP UHID bridge on Linux"
+
+repositories {
+    mavenCentral()
+}
+
+allOpen {
+    annotation("jakarta.enterprise.context.ApplicationScoped")
+}
+
+dependencies {
+    implementation(project(":webauthn4j-ctap-authenticator-uhid"))
+    implementation(project(":webauthn4j-ctap-authenticator"))
+    implementation(libs.kotlinx.coroutines.core)
+
+    implementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:${libs.versions.quarkus.get()}"))
+    implementation("io.quarkus:quarkus-kotlin")
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-picocli")
+}

--- a/unifidokey-uhid/src/main/kotlin/com/webauthn4j/unifidokey/uhid/UniFIDOKeyUHID.kt
+++ b/unifidokey-uhid/src/main/kotlin/com/webauthn4j/unifidokey/uhid/UniFIDOKeyUHID.kt
@@ -1,0 +1,59 @@
+package com.webauthn4j.unifidokey.uhid
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDDevice
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDDeviceConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.jboss.logging.Logger
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import java.io.File
+import kotlin.system.exitProcess
+
+@Command(name = "unifidokey-uhid", mixinStandardHelpOptions = true,
+    description = ["Virtual FIDO2 security key via Linux UHID"])
+class UniFIDOKeyUHID : Runnable {
+
+    @Option(names = ["-d", "--device"], description = ["UHID device path (default: /dev/uhid)"])
+    var devicePath: String = "/dev/uhid"
+
+    private val logger = Logger.getLogger(UniFIDOKeyUHID::class.java)
+
+    override fun run() {
+        checkDeviceAccess()
+
+        val config = UHIDDeviceConfig(devicePath = devicePath)
+        val authenticator = CtapAuthenticator()
+        val device = UHIDDevice(authenticator, config)
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        Runtime.getRuntime().addShutdownHook(Thread {
+            runBlocking { device.stop() }
+        })
+
+        runBlocking {
+            device.start(scope)
+        }
+
+        logger.info("UHID Virtual FIDO2 Device is running")
+        logger.infof("  Device path: %s", config.devicePath)
+
+        // Keep running until interrupted
+        Thread.currentThread().join()
+    }
+
+    private fun checkDeviceAccess() {
+        val uhidFile = File(devicePath)
+        if (!uhidFile.exists()) {
+            logger.errorf("%s does not exist. Make sure your kernel has UHID support (Linux 3.6+).", devicePath)
+            exitProcess(1)
+        }
+        if (!uhidFile.canRead() || !uhidFile.canWrite()) {
+            logger.errorf("No read/write permission on %s. Try running with sudo or configure udev rules.", devicePath)
+            exitProcess(1)
+        }
+    }
+}

--- a/unifidokey-uhid/src/main/resources/application.properties
+++ b/unifidokey-uhid/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.package.jar.type=uber-jar
+quarkus.package.jar.add-runner-suffix=false
+quarkus.package.output-name=unifidokey-uhid
+quarkus.banner.enabled=false

--- a/unifidokey-uhid/src/main/resources/application.properties
+++ b/unifidokey-uhid/src/main/resources/application.properties
@@ -2,3 +2,4 @@ quarkus.package.jar.type=uber-jar
 quarkus.package.jar.add-runner-suffix=false
 quarkus.package.output-name=unifidokey-uhid
 quarkus.banner.enabled=false
+quarkus.log.console.stderr=true

--- a/unifidokey-usbip/README.md
+++ b/unifidokey-usbip/README.md
@@ -1,0 +1,40 @@
+# unifidokey-usbip
+
+CLI application that creates a virtual FIDO2 security key over USB/IP. Remote machines (Windows, Linux) can attach it over the network.
+
+## Quick Start
+
+```bash
+# Build
+./gradlew :unifidokey-usbip:quarkusBuild
+
+# Run
+java -jar unifidokey-usbip/build/unifidokey-usbip.jar
+```
+
+## CLI Options
+
+```
+Usage: webauthn4j-usbip [-hV] [-H=<host>] [-p=<port>]
+  -H, --host=<host>   Bind address (default: 0.0.0.0)
+  -p, --port=<port>   TCP port (default: 3240)
+  -h, --help          Show this help message and exit.
+  -V, --version       Print version information and exit.
+```
+
+## Connecting from Linux
+
+```bash
+sudo modprobe vhci-hcd
+usbip list -r <server-ip>
+sudo usbip attach -r <server-ip> -b 1-1
+```
+
+## Connecting from Windows
+
+Install [usbip-win2](https://github.com/vadimgrn/usbip-win2), then:
+
+```powershell
+usbip.exe list -r <server-ip>
+usbip.exe attach -r <server-ip> -b 1-1
+```

--- a/unifidokey-usbip/build.gradle.kts
+++ b/unifidokey-usbip/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.webauthn4j.metadata)
 
-    implementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:${libs.versions.quarkus.get()}"))
+    implementation(platform("io.quarkus.platform:quarkus-bom:${libs.versions.quarkus.get()}"))
     implementation("io.quarkus:quarkus-kotlin")
     implementation("io.quarkus:quarkus-arc")
     implementation("io.quarkus:quarkus-picocli")

--- a/unifidokey-usbip/build.gradle.kts
+++ b/unifidokey-usbip/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+    id(libs.plugins.kotlin.plugin.allopen.get().pluginId)
+    id(libs.plugins.quarkus.get().pluginId)
+}
+
+description = "Sample application demonstrating CTAP USB-IP server"
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+allOpen {
+    annotation("jakarta.enterprise.context.ApplicationScoped")
+}
+
+dependencies {
+    implementation(project(":webauthn4j-ctap-authenticator-usbip"))
+    implementation(project(":webauthn4j-ctap-authenticator"))
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.webauthn4j.metadata)
+
+    implementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:${libs.versions.quarkus.get()}"))
+    implementation("io.quarkus:quarkus-kotlin")
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-picocli")
+}

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserVerificationHandler.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserVerificationHandler.kt
@@ -1,0 +1,39 @@
+package com.webauthn4j.unifidokey.usbip
+
+import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
+import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
+import com.webauthn4j.ctap.authenticator.UserVerificationHandler
+import com.webauthn4j.ctap.core.data.options.UserVerificationOption
+import kotlinx.coroutines.delay
+
+/**
+ * A UserVerificationHandler that auto-approves after a delay.
+ * The delay ensures CTAPHID_KEEPALIVE messages are sent by the HID transport layer.
+ */
+class ConsoleUserVerificationHandler : UserVerificationHandler {
+
+    companion object {
+        private const val APPROVAL_DELAY_MS = 1000L
+    }
+
+    override fun getUserVerificationOption(rpId: String?): UserVerificationOption =
+        UserVerificationOption.READY
+
+    override suspend fun onMakeCredentialConsentRequested(
+        makeCredentialConsentRequest: MakeCredentialConsentRequest
+    ): Boolean {
+        val rpId = makeCredentialConsentRequest.rp?.id ?: "unknown"
+        println("MakeCredential consent requested for RP: $rpId (auto-approving in ${APPROVAL_DELAY_MS}ms)")
+        delay(APPROVAL_DELAY_MS)
+        return true
+    }
+
+    override suspend fun onGetAssertionConsentRequested(
+        getAssertionConsentRequest: GetAssertionConsentRequest
+    ): Boolean {
+        val rpId = getAssertionConsentRequest.rpId ?: "unknown"
+        println("GetAssertion consent requested for RP: $rpId (auto-approving in ${APPROVAL_DELAY_MS}ms)")
+        delay(APPROVAL_DELAY_MS)
+        return true
+    }
+}

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
@@ -11,6 +11,7 @@ import com.webauthn4j.data.KeyProtectionType
 import com.webauthn4j.data.MatcherProtectionType
 import com.webauthn4j.data.PublicKeyRepresentationFormat
 import com.webauthn4j.data.UserVerificationMethod
+import com.webauthn4j.data.attestation.authenticator.AAGUID
 import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule
 import com.webauthn4j.metadata.data.statement.AuthenticatorGetInfo
 import com.webauthn4j.metadata.data.statement.AuthenticatorGetInfo.Options
@@ -18,8 +19,13 @@ import com.webauthn4j.metadata.data.statement.MetadataStatement
 import com.webauthn4j.metadata.data.statement.VerificationMethodANDCombinations
 import com.webauthn4j.metadata.data.statement.VerificationMethodDescriptor
 import com.webauthn4j.metadata.data.statement.Version
+import com.webauthn4j.util.HexUtil
 import picocli.CommandLine.Command
+import tools.jackson.core.JsonGenerator
 import tools.jackson.databind.SerializationFeature
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.annotation.JsonSerialize
+import tools.jackson.databind.ser.std.StdSerializer
 
 @Command(name = "generate-metadata", mixinStandardHelpOptions = true,
     description = ["Generate FIDO MetadataStatement JSON for Conformance Tools"])
@@ -48,6 +54,9 @@ class GenerateMetadataStatement : Runnable {
                 )),
                 VerificationMethodANDCombinations(listOf(
                     VerificationMethodDescriptor(UserVerificationMethod.PASSCODE_INTERNAL, null, null, null),
+                )),
+                VerificationMethodANDCombinations(listOf(
+                    VerificationMethodDescriptor(UserVerificationMethod.PASSCODE_EXTERNAL, null, null, null),
                 ))
             ),
             listOf(KeyProtectionType.SOFTWARE), // keyProtection
@@ -65,19 +74,19 @@ class GenerateMetadataStatement : Runnable {
             null, // supportedExtensions
             AuthenticatorGetInfo(
                 listOf("U2F_V2", "FIDO_2_0"),
-                null, // extensions
+                emptyList(), // extensions
                 aaguid,
                 Options(
                     Options.PlatformOption.CROSS_PLATFORM,
                     Options.ResidentKeyOption.SUPPORTED,
-                    null, // clientPin
+                    Options.ClientPINOption.NOT_SET, // clientPin (PIN not set initially)
                     Options.UserPresenceOption.SUPPORTED,
                     Options.UserVerificationOption.READY,
                     null, // uvToken
                     null  // config
                 ),
                 2048, // maxMsgSize
-                null  // pinUvAuthProtocols
+                listOf(com.webauthn4j.data.PinProtocolVersion.VERSION_1)  // pinUvAuthProtocols
             )
         )
 
@@ -86,7 +95,19 @@ class GenerateMetadataStatement : Runnable {
             .addModule(WebAuthnMetadataJSONModule())
             .enable(SerializationFeature.INDENT_OUTPUT)
             .changeDefaultPropertyInclusion { JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL) }
+            .addMixIn(AuthenticatorGetInfo::class.java, AuthenticatorGetInfoHexAaguidMixIn::class.java)
             .build()
         println(mapper.writeValueAsString(metadataStatement))
+    }
+
+    abstract class AuthenticatorGetInfoHexAaguidMixIn {
+        @get:JsonSerialize(using = HexAaguidSerializer::class)
+        abstract val aaguid: AAGUID
+    }
+
+    class HexAaguidSerializer : StdSerializer<AAGUID>(AAGUID::class.java) {
+        override fun serialize(value: AAGUID, gen: JsonGenerator, ctxt: SerializationContext) {
+            gen.writeString(HexUtil.encodeToString(value.bytes).lowercase())
+        }
     }
 }

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
@@ -1,0 +1,92 @@
+package com.webauthn4j.unifidokey.usbip
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.attestation.DemoAttestationConstants
+import com.webauthn4j.data.AttachmentHint
+import com.webauthn4j.data.AuthenticationAlgorithm
+import com.webauthn4j.data.AuthenticatorAttestationType
+import com.webauthn4j.data.KeyProtectionType
+import com.webauthn4j.data.MatcherProtectionType
+import com.webauthn4j.data.PublicKeyRepresentationFormat
+import com.webauthn4j.data.UserVerificationMethod
+import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule
+import com.webauthn4j.metadata.data.statement.AuthenticatorGetInfo
+import com.webauthn4j.metadata.data.statement.AuthenticatorGetInfo.Options
+import com.webauthn4j.metadata.data.statement.MetadataStatement
+import com.webauthn4j.metadata.data.statement.VerificationMethodANDCombinations
+import com.webauthn4j.metadata.data.statement.VerificationMethodDescriptor
+import com.webauthn4j.metadata.data.statement.Version
+import picocli.CommandLine.Command
+import tools.jackson.databind.SerializationFeature
+
+@Command(name = "generate-metadata", mixinStandardHelpOptions = true,
+    description = ["Generate FIDO MetadataStatement JSON for Conformance Tools"])
+class GenerateMetadataStatement : Runnable {
+
+    override fun run() {
+        val aaguid = CtapAuthenticator.AAGUID
+
+        val metadataStatement = MetadataStatement(
+            null, // legalHeader
+            null, // aaid
+            aaguid,
+            null, // attestationCertificateKeyIdentifiers
+            "UniFIDOKey USB-IP Virtual FIDO2 Authenticator", // description
+            null, // alternativeDescriptions
+            2,    // authenticatorVersion
+            "fido2", // protocolFamily
+            3,    // schema
+            listOf(Version(1, 0)), // upv
+            listOf(AuthenticationAlgorithm.SECP256R1_ECDSA_SHA256_RAW), // authenticationAlgorithms
+            listOf(PublicKeyRepresentationFormat.COSE), // publicKeyAlgAndEncodings
+            listOf(AuthenticatorAttestationType.BASIC_FULL), // attestationTypes
+            listOf( // userVerificationDetails
+                VerificationMethodANDCombinations(listOf(
+                    VerificationMethodDescriptor(UserVerificationMethod.PRESENCE_INTERNAL, null, null, null),
+                )),
+                VerificationMethodANDCombinations(listOf(
+                    VerificationMethodDescriptor(UserVerificationMethod.PASSCODE_INTERNAL, null, null, null),
+                ))
+            ),
+            listOf(KeyProtectionType.SOFTWARE), // keyProtection
+            null, // isKeyRestricted
+            null, // isFreshUserVerificationRequired
+            listOf(MatcherProtectionType.ON_CHIP), // matcherProtection
+            null, // cryptoStrength
+            listOf(AttachmentHint.EXTERNAL), // attachmentHint
+            emptyList(), // tcDisplay
+            null, // tcDisplayContentType
+            null, // tcDisplayPNGCharacteristics
+            listOf(DemoAttestationConstants.DEMO_ROOT_CA_CERTIFICATE), // attestationRootCertificates
+            null, // ecdaaTrustAnchors
+            null, // icon
+            null, // supportedExtensions
+            AuthenticatorGetInfo(
+                listOf("U2F_V2", "FIDO_2_0"),
+                null, // extensions
+                aaguid,
+                Options(
+                    Options.PlatformOption.CROSS_PLATFORM,
+                    Options.ResidentKeyOption.SUPPORTED,
+                    null, // clientPin
+                    Options.UserPresenceOption.SUPPORTED,
+                    Options.UserVerificationOption.READY,
+                    null, // uvToken
+                    null  // config
+                ),
+                2048, // maxMsgSize
+                null  // pinUvAuthProtocols
+            )
+        )
+
+        val objectConverter = ObjectConverter()
+        val mapper = objectConverter.jsonMapper.rebuild()
+            .addModule(WebAuthnMetadataJSONModule())
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .changeDefaultPropertyInclusion { JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL) }
+            .build()
+        println(mapper.writeValueAsString(metadataStatement))
+    }
+}

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/TopCommand.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/TopCommand.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.unifidokey.usbip
+
+import io.quarkus.picocli.runtime.annotations.TopCommand
+import picocli.CommandLine.Command
+
+@TopCommand
+@Command(name = "unifidokey-usbip", mixinStandardHelpOptions = true,
+    subcommands = [UniFIDOKeyUSBIP::class, GenerateMetadataStatement::class])
+class TopCommand

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
@@ -1,0 +1,50 @@
+package com.webauthn4j.unifidokey.usbip
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDevice
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.jboss.logging.Logger
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+@Command(name = "serve", mixinStandardHelpOptions = true,
+    description = ["Start USB-IP server exposing a virtual FIDO2 security key"])
+class UniFIDOKeyUSBIP : Runnable {
+
+    @Option(names = ["-H", "--host"], description = ["Bind address (default: 0.0.0.0)"])
+    var host: String = "0.0.0.0"
+
+    @Option(names = ["-p", "--port"], description = ["TCP port (default: 3240)"])
+    var port: Int = 3240
+
+    private val logger = Logger.getLogger(UniFIDOKeyUSBIP::class.java)
+
+    override fun run() {
+        val config = USBIPDeviceConfig(host = host, port = port)
+        val authenticator = CtapAuthenticator(
+            attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey()
+        )
+        val device = USBIPDevice(authenticator, config)
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        Runtime.getRuntime().addShutdownHook(Thread {
+            runBlocking { device.stop() }
+        })
+
+        runBlocking {
+            device.start(scope)
+        }
+
+        logger.info("USB-IP Virtual FIDO2 Device is running")
+        logger.infof("  Server: %s:%d", config.host, config.port)
+        logger.infof("  Bus ID: %s", config.busId)
+
+        // Keep running until interrupted
+        Thread.currentThread().join()
+    }
+}

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
@@ -27,7 +27,8 @@ class UniFIDOKeyUSBIP : Runnable {
     override fun run() {
         val config = USBIPDeviceConfig(host = host, port = port)
         val authenticator = CtapAuthenticator(
-            attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey()
+            attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey(),
+            userVerificationHandler = ConsoleUserVerificationHandler()
         )
         val device = USBIPDevice(authenticator, config)
         val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())

--- a/unifidokey-usbip/src/main/resources/application.properties
+++ b/unifidokey-usbip/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.package.jar.type=uber-jar
+quarkus.package.jar.add-runner-suffix=false
+quarkus.package.output-name=unifidokey-usbip
+quarkus.banner.enabled=false

--- a/unifidokey-usbip/src/main/resources/application.properties
+++ b/unifidokey-usbip/src/main/resources/application.properties
@@ -2,3 +2,5 @@ quarkus.package.jar.type=uber-jar
 quarkus.package.jar.add-runner-suffix=false
 quarkus.package.output-name=unifidokey-usbip
 quarkus.banner.enabled=false
+quarkus.log.console.stderr=true
+quarkus.log.category."com.webauthn4j".level=DEBUG

--- a/webauthn4j-ctap-authenticator-uhid/README.md
+++ b/webauthn4j-ctap-authenticator-uhid/README.md
@@ -1,0 +1,28 @@
+# webauthn4j-ctap-authenticator-uhid
+
+Library that exposes a `CtapAuthenticator` as a virtual USB HID FIDO2 device via the Linux UHID subsystem.
+
+## Requirements
+
+- Linux kernel 3.6+ with UHID support
+- Java 17+
+- Read/write access to `/dev/uhid`
+
+## Usage
+
+```kotlin
+val authenticator = CtapAuthenticator()
+val device = UHIDDevice(authenticator)
+val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+device.start(scope)
+// The device is now visible as /dev/hidrawN
+```
+
+## Key Classes
+
+| Class | Description |
+|---|---|
+| `UHIDDevice` | Lifecycle management and UHID event loop |
+| `UHIDConnection` | Low-level `/dev/uhid` I/O |
+| `UHIDDeviceConfig` | Device metadata (name, VID, PID, etc.) |

--- a/webauthn4j-ctap-authenticator-uhid/build.gradle.kts
+++ b/webauthn4j-ctap-authenticator-uhid/build.gradle.kts
@@ -1,0 +1,56 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+}
+
+description = "CTAP UHID bridge library for Linux"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions{
+        jvmTarget = JvmTarget.JVM_17
+        javaParameters = true
+    }
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+    jacocoTestReport {
+        reports {
+            xml.required.set(true)
+        }
+    }
+}
+
+dependencies {
+
+    // Project dependencies
+    api(project(":webauthn4j-ctap-authenticator"))
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.slf4j.api)
+
+    // Test dependencies
+    testImplementation(platform(libs.junit.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.logback.classic)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.assertj.core)
+
+    testImplementation(libs.jackson.module.kotlin)
+    testImplementation(libs.jackson.dataformat.cbor)
+    testImplementation(project(":webauthn4j-ctap-client"))
+    testImplementation(libs.webauthn4j.test)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
@@ -40,6 +40,7 @@ class UHIDDevice(
     suspend fun start(scope: CoroutineScope) {
         connection.open()
         createDevice()
+        hidTransport.start(scope)
         readJob = scope.launch(Dispatchers.IO) {
             readLoop()
         }
@@ -48,6 +49,7 @@ class UHIDDevice(
     suspend fun stop() {
         readJob?.cancelAndJoin()
         readJob = null
+        hidTransport.close()
         if (deviceCreated) {
             destroyDevice()
         }
@@ -96,11 +98,13 @@ class UHIDDevice(
         }
     }
 
-    private suspend fun handleOutput(output: OutputReportEvent) {
+    private fun handleOutput(output: OutputReportEvent) {
         logger.debug("UHID_OUTPUT: size={} (actual HID report: {} bytes), rtype={}",
             output.size, output.data.size, output.rtype)
         hidTransport.onHIDDataReceived(output.data) { responseBytes ->
-            connection.writeEvent(InputReportEvent(responseBytes))
+            synchronized(connection) {
+                connection.writeEvent(InputReportEvent(responseBytes))
+            }
         }
     }
 }

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
@@ -1,0 +1,106 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDTransport
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CreateDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.DestroyDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.InputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CloseEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OpenEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.StartEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.StopEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UnknownEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.FidoHIDReportDescriptor
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.UHIDConnection
+import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.nio.channels.AsynchronousCloseException
+import java.nio.channels.ClosedChannelException
+
+/**
+ * Virtual USB FIDO2 security key backed by the Linux UHID subsystem.
+ *
+ * Exposes a [CtapAuthenticator] to the OS as if it were a physical USB HID
+ * FIDO2 device.
+ */
+class UHIDDevice(
+    ctapAuthenticator: CtapAuthenticator,
+    private val config: UHIDDeviceConfig = UHIDDeviceConfig(),
+    private val connection: UHIDConnection = UHIDConnection(config.devicePath)
+) : AutoCloseable {
+
+    private val logger = LoggerFactory.getLogger(UHIDDevice::class.java)
+    private val hidTransport = HIDTransport(ctapAuthenticator)
+
+    private var readJob: Job? = null
+    private var deviceCreated = false
+
+    suspend fun start(scope: CoroutineScope) {
+        connection.open()
+        createDevice()
+        readJob = scope.launch(Dispatchers.IO) {
+            readLoop()
+        }
+    }
+
+    suspend fun stop() {
+        readJob?.cancelAndJoin()
+        readJob = null
+        if (deviceCreated) {
+            destroyDevice()
+        }
+        connection.close()
+    }
+
+    override fun close() {
+        runBlocking { stop() }
+    }
+
+    private fun createDevice() {
+        connection.writeEvent(CreateDeviceEvent(config, FidoHIDReportDescriptor.DESCRIPTOR))
+        deviceCreated = true
+        logger.info("Virtual FIDO2 device created: {}", config.deviceName)
+    }
+
+    private fun destroyDevice() {
+        try {
+            connection.writeEvent(DestroyDeviceEvent)
+            logger.info("Virtual FIDO2 device destroyed")
+        } catch (e: IOException) {
+            logger.debug("Failed to send destroy event", e)
+        }
+        deviceCreated = false
+    }
+
+    private suspend fun readLoop() {
+        try {
+            while (currentCoroutineContext().isActive && connection.isOpen) {
+                when (val event = connection.readEvent()) {
+                    is OutputReportEvent -> handleOutput(event)
+                    is StartEvent -> logger.debug("UHID device started")
+                    is StopEvent -> logger.debug("UHID device stopped")
+                    is OpenEvent -> logger.debug("UHID device opened by host")
+                    is CloseEvent -> logger.debug("UHID device closed by host")
+                    is UnknownEvent -> logger.debug("Unknown UHID event type: {}", event.type)
+                    is CreateDeviceEvent, is DestroyDeviceEvent, is InputReportEvent -> {}
+                }
+            }
+        } catch (_: ClosedChannelException) {
+            logger.debug("UHID connection closed")
+        } catch (_: AsynchronousCloseException) {
+            logger.debug("UHID connection closed asynchronously")
+        } catch (e: IOException) {
+            logger.error("I/O error in UHID read loop", e)
+        }
+    }
+
+    private suspend fun handleOutput(output: OutputReportEvent) {
+        logger.debug("UHID_OUTPUT: size={} (actual HID report: {} bytes), rtype={}",
+            output.size, output.data.size, output.rtype)
+        hidTransport.onHIDDataReceived(output.data) { responseBytes ->
+            connection.writeEvent(InputReportEvent(responseBytes))
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceConfig.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceConfig.kt
@@ -1,0 +1,11 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+data class UHIDDeviceConfig(
+    val deviceName: String = "WebAuthn4J Virtual FIDO2 Key",
+    val vendorId: Int = 0x1234,
+    val productId: Int = 0xF1D0,
+    val version: Int = 0x0100,
+    val devicePath: String = "/dev/uhid",
+    val physicalAddress: String = "",
+    val uniqueId: String = ""
+)

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CloseEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CloseEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_CLOSE event: userspace closed the device.
+ */
+data object CloseEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_CLOSE)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CreateDeviceEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CreateDeviceEvent.kt
@@ -1,0 +1,101 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDDeviceConfig
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * UHID_CREATE2 event: creates a virtual HID device.
+ */
+data class CreateDeviceEvent(
+    val config: UHIDDeviceConfig,
+    val reportDescriptor: ByteArray
+) : UHIDEvent {
+    override fun toBytes(): ByteArray {
+        require(reportDescriptor.size <= RD_DATA_SIZE) {
+            "Report descriptor must not exceed $RD_DATA_SIZE bytes"
+        }
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(UHIDEvent.TYPE_CREATE2)
+        putFixedString(buf, NAME_OFFSET, config.deviceName, NAME_SIZE)
+        putFixedString(buf, PHYS_OFFSET, config.physicalAddress, PHYS_SIZE)
+        putFixedString(buf, UNIQ_OFFSET, config.uniqueId, UNIQ_SIZE)
+        buf.position(RD_SIZE_OFFSET)
+        buf.putShort(reportDescriptor.size.toShort())
+        buf.position(BUS_OFFSET)
+        buf.putShort(BUS_USB)
+        buf.position(VENDOR_OFFSET)
+        buf.putInt(config.vendorId)
+        buf.position(PRODUCT_OFFSET)
+        buf.putInt(config.productId)
+        buf.position(VERSION_OFFSET)
+        buf.putInt(config.version)
+        buf.position(COUNTRY_OFFSET)
+        buf.putInt(0)
+        buf.position(RD_DATA_OFFSET)
+        buf.put(reportDescriptor)
+        return buf.array()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CreateDeviceEvent) return false
+        return config == other.config && reportDescriptor.contentEquals(other.reportDescriptor)
+    }
+
+    override fun hashCode(): Int = 31 * config.hashCode() + reportDescriptor.contentHashCode()
+
+    companion object {
+        private const val NAME_OFFSET = 4
+        private const val NAME_SIZE = 128
+        private const val PHYS_OFFSET = 132
+        private const val PHYS_SIZE = 64
+        private const val UNIQ_OFFSET = 196
+        private const val UNIQ_SIZE = 64
+        private const val RD_SIZE_OFFSET = 260
+        private const val BUS_OFFSET = 262
+        private const val VENDOR_OFFSET = 264
+        private const val PRODUCT_OFFSET = 268
+        private const val VERSION_OFFSET = 272
+        private const val COUNTRY_OFFSET = 276
+        private const val RD_DATA_OFFSET = 280
+        private const val RD_DATA_SIZE = 4096
+        private const val BUS_USB: Short = 0x03
+
+        fun parse(eventBytes: ByteArray): CreateDeviceEvent {
+            require(eventBytes.size == UHIDEvent.EVENT_SIZE) { "Event must be ${UHIDEvent.EVENT_SIZE} bytes" }
+            val buf = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN)
+            val name = readFixedString(buf, NAME_OFFSET, NAME_SIZE)
+            val phys = readFixedString(buf, PHYS_OFFSET, PHYS_SIZE)
+            val uniq = readFixedString(buf, UNIQ_OFFSET, UNIQ_SIZE)
+            val rdSize = buf.getShort(RD_SIZE_OFFSET).toInt() and 0xFFFF
+            val vendorId = buf.getInt(VENDOR_OFFSET)
+            val productId = buf.getInt(PRODUCT_OFFSET)
+            val version = buf.getInt(VERSION_OFFSET)
+            val rdData = ByteArray(rdSize)
+            buf.position(RD_DATA_OFFSET)
+            buf.get(rdData)
+            val config = UHIDDeviceConfig(
+                deviceName = name, vendorId = vendorId, productId = productId,
+                version = version, physicalAddress = phys, uniqueId = uniq
+            )
+            return CreateDeviceEvent(config, rdData)
+        }
+
+        private fun readFixedString(buf: ByteBuffer, offset: Int, maxLen: Int): String {
+            val bytes = ByteArray(maxLen)
+            buf.position(offset)
+            buf.get(bytes)
+            val nullIndex = bytes.indexOf(0)
+            val endIndex = if (nullIndex >= 0) nullIndex else bytes.size
+            return String(bytes, 0, endIndex, Charsets.UTF_8)
+        }
+
+        private fun putFixedString(buf: ByteBuffer, offset: Int, str: String, maxLen: Int) {
+            val bytes = str.toByteArray(Charsets.UTF_8)
+            val len = minOf(bytes.size, maxLen - 1)
+            buf.position(offset)
+            buf.put(bytes, 0, len)
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/DestroyDeviceEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/DestroyDeviceEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_DESTROY event: removes the virtual HID device.
+ */
+data object DestroyDeviceEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_DESTROY)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/InputReportEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/InputReportEvent.kt
@@ -1,0 +1,44 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * UHID_INPUT2 event: sends a HID report from device to host.
+ */
+data class InputReportEvent(
+    val data: ByteArray
+) : UHIDEvent {
+    override fun toBytes(): ByteArray {
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(UHIDEvent.TYPE_INPUT2)
+        buf.position(SIZE_OFFSET)
+        buf.putShort(data.size.toShort())
+        buf.position(DATA_OFFSET)
+        buf.put(data)
+        return buf.array()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InputReportEvent) return false
+        return data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int = data.contentHashCode()
+
+    companion object {
+        private const val SIZE_OFFSET = 4
+        private const val DATA_OFFSET = 6
+
+        fun parse(eventBytes: ByteArray): InputReportEvent {
+            require(eventBytes.size == UHIDEvent.EVENT_SIZE) { "Event must be ${UHIDEvent.EVENT_SIZE} bytes" }
+            val buf = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN)
+            val size = buf.getShort(SIZE_OFFSET).toInt() and 0xFFFF
+            val data = ByteArray(size)
+            buf.position(DATA_OFFSET)
+            buf.get(data)
+            return InputReportEvent(data)
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OpenEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OpenEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_OPEN event: userspace opened the device.
+ */
+data object OpenEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_OPEN)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OutputReportEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OutputReportEvent.kt
@@ -1,0 +1,57 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * UHID_OUTPUT event: receives a HID report from host to device.
+ */
+data class OutputReportEvent(
+    val data: ByteArray,
+    val size: Int,
+    val rtype: Byte
+) : UHIDEvent {
+    override fun toBytes(): ByteArray {
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(UHIDEvent.TYPE_OUTPUT)
+        buf.position(DATA_OFFSET)
+        buf.put(data)
+        buf.position(SIZE_OFFSET)
+        buf.putShort(size.toShort())
+        buf.put(rtype)
+        return buf.array()
+    }
+
+    companion object {
+        private const val DATA_OFFSET = 4
+        private const val SIZE_OFFSET = 4100
+        private const val RTYPE_OFFSET = 4102
+
+        fun parse(eventBytes: ByteArray): OutputReportEvent {
+            require(eventBytes.size == UHIDEvent.EVENT_SIZE) { "Event must be ${UHIDEvent.EVENT_SIZE} bytes" }
+            val buf = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN)
+            val size = buf.getShort(SIZE_OFFSET).toInt() and 0xFFFF
+            val rtype = buf.get(RTYPE_OFFSET)
+
+            val reportSize = minOf(size, 64)
+            val data = ByteArray(reportSize)
+            buf.position(DATA_OFFSET)
+            buf.get(data, 0, reportSize)
+
+            return OutputReportEvent(data, size, rtype)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OutputReportEvent) return false
+        return size == other.size && rtype == other.rtype && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int {
+        var result = data.contentHashCode()
+        result = 31 * result + size
+        result = 31 * result + rtype.hashCode()
+        return result
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StartEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StartEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_START event: kernel started the device.
+ */
+data object StartEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_START)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StopEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StopEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_STOP event: kernel stopped the device.
+ */
+data object StopEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_STOP)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UHIDEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UHIDEvent.kt
@@ -1,0 +1,48 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Base type for all UHID events.
+ * All uhid_event structs are fixed-size (4380 bytes), little-endian.
+ */
+sealed interface UHIDEvent {
+
+    fun toBytes(): ByteArray
+
+    companion object {
+        const val EVENT_SIZE = 4380
+
+        internal const val TYPE_DESTROY = 1
+        internal const val TYPE_START = 2
+        internal const val TYPE_STOP = 3
+        internal const val TYPE_OPEN = 4
+        internal const val TYPE_CLOSE = 5
+        internal const val TYPE_OUTPUT = 6
+        internal const val TYPE_CREATE2 = 11
+        internal const val TYPE_INPUT2 = 12
+
+        fun parse(eventBytes: ByteArray): UHIDEvent {
+            require(eventBytes.size == EVENT_SIZE) { "Event must be $EVENT_SIZE bytes" }
+            val type = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN).getInt(0)
+            return when (type) {
+                TYPE_DESTROY -> DestroyDeviceEvent
+                TYPE_START -> StartEvent
+                TYPE_STOP -> StopEvent
+                TYPE_OPEN -> OpenEvent
+                TYPE_CLOSE -> CloseEvent
+                TYPE_OUTPUT -> OutputReportEvent.parse(eventBytes)
+                TYPE_CREATE2 -> CreateDeviceEvent.parse(eventBytes)
+                TYPE_INPUT2 -> InputReportEvent.parse(eventBytes)
+                else -> UnknownEvent(type)
+            }
+        }
+
+        internal fun createSimpleEvent(type: Int): ByteArray {
+            val buf = ByteBuffer.allocate(EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+            buf.putInt(type)
+            return buf.array()
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UnknownEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UnknownEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * Unknown UHID event type.
+ */
+data class UnknownEvent(val type: Int) : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(type)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/FidoHIDReportDescriptor.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/FidoHIDReportDescriptor.kt
@@ -1,0 +1,26 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.usb
+
+/**
+ * Standard FIDO HID report descriptor as defined in the CTAP specification.
+ * Registers a FIDO Alliance Usage Page (0xF1D0) device with 64-byte input and output reports.
+ */
+object FidoHIDReportDescriptor {
+    val DESCRIPTOR: ByteArray = byteArrayOf(
+        0x06, 0xD0.toByte(), 0xF1.toByte(),   // Usage Page (FIDO Alliance = 0xF1D0)
+        0x09, 0x01,                             // Usage (U2F HID Authenticator Device)
+        0xA1.toByte(), 0x01,                    // Collection (Application)
+        0x09, 0x20,                             //   Usage (Input Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x81.toByte(), 0x02,                    //   Input (Data, Var, Abs)
+        0x09, 0x21,                             //   Usage (Output Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x91.toByte(), 0x02,                    //   Output (Data, Var, Abs)
+        0xC0.toByte()                           // End Collection
+    )
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/UHIDConnection.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/UHIDConnection.kt
@@ -1,0 +1,60 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.usb
+
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * Low-level I/O wrapper for /dev/uhid.
+ * Reads and writes fixed-size uhid_event structs via FileChannel.
+ */
+open class UHIDConnection(private val devicePath: String = "/dev/uhid") : AutoCloseable {
+
+    private var channel: FileChannel? = null
+
+    open fun open() {
+        channel = FileChannel.open(
+            Path.of(devicePath),
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE
+        )
+    }
+
+    open fun writeEvent(event: UHIDEvent) {
+        writeBytes(event.toBytes())
+    }
+
+    open fun readEvent(): UHIDEvent {
+        return UHIDEvent.parse(readBytes())
+    }
+
+    open val isOpen: Boolean
+        get() = channel?.isOpen == true
+
+    override fun close() {
+        channel?.close()
+        channel = null
+    }
+
+    private fun writeBytes(bytes: ByteArray) {
+        val ch = channel ?: throw IllegalStateException("Connection is not open")
+        val buf = ByteBuffer.wrap(bytes)
+        while (buf.hasRemaining()) {
+            ch.write(buf)
+        }
+    }
+
+    private fun readBytes(): ByteArray {
+        val ch = channel ?: throw IllegalStateException("Connection is not open")
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+        while (buf.hasRemaining()) {
+            val bytesRead = ch.read(buf)
+            if (bytesRead == -1) {
+                throw java.io.IOException("End of stream reached on $devicePath")
+            }
+        }
+        return buf.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceTest.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceTest.kt
@@ -1,0 +1,307 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDResponseMessageBuilder
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CreateDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.InputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.UHIDConnection
+import com.webauthn4j.ctap.core.converter.CtapRequestConverter
+import com.webauthn4j.ctap.core.data.*
+import com.webauthn4j.ctap.core.data.hid.*
+import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.DEFAULT_PACKET_SIZE
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialParameters
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorInputs
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorInput
+import kotlinx.coroutines.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+internal class UHIDDeviceTest {
+
+    private class FakeUHIDConnection : UHIDConnection() {
+        val writtenEvents = ConcurrentLinkedQueue<UHIDEvent>()
+        private val inputQueue = LinkedBlockingQueue<UHIDEvent>()
+        @Volatile
+        private var opened = false
+        @Volatile
+        private var closed = false
+
+        override fun open() { opened = true }
+
+        fun enqueueEvent(event: UHIDEvent) { inputQueue.put(event) }
+
+        override fun readEvent(): UHIDEvent {
+            while (!closed) {
+                val event = inputQueue.poll(100, TimeUnit.MILLISECONDS)
+                if (event != null) return event
+            }
+            throw java.io.IOException("Connection closed")
+        }
+
+        override fun writeEvent(event: UHIDEvent) {
+            writtenEvents.add(event)
+        }
+
+        override val isOpen: Boolean get() = opened && !closed
+
+        override fun close() { closed = true }
+    }
+
+    /**
+     * Helper that handles UHID ↔ HID packet translation for tests.
+     */
+    private class TestHIDClient(private val connection: FakeUHIDConnection) {
+
+        fun sendHIDPackets(packets: List<HIDPacket>) {
+            for (packet in packets) {
+                val packetBytes = packet.toBytes()
+                connection.enqueueEvent(OutputReportEvent(packetBytes, packetBytes.size, 0x00))
+            }
+        }
+
+        fun collectResponseHIDPackets(timeoutMs: Long = 2000): List<ByteArray> {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            val packets = mutableListOf<ByteArray>()
+            Thread.sleep(minOf(timeoutMs, 500))
+            while (System.currentTimeMillis() < deadline) {
+                val event = connection.writtenEvents.poll() ?: break
+                if (event is InputReportEvent) {
+                    packets.add(event.data)
+                }
+            }
+            return packets
+        }
+
+        fun performCtapHIDInit(): HIDChannelId {
+            val nonce = ByteArray(8) { (it + 1).toByte() }
+            val initMessage = HIDINITRequestMessage(HIDChannelId.BROADCAST, nonce)
+            sendHIDPackets(initMessage.toHIDPackets(DEFAULT_PACKET_SIZE))
+            val responsePackets = collectResponseHIDPackets()
+            assertThat(responsePackets).isNotEmpty()
+
+            // Parse the INIT response to extract channel ID
+            val hidPacket = responsePackets.first()
+            // Channel ID is at bytes 15-18 of the INIT response data
+            // Packet layout: CID(4) + CMD(1) + LEN(2) + DATA(...)
+            // INIT response data: nonce(8) + channelId(4) + ...
+            val channelIdBytes = hidPacket.copyOfRange(15, 19)
+            return HIDChannelId(channelIdBytes)
+        }
+
+        fun sendCborCommand(channelId: HIDChannelId, ctapCommand: CtapCommand, cborData: ByteArray) {
+            val message = HIDCBORRequestMessage(channelId, ctapCommand, cborData)
+            sendHIDPackets(message.toHIDPackets(DEFAULT_PACKET_SIZE))
+        }
+
+        fun collectCborResponse(timeoutMs: Long = 3000): Pair<Byte, ByteArray> {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            val builder = HIDResponseMessageBuilder(DEFAULT_PACKET_SIZE)
+
+            // Wait for processing to begin
+            Thread.sleep(500)
+
+            while (System.currentTimeMillis() < deadline) {
+                val event = connection.writtenEvents.poll()
+                if (event == null) {
+                    Thread.sleep(50)
+                    continue
+                }
+
+                if (event !is InputReportEvent) continue
+                val packetBytes = event.data
+
+                // Check if this is a keepalive (command 0xBB = KEEPALIVE | 0x80)
+                if (packetBytes.size >= 5 && packetBytes[4] == (HIDCommand.CTAPHID_KEEPALIVE.value.toInt() or 0x80).toByte()) {
+                    continue // Skip keepalive
+                }
+
+                // Parse HID packet
+                val hidPacket = com.webauthn4j.ctap.core.converter.HIDPacketConverter().convert(packetBytes)
+                when (hidPacket) {
+                    is HIDInitializationPacket -> builder.initialize(hidPacket)
+                    is HIDContinuationPacket -> builder.append(hidPacket)
+                }
+
+                if (builder.isCompleted) {
+                    val message = builder.build()
+                    val data = message.data
+                    // data[0] = status code, data[1..] = CBOR response
+                    val statusCode = data[0]
+                    val cborResponse = if (data.size > 1) data.copyOfRange(1, data.size) else ByteArray(0)
+                    return Pair(statusCode, cborResponse)
+                }
+            }
+            throw AssertionError("Timed out waiting for CBOR response")
+        }
+    }
+
+    private val objectConverter = ObjectConverter()
+    private val ctapRequestConverter = CtapRequestConverter(objectConverter)
+
+    @Test
+    fun start_createsDevice() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+
+            val createEvent = fakeConnection.writtenEvents.poll()
+            assertThat(createEvent).isInstanceOf(CreateDeviceEvent::class.java)
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun ctaphidInit_returnsResponse() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+            fakeConnection.writtenEvents.clear()
+
+            val client = TestHIDClient(fakeConnection)
+            val channelId = client.performCtapHIDInit()
+
+            assertThat(channelId).isNotEqualTo(HIDChannelId.BROADCAST)
+            assertThat(channelId.value).isNotEqualTo(ByteArray(4)) // Not all zeros
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun makeCredential_returnsSuccess() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+            fakeConnection.writtenEvents.clear()
+
+            val client = TestHIDClient(fakeConnection)
+
+            // Step 1: CTAPHID_INIT to allocate a channel
+            val channelId = client.performCtapHIDInit()
+
+            // Step 2: Build MakeCredential request
+            val request = AuthenticatorMakeCredentialRequest(
+                clientDataHash = ByteArray(32),
+                rp = CtapPublicKeyCredentialRpEntity("example.com", "Example", null),
+                user = CtapPublicKeyCredentialUserEntity(
+                    byteArrayOf(0x01, 0x02, 0x03), "user@example.com", "Test User", null
+                ),
+                pubKeyCredParams = listOf(
+                    PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                    )
+                ),
+                excludeList = emptyList(),
+                extensions = AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>(),
+                options = AuthenticatorMakeCredentialRequest.Options(rk = false, uv = false),
+                pinAuth = null,
+                pinProtocol = null
+            )
+            val requestBytes = ctapRequestConverter.convertToBytes(request)
+            val ctapCommandByte = requestBytes[0]
+            val cborData = requestBytes.copyOfRange(1, requestBytes.size)
+
+            // Step 3: Send CTAPHID_CBOR command
+            client.sendCborCommand(channelId, CtapCommand(ctapCommandByte), cborData)
+
+            // Step 4: Collect response
+            val (statusCode, _) = client.collectCborResponse()
+
+            // Step 5: Verify
+            assertThat(statusCode).isEqualTo(CtapStatusCode.CTAP2_OK.byte)
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun getAssertion_afterMakeCredential_returnsSuccess() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+            fakeConnection.writtenEvents.clear()
+
+            val client = TestHIDClient(fakeConnection)
+            val channelId = client.performCtapHIDInit()
+
+            // -- MakeCredential --
+            val rpId = "example.com"
+            val makeCredRequest = AuthenticatorMakeCredentialRequest(
+                clientDataHash = ByteArray(32),
+                rp = CtapPublicKeyCredentialRpEntity(rpId, "Example", null),
+                user = CtapPublicKeyCredentialUserEntity(
+                    byteArrayOf(0x01, 0x02, 0x03), "user@example.com", "Test User", null
+                ),
+                pubKeyCredParams = listOf(
+                    PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                    )
+                ),
+                excludeList = emptyList(),
+                extensions = AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>(),
+                options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = false),
+                pinAuth = null,
+                pinProtocol = null
+            )
+            val makeCredBytes = ctapRequestConverter.convertToBytes(makeCredRequest)
+            client.sendCborCommand(channelId, CtapCommand(makeCredBytes[0]), makeCredBytes.copyOfRange(1, makeCredBytes.size))
+            val (makeCredStatus, _) = client.collectCborResponse()
+            assertThat(makeCredStatus).isEqualTo(CtapStatusCode.CTAP2_OK.byte)
+
+            // -- GetAssertion --
+            val getAssertionRequest = AuthenticatorGetAssertionRequest(
+                rpId = rpId,
+                clientDataHash = ByteArray(32),
+                allowList = emptyList(),
+                extensions = null,
+                options = AuthenticatorGetAssertionRequest.Options(up = true, uv = false),
+                pinAuth = null,
+                pinProtocol = null
+            )
+            val getAssertionBytes = ctapRequestConverter.convertToBytes(getAssertionRequest)
+            client.sendCborCommand(channelId, CtapCommand(getAssertionBytes[0]), getAssertionBytes.copyOfRange(1, getAssertionBytes.size))
+            val (getAssertionStatus, _) = client.collectCborResponse()
+            assertThat(getAssertionStatus).isEqualTo(CtapStatusCode.CTAP2_OK.byte)
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDEventTest.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDEventTest.kt
@@ -1,0 +1,161 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CreateDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.DestroyDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.InputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.StartEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UnknownEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.FidoHIDReportDescriptor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+internal class UHIDEventTest {
+
+    @Test
+    fun createDeviceEvent_setsTypeAndFields() {
+        val config = UHIDDeviceConfig(
+            deviceName = "TestDevice",
+            vendorId = 0x0525,
+            productId = 0xF025,
+            version = 0x0100,
+            physicalAddress = "phys",
+            uniqueId = "uniq"
+        )
+        val rdesc = FidoHIDReportDescriptor.DESCRIPTOR
+
+        val event = CreateDeviceEvent(config, rdesc).toBytes()
+
+        assertThat(event.size).isEqualTo(UHIDEvent.EVENT_SIZE)
+
+        val buf = ByteBuffer.wrap(event).order(ByteOrder.LITTLE_ENDIAN)
+
+        // type = UHID_CREATE2 (11)
+        assertThat(buf.getInt(0)).isEqualTo(11)
+
+        // name
+        val nameBytes = ByteArray(128)
+        buf.position(4)
+        buf.get(nameBytes)
+        val name = String(nameBytes, Charsets.UTF_8).trimEnd('\u0000')
+        assertThat(name).isEqualTo("TestDevice")
+
+        // phys
+        val physBytes = ByteArray(64)
+        buf.position(132)
+        buf.get(physBytes)
+        val phys = String(physBytes, Charsets.UTF_8).trimEnd('\u0000')
+        assertThat(phys).isEqualTo("phys")
+
+        // uniq
+        val uniqBytes = ByteArray(64)
+        buf.position(196)
+        buf.get(uniqBytes)
+        val uniq = String(uniqBytes, Charsets.UTF_8).trimEnd('\u0000')
+        assertThat(uniq).isEqualTo("uniq")
+
+        // rd_size
+        val rdSize = buf.getShort(260).toInt() and 0xFFFF
+        assertThat(rdSize).isEqualTo(rdesc.size)
+
+        // bus
+        assertThat(buf.getShort(262)).isEqualTo(0x03.toShort()) // BUS_USB
+
+        // vendor, product, version
+        assertThat(buf.getInt(264)).isEqualTo(0x0525)
+        assertThat(buf.getInt(268)).isEqualTo(0xF025)
+        assertThat(buf.getInt(272)).isEqualTo(0x0100)
+
+        // country
+        assertThat(buf.getInt(276)).isEqualTo(0)
+
+        // rd_data
+        val rdData = ByteArray(rdesc.size)
+        buf.position(280)
+        buf.get(rdData)
+        assertThat(rdData).isEqualTo(rdesc)
+    }
+
+    @Test
+    fun inputReportEvent_setsTypeAndData() {
+        val data = ByteArray(64) { it.toByte() }
+        val event = InputReportEvent(data).toBytes()
+
+        assertThat(event.size).isEqualTo(UHIDEvent.EVENT_SIZE)
+
+        val buf = ByteBuffer.wrap(event).order(ByteOrder.LITTLE_ENDIAN)
+        // type = UHID_INPUT2 (12)
+        assertThat(buf.getInt(0)).isEqualTo(12)
+        assertThat(buf.getShort(4).toInt() and 0xFFFF).isEqualTo(64)
+
+        val readData = ByteArray(64)
+        buf.position(6)
+        buf.get(readData)
+        assertThat(readData).isEqualTo(data)
+    }
+
+    @Test
+    fun destroyDeviceEvent_setsType() {
+        val event = DestroyDeviceEvent.toBytes()
+
+        assertThat(event.size).isEqualTo(UHIDEvent.EVENT_SIZE)
+
+        val buf = ByteBuffer.wrap(event).order(ByteOrder.LITTLE_ENDIAN)
+        // type = UHID_DESTROY (1)
+        assertThat(buf.getInt(0)).isEqualTo(1)
+    }
+
+    @Test
+    fun parse_returnsOutputReportEvent() {
+        val reportData = ByteArray(64) { (it + 0x10).toByte() }
+        val eventBytes = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .apply {
+                putInt(6) // UHID_OUTPUT
+                position(4)
+                put(reportData)
+                position(4100)
+                putShort(64)
+                put(0x00)
+            }
+            .array()
+
+        val event = UHIDEvent.parse(eventBytes)
+
+        assertThat(event).isInstanceOf(OutputReportEvent::class.java)
+        val output = event as OutputReportEvent
+        assertThat(output.size).isEqualTo(64)
+        assertThat(output.data).isEqualTo(reportData)
+        assertThat(output.rtype).isEqualTo(0x00.toByte())
+    }
+
+    @Test
+    fun parse_returnsStartEvent() {
+        val eventBytes = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(2) // UHID_START
+            .array()
+
+        assertThat(UHIDEvent.parse(eventBytes)).isEqualTo(StartEvent)
+    }
+
+    @Test
+    fun parse_returnsUnknownForUnknownType() {
+        val eventBytes = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(99)
+            .array()
+
+        val event = UHIDEvent.parse(eventBytes)
+        assertThat(event).isInstanceOf(UnknownEvent::class.java)
+        assertThat((event as UnknownEvent).type).isEqualTo(99)
+    }
+
+    @Test
+    fun fidoHIDReportDescriptor_hasExpectedSize() {
+        assertThat(FidoHIDReportDescriptor.DESCRIPTOR.size).isEqualTo(34)
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/README.md
+++ b/webauthn4j-ctap-authenticator-usbip/README.md
@@ -1,0 +1,32 @@
+# webauthn4j-ctap-authenticator-usbip
+
+Library that exposes a `CtapAuthenticator` as a virtual USB HID FIDO2 device over USB/IP (TCP/IP).
+
+The primary use case is running **FIDO Conformance Tests on Windows** against the WebAuthn4J CTAP Authenticator. The `unifidokey-usbip` CLI application uses this module to serve the authenticator, and Windows-side tools connect via USB/IP as if it were a physical security key.
+
+## Requirements
+
+- Java 17+
+- USB/IP client on the connecting machine ([usbip-win2](https://github.com/vadimgrn/usbip-win2) for Windows, `usbip` for Linux)
+
+## Usage
+
+```kotlin
+val authenticator = CtapAuthenticator()
+val config = USBIPDeviceConfig(host = "0.0.0.0", port = 3240)
+val device = USBIPDevice(authenticator, config)
+val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+device.start(scope)
+// Clients can now attach via: usbip attach -r <server-ip> -b 1-1
+```
+
+## Key Classes
+
+| Class | Description |
+|---|---|
+| `USBIPDevice` | TCP accept loop, lifecycle management, and URB routing |
+| `USBIPClientHandler` | Per-client protocol state machine |
+| `USBIPDeviceConfig` | Server and device configuration |
+| `ControlRequestHandler` | USB control endpoint (EP0) handling |
+| `InterruptEndpointHandler` | HID interrupt endpoint handling |

--- a/webauthn4j-ctap-authenticator-usbip/build.gradle.kts
+++ b/webauthn4j-ctap-authenticator-usbip/build.gradle.kts
@@ -1,0 +1,57 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+}
+
+description = "CTAP USB-IP server library for cross-platform virtual FIDO2 devices"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions{
+        jvmTarget = JvmTarget.JVM_17
+        javaParameters = true
+    }
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+    jacocoTestReport {
+        reports {
+            xml.required.set(true)
+        }
+    }
+}
+
+dependencies {
+
+    // Project dependencies
+    api(project(":webauthn4j-ctap-authenticator"))
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.ktor.network)
+    implementation(libs.slf4j.api)
+
+    // Test dependencies
+    testImplementation(platform(libs.junit.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.logback.classic)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.assertj.core)
+
+    testImplementation(libs.jackson.module.kotlin)
+    testImplementation(libs.jackson.dataformat.cbor)
+    testImplementation(project(":webauthn4j-ctap-client"))
+    testImplementation(libs.webauthn4j.test)
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
@@ -43,6 +43,8 @@ class USBIPDevice(
         logger.info("Server address: {}:{}", config.host, config.port)
         logger.info("Bus ID: {}", config.busId)
 
+        hidTransport.start(scope)
+
         val deviceInfo = createDeviceInfo()
         val sm = SelectorManager(Dispatchers.IO)
         selectorManager = sm
@@ -73,6 +75,7 @@ class USBIPDevice(
         selectorManager?.close()
         selectorManager = null
         interruptHandler.close()
+        hidTransport.close()
         logger.info("USB-IP server stopped")
     }
 

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
@@ -1,0 +1,132 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDTransport
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.DeviceInfo
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.USBIPProtocol
+import com.webauthn4j.ctap.authenticator.transport.usbip.server.USBIPClientHandler
+import com.webauthn4j.ctap.authenticator.transport.usbip.usb.ControlRequestHandler
+import com.webauthn4j.ctap.authenticator.transport.usbip.usb.InterruptEndpointHandler
+import io.ktor.network.selector.SelectorManager
+import io.ktor.network.sockets.aSocket
+import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+
+/**
+ * Virtual USB FIDO2 security key exposed over USB/IP (TCP/IP).
+ *
+ * Wraps a [CtapAuthenticator] and serves it as a USB HID device that remote
+ * machines can attach via the USB/IP protocol.
+ */
+class USBIPDevice(
+    ctapAuthenticator: CtapAuthenticator,
+    private val config: USBIPDeviceConfig = USBIPDeviceConfig()
+) : AutoCloseable {
+
+    private val logger = LoggerFactory.getLogger(USBIPDevice::class.java)
+    private val hidTransport = HIDTransport(ctapAuthenticator)
+
+    private val controlHandler = ControlRequestHandler(config)
+    private val interruptHandler = InterruptEndpointHandler(hidTransport)
+
+    private var serverJob: Job? = null
+    private var selectorManager: SelectorManager? = null
+
+    suspend fun start(scope: CoroutineScope) {
+        logger.info("Starting USB-IP server")
+        logger.info("Device: {}", config.deviceName)
+        logger.info("VID:PID = 0x{}:0x{}",
+            Integer.toHexString(config.vendorId),
+            Integer.toHexString(config.productId))
+        logger.info("Server address: {}:{}", config.host, config.port)
+        logger.info("Bus ID: {}", config.busId)
+
+        val deviceInfo = createDeviceInfo()
+        val sm = SelectorManager(Dispatchers.IO)
+        selectorManager = sm
+
+        serverJob = scope.launch(Dispatchers.IO) {
+            val serverSocket = aSocket(sm).tcp().bind(config.host, config.port)
+            try {
+                logger.info("USB-IP server listening on {}:{}", config.host, config.port)
+
+                while (isActive) {
+                    val clientSocket = serverSocket.accept()
+                    logger.info("Client connected from {}", clientSocket.remoteAddress)
+
+                    launch {
+                        USBIPClientHandler(clientSocket, deviceInfo, this@USBIPDevice).handle()
+                    }
+                }
+            } finally {
+                serverSocket.close()
+            }
+        }
+    }
+
+    suspend fun stop() {
+        logger.info("Stopping USB-IP server")
+        serverJob?.cancelAndJoin()
+        serverJob = null
+        selectorManager?.close()
+        selectorManager = null
+        interruptHandler.close()
+        logger.info("USB-IP server stopped")
+    }
+
+    override fun close() {
+        runBlocking { stop() }
+    }
+
+    /**
+     * Routes a URB to the appropriate handler based on endpoint and direction.
+     */
+    internal suspend fun handleSubmit(request: SubmitRequest): SubmitResponse {
+        return when (request.ep) {
+            USBIPProtocol.EP0_ADDRESS -> controlHandler.handle(request)
+            EP_INTERRUPT_NUMBER -> {
+                if (request.direction == USBIPProtocol.USBIP_DIR_OUT) {
+                    interruptHandler.handleOut(request)
+                } else {
+                    interruptHandler.handleIn(request)
+                }
+            }
+            else -> {
+                logger.warn("Unknown endpoint: 0x{}", Integer.toHexString(request.ep))
+                SubmitResponse.error(request, USBIPProtocol.STATUS_EPIPE)
+            }
+        }
+    }
+
+    private fun createDeviceInfo(): DeviceInfo {
+        return DeviceInfo(
+            path = "/sys/devices/virtual/usbip/${config.busId}",
+            busid = config.busId,
+            busnum = config.busNum,
+            devnum = config.devNum,
+            speed = 3,
+            idVendor = config.vendorId,
+            idProduct = config.productId,
+            bcdDevice = config.version,
+            bDeviceClass = 0,
+            bDeviceSubClass = 0,
+            bDeviceProtocol = 0,
+            bConfigurationValue = 1,
+            bNumConfigurations = 1,
+            bNumInterfaces = 1,
+            interfaces = listOf(
+                DeviceInfo.InterfaceInfo(
+                    bInterfaceClass = 0x03,
+                    bInterfaceSubClass = 0x00,
+                    bInterfaceProtocol = 0x00
+                )
+            )
+        )
+    }
+
+    companion object {
+        private const val EP_INTERRUPT_NUMBER = 1
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDeviceConfig.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDeviceConfig.kt
@@ -1,0 +1,36 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip
+
+/**
+ * Configuration for USB-IP virtual device.
+ *
+ * @property deviceName Human-readable device name (manufacturer + product name)
+ * @property vendorId USB Vendor ID (0x0000-0xFFFF)
+ * @property productId USB Product ID (0x0000-0xFFFF)
+ * @property version Device version in BCD format (e.g., 0x0100 for v1.0)
+ * @property host Host address to bind the USB-IP server (0.0.0.0 for all interfaces)
+ * @property port TCP port for USB-IP protocol (standard is 3240)
+ * @property busId Bus ID string for USB-IP device identification (e.g., "1-1")
+ * @property busNum USB bus number
+ * @property devNum USB device number on the bus
+ */
+data class USBIPDeviceConfig(
+    val deviceName: String = "WebAuthn4J Virtual FIDO2 Key",
+    val vendorId: Int = 0x1234,
+    val productId: Int = 0xF1D0,
+    val version: Int = 0x0100,
+    val host: String = "0.0.0.0",
+    val port: Int = 3240,
+    val busId: String = "1-1",
+    val busNum: Int = 1,
+    val devNum: Int = 2
+) {
+    init {
+        require(vendorId in 0x0000..0xFFFF) { "Vendor ID must be 0x0000-0xFFFF" }
+        require(productId in 0x0000..0xFFFF) { "Product ID must be 0x0000-0xFFFF" }
+        require(version in 0x0000..0xFFFF) { "Version must be 0x0000-0xFFFF" }
+        require(port in 1..65535) { "Port must be 1-65535" }
+        require(busNum >= 0) { "Bus number must be non-negative" }
+        require(devNum >= 0) { "Device number must be non-negative" }
+        require(busId.isNotBlank()) { "Bus ID must not be blank" }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/DeviceInfo.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/DeviceInfo.kt
@@ -1,0 +1,67 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+
+/**
+ * Device information structure for USB-IP.
+ */
+data class DeviceInfo(
+    val path: String,
+    val busid: String,
+    val busnum: Int,
+    val devnum: Int,
+    val speed: Int,
+    val idVendor: Int,
+    val idProduct: Int,
+    val bcdDevice: Int,
+    val bDeviceClass: Int,
+    val bDeviceSubClass: Int,
+    val bDeviceProtocol: Int,
+    val bConfigurationValue: Int,
+    val bNumConfigurations: Int,
+    val bNumInterfaces: Int,
+    val interfaces: List<InterfaceInfo> = emptyList()
+) {
+    data class InterfaceInfo(
+        val bInterfaceClass: Int,
+        val bInterfaceSubClass: Int,
+        val bInterfaceProtocol: Int
+    )
+
+    /**
+     * Writes this device info to the buffer.
+     * @param includeInterfaces true for devlist (includes 4-byte interface descriptors), false for import
+     */
+    fun writeTo(buffer: ByteBuffer, includeInterfaces: Boolean = false) {
+        writeString(buffer, path, 256)
+        writeString(buffer, busid, 32)
+        buffer.putInt(busnum)
+        buffer.putInt(devnum)
+        buffer.putInt(speed)
+        buffer.putShort(idVendor.toShort())
+        buffer.putShort(idProduct.toShort())
+        buffer.putShort(bcdDevice.toShort())
+        buffer.put(bDeviceClass.toByte())
+        buffer.put(bDeviceSubClass.toByte())
+        buffer.put(bDeviceProtocol.toByte())
+        buffer.put(bConfigurationValue.toByte())
+        buffer.put(bNumConfigurations.toByte())
+        buffer.put(bNumInterfaces.toByte())
+
+        if (includeInterfaces) {
+            for (iface in interfaces) {
+                buffer.put(iface.bInterfaceClass.toByte())
+                buffer.put(iface.bInterfaceSubClass.toByte())
+                buffer.put(iface.bInterfaceProtocol.toByte())
+                buffer.put(0) // padding
+            }
+        }
+    }
+
+    private fun writeString(buffer: ByteBuffer, str: String, length: Int) {
+        val bytes = str.toByteArray(Charsets.US_ASCII)
+        val toCopy = minOf(bytes.size, length - 1)
+        buffer.put(bytes, 0, toCopy)
+        repeat(length - toCopy) { buffer.put(0) }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/DeviceListResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/DeviceListResponse.kt
@@ -1,0 +1,27 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * OP_REP_DEVLIST response.
+ */
+data class DeviceListResponse(
+    val devices: List<DeviceInfo>
+) {
+    fun toBytes(): ByteArray {
+        val bufferSize = 12 + devices.sumOf { 312 + 4 * it.bNumInterfaces }
+        val buffer = ByteBuffer.allocate(bufferSize).order(ByteOrder.BIG_ENDIAN)
+
+        buffer.putShort(USBIPProtocol.USBIP_VERSION.toShort())
+        buffer.putShort(USBIPProtocol.OP_REP_DEVLIST.toShort())
+        buffer.putInt(0) // status
+        buffer.putInt(devices.size)
+
+        for (device in devices) {
+            device.writeTo(buffer, includeInterfaces = true)
+        }
+
+        return buffer.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/ImportRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/ImportRequest.kt
@@ -1,0 +1,22 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * OP_REQ_IMPORT request.
+ */
+data class ImportRequest(
+    val busId: String
+) {
+    companion object {
+        fun parse(buffer: ByteBuffer): ImportRequest {
+            buffer.order(ByteOrder.BIG_ENDIAN)
+            val bytes = ByteArray(32)
+            buffer.get(bytes)
+            val nullIndex = bytes.indexOf(0)
+            val endIndex = if (nullIndex >= 0) nullIndex else bytes.size
+            return ImportRequest(String(bytes, 0, endIndex, Charsets.US_ASCII))
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/ImportResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/ImportResponse.kt
@@ -1,0 +1,23 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * OP_REP_IMPORT response.
+ */
+data class ImportResponse(
+    val device: DeviceInfo
+) {
+    fun toBytes(): ByteArray {
+        val buffer = ByteBuffer.allocate(320).order(ByteOrder.BIG_ENDIAN)
+
+        buffer.putShort(USBIPProtocol.USBIP_VERSION.toShort())
+        buffer.putShort(USBIPProtocol.OP_REP_IMPORT.toShort())
+        buffer.putInt(0) // status
+
+        device.writeTo(buffer, includeInterfaces = false)
+
+        return buffer.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/SubmitRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/SubmitRequest.kt
@@ -1,0 +1,75 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * USB Request Block (URB) for submit command.
+ */
+data class SubmitRequest(
+    val seqnum: Int,
+    val devid: Int,
+    val direction: Int,
+    val ep: Int,
+    val transferFlags: Int,
+    val transferBufferLength: Int,
+    val startFrame: Int,
+    val numberOfPackets: Int,
+    val interval: Int,
+    val setup: ByteArray,
+    val data: ByteArray
+) {
+    companion object {
+        /**
+         * Parses a CMD_SUBMIT from the buffer (position should be at seqnum, after command code).
+         */
+        fun parse(buffer: ByteBuffer): SubmitRequest {
+            buffer.order(ByteOrder.BIG_ENDIAN)
+            val seqnum = buffer.int
+            val devid = buffer.int
+            val direction = buffer.int
+            val ep = buffer.int
+            val transferFlags = buffer.int
+            val transferBufferLength = buffer.int
+            val startFrame = buffer.int
+            val numberOfPackets = buffer.int
+            val interval = buffer.int
+            val setup = ByteArray(8)
+            buffer.get(setup)
+
+            return SubmitRequest(
+                seqnum = seqnum, devid = devid, direction = direction, ep = ep,
+                transferFlags = transferFlags, transferBufferLength = transferBufferLength,
+                startFrame = startFrame, numberOfPackets = numberOfPackets, interval = interval,
+                setup = setup, data = ByteArray(0)
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as SubmitRequest
+        return seqnum == other.seqnum && devid == other.devid && direction == other.direction &&
+                ep == other.ep && transferFlags == other.transferFlags &&
+                transferBufferLength == other.transferBufferLength &&
+                startFrame == other.startFrame && numberOfPackets == other.numberOfPackets &&
+                interval == other.interval && setup.contentEquals(other.setup) &&
+                data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int {
+        var result = seqnum
+        result = 31 * result + devid
+        result = 31 * result + direction
+        result = 31 * result + ep
+        result = 31 * result + transferFlags
+        result = 31 * result + transferBufferLength
+        result = 31 * result + startFrame
+        result = 31 * result + numberOfPackets
+        result = 31 * result + interval
+        result = 31 * result + setup.contentHashCode()
+        result = 31 * result + data.contentHashCode()
+        return result
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/SubmitResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/SubmitResponse.kt
@@ -1,0 +1,84 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * URB result for submit return.
+ */
+data class SubmitResponse(
+    val seqnum: Int,
+    val devid: Int,
+    val direction: Int,
+    val ep: Int,
+    val status: Int,
+    val actualLength: Int,
+    val startFrame: Int,
+    val numberOfPackets: Int,
+    val errorCount: Int,
+    val data: ByteArray
+) {
+    /**
+     * Writes this result as a USBIP_RET_SUBMIT response to the buffer.
+     */
+    fun writeTo(buffer: ByteBuffer) {
+        buffer.putInt(USBIPProtocol.USBIP_RET_SUBMIT)
+        buffer.putInt(seqnum)
+        buffer.putInt(devid)
+        buffer.putInt(direction)
+        buffer.putInt(ep)
+
+        buffer.putInt(status)
+        buffer.putInt(actualLength)
+        buffer.putInt(startFrame)
+        buffer.putInt(numberOfPackets)
+        buffer.putInt(errorCount)
+
+        buffer.putLong(0) // setup padding
+        buffer.put(data)
+    }
+
+    fun toBytes(): ByteArray {
+        val buffer = ByteBuffer.allocate(48 + data.size).order(ByteOrder.BIG_ENDIAN)
+        writeTo(buffer)
+        return buffer.array()
+    }
+
+    companion object {
+        fun success(request: SubmitRequest, data: ByteArray, actualLength: Int = data.size): SubmitResponse = SubmitResponse(
+            seqnum = request.seqnum, devid = request.devid, direction = request.direction, ep = request.ep,
+            status = USBIPProtocol.STATUS_SUCCESS, actualLength = actualLength,
+            startFrame = 0, numberOfPackets = 0, errorCount = 0, data = data
+        )
+
+        fun error(request: SubmitRequest, status: Int): SubmitResponse = SubmitResponse(
+            seqnum = request.seqnum, devid = request.devid, direction = request.direction, ep = request.ep,
+            status = status, actualLength = 0,
+            startFrame = 0, numberOfPackets = 0, errorCount = 0, data = ByteArray(0)
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as SubmitResponse
+        return seqnum == other.seqnum && devid == other.devid && direction == other.direction &&
+                ep == other.ep && status == other.status && actualLength == other.actualLength &&
+                startFrame == other.startFrame && numberOfPackets == other.numberOfPackets &&
+                errorCount == other.errorCount && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int {
+        var result = seqnum
+        result = 31 * result + devid
+        result = 31 * result + direction
+        result = 31 * result + ep
+        result = 31 * result + status
+        result = 31 * result + actualLength
+        result = 31 * result + startFrame
+        result = 31 * result + numberOfPackets
+        result = 31 * result + errorCount
+        result = 31 * result + data.contentHashCode()
+        return result
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/USBIPProtocol.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/USBIPProtocol.kt
@@ -1,0 +1,36 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+
+/**
+ * USB-IP protocol constants.
+ * See: https://docs.kernel.org/usb/usbip_protocol.html
+ */
+object USBIPProtocol {
+
+    const val USBIP_VERSION = 0x0111
+
+    // Handshake opcodes
+    const val OP_REQ_DEVLIST = 0x8005
+    const val OP_REP_DEVLIST = 0x0005
+    const val OP_REQ_IMPORT = 0x8003
+    const val OP_REP_IMPORT = 0x0003
+
+    // URB commands
+    const val USBIP_CMD_SUBMIT = 0x00000001
+    const val USBIP_RET_SUBMIT = 0x00000003
+    const val USBIP_CMD_UNLINK = 0x00000002
+    const val USBIP_RET_UNLINK = 0x00000004
+
+    // Transfer direction
+    const val USBIP_DIR_OUT = 0x00
+    const val USBIP_DIR_IN = 0x01
+
+    // USB endpoint
+    const val EP0_ADDRESS = 0x00
+
+    // Status codes (Linux errno)
+    const val STATUS_SUCCESS = 0
+    const val STATUS_EINVAL = -22
+    const val STATUS_EPIPE = -32
+    const val STATUS_ECONNRESET = -104
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/UnlinkRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/UnlinkRequest.kt
@@ -1,0 +1,25 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * USBIP_CMD_UNLINK request.
+ */
+data class UnlinkRequest(
+    val seqnum: Int,
+    val unlinkSeqnum: Int
+) {
+    companion object {
+        /**
+         * Parses a CMD_UNLINK from the buffer (position should be at seqnum, after command code).
+         */
+        fun parse(buffer: ByteBuffer): UnlinkRequest {
+            buffer.order(ByteOrder.BIG_ENDIAN)
+            val seqnum = buffer.int
+            buffer.position(buffer.position() + 12) // skip devid, direction, ep
+            val unlinkSeqnum = buffer.int
+            return UnlinkRequest(seqnum = seqnum, unlinkSeqnum = unlinkSeqnum)
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/UnlinkResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/protocol/UnlinkResponse.kt
@@ -1,0 +1,26 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.protocol
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * USBIP_RET_UNLINK response.
+ */
+data class UnlinkResponse(
+    val seqnum: Int
+) {
+    fun toBytes(): ByteArray {
+        val buffer = ByteBuffer.allocate(48).order(ByteOrder.BIG_ENDIAN)
+
+        buffer.putInt(USBIPProtocol.USBIP_RET_UNLINK)
+        buffer.putInt(seqnum)
+        buffer.putInt(0) // devid
+        buffer.putInt(0) // direction
+        buffer.putInt(0) // ep
+
+        buffer.putInt(USBIPProtocol.STATUS_ECONNRESET)
+        repeat(6) { buffer.putInt(0) } // padding
+
+        return buffer.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/server/USBIPClientHandler.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/server/USBIPClientHandler.kt
@@ -1,0 +1,192 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.server
+
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDevice
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.DeviceInfo
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.DeviceListResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.ImportRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.ImportResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.UnlinkRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.UnlinkResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.USBIPProtocol
+import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.openReadChannel
+import io.ktor.network.sockets.openWriteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.readFully
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Handles a single USB-IP client connection through the protocol state machine.
+ *
+ * The protocol has two phases:
+ * 1. Handshake phase: device list and import requests (version+opcode header format)
+ * 2. URB phase: submit and unlink commands (command+seqnum header format)
+ */
+class USBIPClientHandler(
+    private val socket: Socket,
+    private val deviceInfo: DeviceInfo,
+    private val device: USBIPDevice
+) {
+    private val logger = LoggerFactory.getLogger(USBIPClientHandler::class.java)
+    private val writeMutex = Mutex()
+    private val pendingInJobs = ConcurrentHashMap<Int, Job>()
+
+    private lateinit var readChannel: ByteReadChannel
+    private lateinit var writeChannel: ByteWriteChannel
+
+    suspend fun handle() {
+        readChannel = socket.openReadChannel()
+        writeChannel = socket.openWriteChannel(autoFlush = true)
+        try {
+            handleHandshakePhase()
+            coroutineScope {
+                handleSubmitPhase()
+            }
+        } catch (e: Exception) {
+            logger.debug("Client disconnected", e)
+        } finally {
+            socket.close()
+        }
+    }
+
+    // --- Handshake phase: version(2) + opcode(2) + status(4) ---
+
+    private suspend fun handleHandshakePhase() {
+        while (true) {
+            val header = readBigEndianBuffer(8)
+            val version = header.short.toInt() and 0xFFFF
+            val opCode = header.short.toInt() and 0xFFFF
+
+            logger.debug("Handshake: version=0x{}, opCode=0x{}",
+                Integer.toHexString(version), Integer.toHexString(opCode))
+
+            when (opCode) {
+                USBIPProtocol.OP_REQ_DEVLIST -> handleDevlist()
+                USBIPProtocol.OP_REQ_IMPORT -> {
+                    if (handleImport()) return
+                }
+                else -> logger.warn("Unknown handshake opcode: 0x{}", Integer.toHexString(opCode))
+            }
+        }
+    }
+
+    private suspend fun handleDevlist() {
+        logger.debug("Handling OP_REQ_DEVLIST")
+        writeResponse(DeviceListResponse(listOf(deviceInfo)).toBytes())
+    }
+
+    private suspend fun handleImport(): Boolean {
+        val importRequest = ImportRequest.parse(readBigEndianBuffer(32))
+        logger.debug("Handling OP_REQ_IMPORT: busid={}", importRequest.busId)
+
+        if (importRequest.busId != deviceInfo.busid) {
+            logger.warn("Import request for unknown busid: {}", importRequest.busId)
+            return false
+        }
+
+        writeResponse(ImportResponse(deviceInfo).toBytes())
+        logger.info("Device attached to client")
+        return true
+    }
+
+    // --- URB phase: command(4) + seqnum(4) + ... ---
+
+    private suspend fun CoroutineScope.handleSubmitPhase() {
+        while (isActive) {
+            val header = readBigEndianBuffer(48)
+            when (header.int) {
+                USBIPProtocol.USBIP_CMD_SUBMIT -> handleCmdSubmit(header)
+                USBIPProtocol.USBIP_CMD_UNLINK -> handleCmdUnlink(header)
+                else -> logger.warn("Unknown command")
+            }
+        }
+    }
+
+    private suspend fun CoroutineScope.handleCmdSubmit(header: ByteBuffer) {
+        var request = SubmitRequest.parse(header)
+
+        if (request.transferBufferLength > MAX_TRANSFER_BUFFER_LENGTH) {
+            logger.warn("Transfer size too large: {}", request.transferBufferLength)
+            writeResponse(SubmitResponse.error(request, USBIPProtocol.STATUS_EINVAL))
+            return
+        }
+
+        if (request.direction == USBIPProtocol.USBIP_DIR_OUT && request.transferBufferLength > 0) {
+            request = request.copy(data = readBytes(request.transferBufferLength))
+        }
+
+        logger.trace("CMD_SUBMIT: ep={}, dir={}, len={}", request.ep, request.direction, request.transferBufferLength)
+
+        val capturedRequest = request
+        launch {
+            try {
+                writeResponse(device.handleSubmit(capturedRequest))
+            } catch (_: CancellationException) {
+                // Request was unlinked via CMD_UNLINK, no response needed
+            } catch (e: Exception) {
+                logger.error("Error processing submit request", e)
+                writeResponse(SubmitResponse.error(capturedRequest, USBIPProtocol.STATUS_EINVAL))
+            }
+        }.trackIfInterruptIn(request)
+    }
+
+    private suspend fun handleCmdUnlink(header: ByteBuffer) {
+        val unlinkRequest = UnlinkRequest.parse(header)
+
+        logger.debug("CMD_UNLINK: seqnum={}, unlinkSeqnum={}", unlinkRequest.seqnum, unlinkRequest.unlinkSeqnum)
+        pendingInJobs.remove(unlinkRequest.unlinkSeqnum)?.cancel()
+        writeResponse(UnlinkResponse(unlinkRequest.seqnum).toBytes())
+    }
+
+    // --- Helpers ---
+
+    private fun Job.trackIfInterruptIn(request: SubmitRequest) {
+        if (request.ep != USBIPProtocol.EP0_ADDRESS && request.direction == USBIPProtocol.USBIP_DIR_IN) {
+            pendingInJobs[request.seqnum] = this
+            invokeOnCompletion { pendingInJobs.remove(request.seqnum) }
+        }
+    }
+
+    private suspend fun writeResponse(result: SubmitResponse) {
+        writeResponse(result.toBytes())
+    }
+
+    private suspend fun readBytes(length: Int): ByteArray {
+        val buffer = ByteArray(length)
+        readChannel.readFully(buffer, 0, length)
+        return buffer
+    }
+
+    private suspend fun readBigEndianBuffer(length: Int): ByteBuffer {
+        return ByteBuffer.wrap(readBytes(length)).order(ByteOrder.BIG_ENDIAN)
+    }
+
+    private suspend fun writeResponse(data: ByteArray) {
+        writeMutex.withLock {
+            writeChannel.writeFully(data, 0, data.size)
+        }
+    }
+
+    fun close() {
+        socket.close()
+    }
+
+    companion object {
+        private const val MAX_TRANSFER_BUFFER_LENGTH = 4096
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/server/USBIPClientHandler.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/server/USBIPClientHandler.kt
@@ -18,8 +18,10 @@ import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.readFully
 import io.ktor.utils.io.writeFully
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -45,6 +47,7 @@ class USBIPClientHandler(
     private val logger = LoggerFactory.getLogger(USBIPClientHandler::class.java)
     private val writeMutex = Mutex()
     private val pendingInJobs = ConcurrentHashMap<Int, Job>()
+    private val inRequestQueue = Channel<PendingInRequest>(Channel.UNLIMITED)
 
     private lateinit var readChannel: ByteReadChannel
     private lateinit var writeChannel: ByteWriteChannel
@@ -107,12 +110,34 @@ class USBIPClientHandler(
     // --- URB phase: command(4) + seqnum(4) + ... ---
 
     private suspend fun CoroutineScope.handleSubmitPhase() {
+        launch { interruptInPump() }
         while (isActive) {
             val header = readBigEndianBuffer(48)
             when (header.int) {
                 USBIPProtocol.USBIP_CMD_SUBMIT -> handleCmdSubmit(header)
                 USBIPProtocol.USBIP_CMD_UNLINK -> handleCmdUnlink(header)
                 else -> logger.warn("Unknown command")
+            }
+        }
+    }
+
+    /**
+     * Sequentially processes queued Interrupt IN requests.
+     * Interrupt IN is a polling transfer that suspends until the device has data to send.
+     * A sequential pump ensures response ordering for multi-packet HID replies.
+     */
+    private suspend fun interruptInPump() {
+        for (pending in inRequestQueue) {
+            try {
+                val response = device.handleSubmit(pending.request)
+                writeResponse(response)
+                pending.done.complete(Unit)
+            } catch (_: CancellationException) {
+                pending.done.complete(Unit)
+            } catch (e: Exception) {
+                logger.error("Error processing Interrupt IN request", e)
+                writeResponse(SubmitResponse.error(pending.request, USBIPProtocol.STATUS_EINVAL))
+                pending.done.complete(Unit)
             }
         }
     }
@@ -130,19 +155,28 @@ class USBIPClientHandler(
             request = request.copy(data = readBytes(request.transferBufferLength))
         }
 
-        logger.trace("CMD_SUBMIT: ep={}, dir={}, len={}", request.ep, request.direction, request.transferBufferLength)
+        logger.debug("CMD_SUBMIT: ep={}, dir={}, len={}", request.ep, request.direction, request.transferBufferLength)
 
         val capturedRequest = request
-        launch {
-            try {
-                writeResponse(device.handleSubmit(capturedRequest))
-            } catch (_: CancellationException) {
-                // Request was unlinked via CMD_UNLINK, no response needed
-            } catch (e: Exception) {
-                logger.error("Error processing submit request", e)
-                writeResponse(SubmitResponse.error(capturedRequest, USBIPProtocol.STATUS_EINVAL))
+        when {
+            // Control transfers (EP0) and OUT transfers always have immediate responses.
+            request.ep == USBIPProtocol.EP0_ADDRESS || request.direction == USBIPProtocol.USBIP_DIR_OUT -> {
+                try {
+                    writeResponse(device.handleSubmit(capturedRequest))
+                } catch (e: Exception) {
+                    logger.error("Error processing submit request", e)
+                    writeResponse(SubmitResponse.error(capturedRequest, USBIPProtocol.STATUS_EINVAL))
+                }
             }
-        }.trackIfInterruptIn(request)
+            // Interrupt IN transfers suspend until data is available; route through sequential pump.
+            else -> {
+                val pending = PendingInRequest(capturedRequest)
+                inRequestQueue.send(pending)
+                val job = launch { pending.done.await() }
+                pendingInJobs[request.seqnum] = job
+                job.invokeOnCompletion { pendingInJobs.remove(request.seqnum) }
+            }
+        }
     }
 
     private suspend fun handleCmdUnlink(header: ByteBuffer) {
@@ -155,12 +189,10 @@ class USBIPClientHandler(
 
     // --- Helpers ---
 
-    private fun Job.trackIfInterruptIn(request: SubmitRequest) {
-        if (request.ep != USBIPProtocol.EP0_ADDRESS && request.direction == USBIPProtocol.USBIP_DIR_IN) {
-            pendingInJobs[request.seqnum] = this
-            invokeOnCompletion { pendingInJobs.remove(request.seqnum) }
-        }
-    }
+    private class PendingInRequest(
+        val request: SubmitRequest,
+        val done: CompletableDeferred<Unit> = CompletableDeferred()
+    )
 
     private suspend fun writeResponse(result: SubmitResponse) {
         writeResponse(result.toBytes())
@@ -180,10 +212,6 @@ class USBIPClientHandler(
         writeMutex.withLock {
             writeChannel.writeFully(data, 0, data.size)
         }
-    }
-
-    fun close() {
-        socket.close()
     }
 
     companion object {

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/ControlRequestHandler.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/ControlRequestHandler.kt
@@ -1,0 +1,72 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.usb
+
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.USBIPProtocol
+import org.slf4j.LoggerFactory
+
+/**
+ * Handles USB control endpoint (EP0) transfers.
+ * Processes standard USB requests like GET_DESCRIPTOR, SET_CONFIGURATION, etc.
+ */
+class ControlRequestHandler(
+    private val config: USBIPDeviceConfig
+) {
+    private val logger = LoggerFactory.getLogger(ControlRequestHandler::class.java)
+
+    fun handle(request: SubmitRequest): SubmitResponse {
+        val setup = SetupPacket.parse(request.setup)
+
+        logger.debug("Control request: type=0x{}, req=0x{}, value=0x{}, index=0x{}, length={}",
+            Integer.toHexString(setup.bmRequestType),
+            Integer.toHexString(setup.bRequest),
+            Integer.toHexString(setup.wValue),
+            Integer.toHexString(setup.wIndex),
+            setup.wLength)
+
+        return when (setup.bRequest) {
+            USBConstants.USB_REQ_GET_DESCRIPTOR -> handleGetDescriptor(request, setup)
+            USBConstants.USB_REQ_SET_CONFIGURATION -> handleSetConfiguration(request, setup.wValue)
+            USBConstants.USB_REQ_SET_IDLE -> handleSetIdle(request)
+            else -> {
+                logger.warn("Unsupported control request: 0x{}", Integer.toHexString(setup.bRequest))
+                SubmitResponse.error(request, USBIPProtocol.STATUS_EPIPE)
+            }
+        }
+    }
+
+    private fun handleGetDescriptor(request: SubmitRequest, setup: SetupPacket): SubmitResponse {
+        val descriptorType = (setup.wValue shr 8) and 0xFF
+        val descriptorIndex = setup.wValue and 0xFF
+
+        logger.debug("GET_DESCRIPTOR: type=0x{}, index={}, length={}",
+            Integer.toHexString(descriptorType), descriptorIndex, setup.wLength)
+
+        val descriptorData = when (descriptorType) {
+            USBConstants.USB_DT_DEVICE -> USBDescriptors.generateDeviceDescriptor(config)
+            USBConstants.USB_DT_CONFIG -> USBDescriptors.generateConfigurationDescriptor()
+            USBConstants.USB_DT_STRING -> USBDescriptors.generateStringDescriptor(descriptorIndex, config.deviceName)
+            USBConstants.USB_DT_REPORT -> USBDescriptors.getReportDescriptor()
+            USBConstants.USB_DT_HID -> USBDescriptors.getHIDDescriptor()
+            else -> {
+                logger.warn("Unknown descriptor type: 0x{}", Integer.toHexString(descriptorType))
+                return SubmitResponse.error(request, USBIPProtocol.STATUS_EPIPE)
+            }
+        }
+
+        val responseData = descriptorData.copyOf(minOf(descriptorData.size, setup.wLength))
+        logger.debug("Returning {} bytes of descriptor data", responseData.size)
+        return SubmitResponse.success(request, responseData)
+    }
+
+    private fun handleSetConfiguration(request: SubmitRequest, value: Int): SubmitResponse {
+        logger.debug("SET_CONFIGURATION: value={}", value)
+        return SubmitResponse.success(request, ByteArray(0))
+    }
+
+    private fun handleSetIdle(request: SubmitRequest): SubmitResponse {
+        logger.debug("SET_IDLE request")
+        return SubmitResponse.success(request, ByteArray(0))
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/InterruptEndpointHandler.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/InterruptEndpointHandler.kt
@@ -1,0 +1,58 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.usb
+
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDTransport
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.protocol.SubmitRequest
+import kotlinx.coroutines.channels.Channel
+import org.slf4j.LoggerFactory
+
+/**
+ * Handles HID interrupt endpoint transfers (IN and OUT).
+ *
+ * For Interrupt IN, [handleIn] suspends until response data becomes available,
+ * matching real USB behavior where NAK is handled transparently by the
+ * host controller at the hardware level.
+ */
+class InterruptEndpointHandler(
+    private val hidTransport: HIDTransport
+) {
+    private val logger = LoggerFactory.getLogger(InterruptEndpointHandler::class.java)
+
+    private val responseChannel = Channel<ByteArray>(Channel.UNLIMITED)
+
+    /**
+     * Handles Interrupt OUT transfer (host -> device).
+     * Receives 64-byte HID reports and passes them to HIDTransport.
+     */
+    suspend fun handleOut(request: SubmitRequest): SubmitResponse {
+        logger.debug("Interrupt OUT: {} bytes", request.data.size)
+
+        if (request.data.isEmpty()) {
+            logger.warn("Interrupt OUT with no data")
+            return SubmitResponse.success(request, ByteArray(0))
+        }
+
+        hidTransport.onHIDDataReceived(request.data) { responseBytes ->
+            responseChannel.trySend(responseBytes)
+            logger.debug("Queued response: {} bytes", responseBytes.size)
+        }
+
+        return SubmitResponse.success(request, ByteArray(0), actualLength = request.data.size)
+    }
+
+    /**
+     * Handles Interrupt IN transfer (device -> host).
+     * Suspends until response data is available.
+     * Cancellation via CMD_UNLINK is handled by cancelling the calling coroutine.
+     */
+    suspend fun handleIn(request: SubmitRequest): SubmitResponse {
+        logger.trace("Interrupt IN: waiting for data (seqnum={})", request.seqnum)
+        val data = responseChannel.receive()
+        logger.debug("Interrupt IN: returning {} bytes (seqnum={})", data.size, request.seqnum)
+        return SubmitResponse.success(request, data)
+    }
+
+    fun close() {
+        responseChannel.close()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/InterruptEndpointHandler.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/InterruptEndpointHandler.kt
@@ -12,6 +12,10 @@ import org.slf4j.LoggerFactory
  * For Interrupt IN, [handleIn] suspends until response data becomes available,
  * matching real USB behavior where NAK is handled transparently by the
  * host controller at the hardware level.
+ *
+ * HID OUT data is passed directly to [HIDTransport.onHIDDataReceived] which
+ * queues it internally for async processing. Response data is collected via
+ * the callback and made available to IN transfers through [responseChannel].
  */
 class InterruptEndpointHandler(
     private val hidTransport: HIDTransport
@@ -20,11 +24,7 @@ class InterruptEndpointHandler(
 
     private val responseChannel = Channel<ByteArray>(Channel.UNLIMITED)
 
-    /**
-     * Handles Interrupt OUT transfer (host -> device).
-     * Receives 64-byte HID reports and passes them to HIDTransport.
-     */
-    suspend fun handleOut(request: SubmitRequest): SubmitResponse {
+    fun handleOut(request: SubmitRequest): SubmitResponse {
         logger.debug("Interrupt OUT: {} bytes", request.data.size)
 
         if (request.data.isEmpty()) {
@@ -37,16 +37,11 @@ class InterruptEndpointHandler(
             logger.debug("Queued response: {} bytes", responseBytes.size)
         }
 
-        return SubmitResponse.success(request, ByteArray(0), actualLength = request.data.size)
+        return SubmitResponse.success(request, ByteArray(0))
     }
 
-    /**
-     * Handles Interrupt IN transfer (device -> host).
-     * Suspends until response data is available.
-     * Cancellation via CMD_UNLINK is handled by cancelling the calling coroutine.
-     */
     suspend fun handleIn(request: SubmitRequest): SubmitResponse {
-        logger.trace("Interrupt IN: waiting for data (seqnum={})", request.seqnum)
+        logger.debug("Interrupt IN: waiting for data (seqnum={})", request.seqnum)
         val data = responseChannel.receive()
         logger.debug("Interrupt IN: returning {} bytes (seqnum={})", data.size, request.seqnum)
         return SubmitResponse.success(request, data)

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/SetupPacket.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/SetupPacket.kt
@@ -1,0 +1,22 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.usb
+
+/**
+ * Parsed USB setup packet (8 bytes) from a control transfer.
+ */
+data class SetupPacket(
+    val bmRequestType: Int,
+    val bRequest: Int,
+    val wValue: Int,
+    val wIndex: Int,
+    val wLength: Int
+) {
+    companion object {
+        fun parse(setup: ByteArray): SetupPacket = SetupPacket(
+            bmRequestType = setup[0].toInt() and 0xFF,
+            bRequest = setup[1].toInt() and 0xFF,
+            wValue = ((setup[3].toInt() and 0xFF) shl 8) or (setup[2].toInt() and 0xFF),
+            wIndex = ((setup[5].toInt() and 0xFF) shl 8) or (setup[4].toInt() and 0xFF),
+            wLength = ((setup[7].toInt() and 0xFF) shl 8) or (setup[6].toInt() and 0xFF)
+        )
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/USBConstants.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/USBConstants.kt
@@ -1,0 +1,19 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.usb
+
+/**
+ * Standard USB constants (request codes, descriptor types).
+ */
+object USBConstants {
+
+    // Standard USB request codes
+    const val USB_REQ_GET_DESCRIPTOR = 0x06
+    const val USB_REQ_SET_CONFIGURATION = 0x09
+    const val USB_REQ_SET_IDLE = 0x0A
+
+    // Descriptor types
+    const val USB_DT_DEVICE = 0x01
+    const val USB_DT_CONFIG = 0x02
+    const val USB_DT_STRING = 0x03
+    const val USB_DT_HID = 0x21
+    const val USB_DT_REPORT = 0x22
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/USBDescriptors.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/usb/USBDescriptors.kt
@@ -1,0 +1,169 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.usb
+
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
+
+/**
+ * USB descriptor generator for FIDO HID devices.
+ * Generates all required descriptors for USB-IP protocol.
+ */
+object USBDescriptors {
+
+    /**
+     * Standard FIDO HID report descriptor (34 bytes).
+     * Defines 64-byte input and output reports for FIDO Alliance Usage Page (0xF1D0).
+     */
+    private val FIDO_HID_REPORT_DESCRIPTOR = byteArrayOf(
+        0x06, 0xD0.toByte(), 0xF1.toByte(),   // Usage Page (FIDO Alliance = 0xF1D0)
+        0x09, 0x01,                             // Usage (U2F HID Authenticator Device)
+        0xA1.toByte(), 0x01,                    // Collection (Application)
+        0x09, 0x20,                             //   Usage (Input Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x81.toByte(), 0x02,                    //   Input (Data, Var, Abs)
+        0x09, 0x21,                             //   Usage (Output Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x91.toByte(), 0x02,                    //   Output (Data, Var, Abs)
+        0xC0.toByte()                           // End Collection
+    )
+
+    /**
+     * Generates USB device descriptor (18 bytes).
+     * Describes basic device properties like VID/PID and USB version.
+     */
+    fun generateDeviceDescriptor(config: USBIPDeviceConfig): ByteArray {
+        return byteArrayOf(
+            0x12,                                // bLength (18 bytes)
+            0x01,                                // bDescriptorType (Device)
+            0x00, 0x02,                          // bcdUSB (USB 2.0)
+            0x00,                                // bDeviceClass (defined in interface)
+            0x00,                                // bDeviceSubClass
+            0x00,                                // bDeviceProtocol
+            0x40,                                // bMaxPacketSize0 (64 bytes)
+            (config.vendorId and 0xFF).toByte(),
+            ((config.vendorId shr 8) and 0xFF).toByte(),
+            (config.productId and 0xFF).toByte(),
+            ((config.productId shr 8) and 0xFF).toByte(),
+            (config.version and 0xFF).toByte(),
+            ((config.version shr 8) and 0xFF).toByte(),
+            0x01,                                // iManufacturer (string index 1)
+            0x02,                                // iProduct (string index 2)
+            0x00,                                // iSerialNumber (none)
+            0x01                                 // bNumConfigurations
+        )
+    }
+
+    /**
+     * Generates complete configuration descriptor tree (41 bytes).
+     * Includes: Configuration + Interface + HID + 2 Endpoints (IN + OUT).
+     */
+    fun generateConfigurationDescriptor(): ByteArray {
+        val totalLength = 9 + 9 + 9 + 7 + 7  // Config + Interface + HID + EP_IN + EP_OUT = 41
+
+        return byteArrayOf(
+            // Configuration Descriptor (9 bytes)
+            0x09,                                // bLength
+            0x02,                                // bDescriptorType (Configuration)
+            (totalLength and 0xFF).toByte(),
+            ((totalLength shr 8) and 0xFF).toByte(),  // wTotalLength
+            0x01,                                // bNumInterfaces
+            0x01,                                // bConfigurationValue
+            0x00,                                // iConfiguration
+            0xA0.toByte(),                       // bmAttributes (Bus powered, Remote wakeup)
+            0x32,                                // bMaxPower (100mA)
+
+            // Interface Descriptor (9 bytes)
+            0x09,                                // bLength
+            0x04,                                // bDescriptorType (Interface)
+            0x00,                                // bInterfaceNumber
+            0x00,                                // bAlternateSetting
+            0x02,                                // bNumEndpoints (IN + OUT)
+            0x03,                                // bInterfaceClass (HID)
+            0x00,                                // bInterfaceSubClass
+            0x00,                                // bInterfaceProtocol
+            0x00,                                // iInterface
+
+            // HID Descriptor (9 bytes)
+            0x09,                                // bLength
+            0x21,                                // bDescriptorType (HID)
+            0x11, 0x01,                          // bcdHID (HID 1.11)
+            0x00,                                // bCountryCode
+            0x01,                                // bNumDescriptors
+            0x22,                                // bDescriptorType (Report)
+            (FIDO_HID_REPORT_DESCRIPTOR.size and 0xFF).toByte(),
+            ((FIDO_HID_REPORT_DESCRIPTOR.size shr 8) and 0xFF).toByte(),
+
+            // Endpoint Descriptor - Interrupt IN (7 bytes)
+            0x07,                                // bLength
+            0x05,                                // bDescriptorType (Endpoint)
+            0x81.toByte(),                       // bEndpointAddress (IN, EP1)
+            0x03,                                // bmAttributes (Interrupt)
+            0x40, 0x00,                          // wMaxPacketSize (64 bytes)
+            0x05,                                // bInterval (5ms)
+
+            // Endpoint Descriptor - Interrupt OUT (7 bytes)
+            0x07,                                // bLength
+            0x05,                                // bDescriptorType (Endpoint)
+            0x01,                                // bEndpointAddress (OUT, EP1)
+            0x03,                                // bmAttributes (Interrupt)
+            0x40, 0x00,                          // wMaxPacketSize (64 bytes)
+            0x05                                 // bInterval (5ms)
+        )
+    }
+
+    /**
+     * Returns the FIDO HID report descriptor.
+     */
+    fun getReportDescriptor(): ByteArray {
+        return FIDO_HID_REPORT_DESCRIPTOR
+    }
+
+    /**
+     * Returns the 9-byte HID class descriptor.
+     */
+    fun getHIDDescriptor(): ByteArray {
+        return byteArrayOf(
+            0x09,                                // bLength
+            0x21,                                // bDescriptorType (HID)
+            0x11, 0x01,                          // bcdHID (HID 1.11)
+            0x00,                                // bCountryCode
+            0x01,                                // bNumDescriptors
+            0x22,                                // bDescriptorType (Report)
+            (FIDO_HID_REPORT_DESCRIPTOR.size and 0xFF).toByte(),
+            ((FIDO_HID_REPORT_DESCRIPTOR.size shr 8) and 0xFF).toByte()
+        )
+    }
+
+    /**
+     * Generates USB string descriptor.
+     * @param index String descriptor index (0 = language IDs, 1 = manufacturer, 2 = product)
+     * @param value String value (used for product name from config)
+     */
+    fun generateStringDescriptor(index: Int, value: String = ""): ByteArray {
+        return when (index) {
+            0 -> byteArrayOf(
+                0x04,                            // bLength
+                0x03,                            // bDescriptorType (String)
+                0x09, 0x04                       // Language ID: English (US) = 0x0409
+            )
+            1 -> encodeStringDescriptor("WebAuthn4J")
+            2 -> encodeStringDescriptor(value)
+            else -> byteArrayOf(0x02, 0x03)      // Empty string
+        }
+    }
+
+    /**
+     * Encodes a string as UTF-16LE for USB string descriptor.
+     */
+    private fun encodeStringDescriptor(str: String): ByteArray {
+        val utf16 = str.toByteArray(Charsets.UTF_16LE)
+        return byteArrayOf(
+            (utf16.size + 2).toByte(),           // bLength
+            0x03                                  // bDescriptorType (String)
+        ) + utf16
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDRequestMessageBuilder.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDRequestMessageBuilder.kt
@@ -16,7 +16,9 @@ import com.webauthn4j.ctap.core.data.hid.HIDStatusCode
 import com.webauthn4j.ctap.core.data.hid.HIDWINKRequestMessage
 import com.webauthn4j.ctap.core.data.nfc.CommandAPDU
 
-class HIDRequestMessageBuilder : HIDMessageBuilderBase<HIDRequestMessage>() {
+class HIDRequestMessageBuilder(
+    packetSize: Int = com.webauthn4j.ctap.core.data.hid.HIDMessage.DEFAULT_PACKET_SIZE
+) : HIDMessageBuilderBase<HIDRequestMessage>(packetSize) {
 
     override fun createMessage(
         channelId: HIDChannelId,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDResponseMessageBuilder.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDResponseMessageBuilder.kt
@@ -14,7 +14,9 @@ import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDStatusCode
 import com.webauthn4j.ctap.core.data.hid.HIDWINKResponseMessage
 
-class HIDResponseMessageBuilder : HIDMessageBuilderBase<HIDResponseMessage>() {
+class HIDResponseMessageBuilder(
+    packetSize: Int = com.webauthn4j.ctap.core.data.hid.HIDMessage.DEFAULT_PACKET_SIZE
+) : HIDMessageBuilderBase<HIDResponseMessage>(packetSize) {
     override fun createMessage(
         channelId: HIDChannelId,
         command: HIDCommand,


### PR DESCRIPTION
Add two transport bridge modules that expose CtapAuthenticator as virtual USB FIDO2 security keys:

- **webauthn4j-ctap-authenticator-uhid**: Linux UHID device for local virtual HID devices via /dev/uhid
- **webauthn4j-ctap-authenticator-usbip**: USB-IP device for cross-platform virtual FIDO2 devices over TCP/IP (primary use case: FIDO Conformance Tests on Windows)
- **unifidokey-uhid / unifidokey-usbip**: Quarkus CLI applications (picocli) with uber-jar packaging

WIP changes on top:
- Async HID OUT processing via outDataChannel to prevent KEEPALIVE delivery blocking
- CTAPHID_CANCEL bypass for immediate processing
- cancelOnGoingTransaction() implementation in CtapAuthenticatorSession
- CancellationException propagation in CtapCommandExecutionBase
- ConsoleUserVerificationHandler for auto-approval testing