### PR TITLE
Fix CTAPHID protocol issues and extract command handlers

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -161,10 +161,8 @@ class CtapAuthenticatorSession internal constructor(
         exceptionReporters.forEach { it.onException(exception) }
     }
 
+    @Deprecated("Lock is now handled at the HID transport layer", level = DeprecationLevel.WARNING)
     suspend fun lock(timeMillis: Long) {
-        mutex.withLock {
-            delay(timeMillis)
-        }
     }
 
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
@@ -1,0 +1,109 @@
+package com.webauthn4j.ctap.authenticator.transport.hid
+
+import com.webauthn4j.ctap.authenticator.transport.hid.handler.*
+import com.webauthn4j.ctap.core.data.hid.*
+import org.slf4j.LoggerFactory
+
+class HIDChannel(
+    private val channelId: HIDChannelId,
+    private val activeTransactionChannelIdSetter: (HIDChannelId?) -> Unit,
+    private val initHandler: HIDInitCommandHandler,
+    private val cborHandler: HIDCborCommandHandler,
+    private val msgHandler: HIDMsgCommandHandler,
+    private val pingHandler: HIDPingCommandHandler,
+    private val cancelHandler: HIDCancelCommandHandler,
+    private val winkHandler: HIDWinkCommandHandler,
+    private val lockHandler: HIDLockCommandHandler
+) {
+
+    private val logger = LoggerFactory.getLogger(HIDChannel::class.java)
+    private val hidRequestMessageBuilder = HIDRequestMessageBuilder()
+
+    suspend fun handlePacket(
+        hidPacket: HIDPacket,
+        responseCallback: (HIDPacket) -> Unit
+    ) {
+        //spec| A transaction has to be completed within a specified period of time to prevent a stalling
+        //spec| application to cause the device to be completely locked out for access by other applications.
+        if (hidPacket is HIDInitializationPacket && hidRequestMessageBuilder.isTimedOut) {
+            logger.debug("Message assembly timed out, resetting builder")
+            hidRequestMessageBuilder.clear()
+        }
+
+        when (hidPacket) {
+            is HIDInitializationPacket -> {
+                activeTransactionChannelIdSetter(channelId)
+                hidRequestMessageBuilder.initialize(hidPacket)
+            }
+            is HIDContinuationPacket -> {
+                if (hidRequestMessageBuilder.isTimedOut) {
+                    hidRequestMessageBuilder.clear()
+                    activeTransactionChannelIdSetter(null)
+                    throw HIDProtocolException(HIDErrorCode.MSG_TIMEOUT, "Message assembly timed out")
+                }
+                hidRequestMessageBuilder.append(hidPacket)
+            }
+            else -> throw HIDProtocolException(HIDErrorCode.OTHER, "Unknown HIDPacket subclass")
+        }
+        if (hidRequestMessageBuilder.isCompleted) {
+            val hidMessage = hidRequestMessageBuilder.build()
+            hidRequestMessageBuilder.clear()
+            try {
+                handleMessage(hidMessage) {
+                    it.toHIDPackets().forEach { packet -> responseCallback(packet) }
+                }
+            } catch (e: HIDProtocolException) {
+                throw e
+            } catch (e: RuntimeException) {
+                logger.error("Unexpected exception is thrown while processing HID message", e)
+                HIDERRORResponseMessage(hidMessage.channelId, HIDErrorCode.OTHER).toHIDPackets()
+                    .forEach { packet -> responseCallback(packet) }
+            } finally {
+                activeTransactionChannelIdSetter(null)
+            }
+        }
+    }
+
+    private suspend fun handleMessage(
+        hidMessage: HIDMessage,
+        responseCallback: (HIDResponseMessage) -> Unit
+    ) {
+        logger.debug("CTAP Request HID Message: {}", hidMessage)
+        when (hidMessage.command) {
+            HIDCommand.CTAPHID_MSG -> {
+                msgHandler.handle(hidMessage as HIDMSGRequestMessage) {
+                    logger.debug("CTAP Response HID Message: {}", it)
+                    responseCallback(it)
+                }
+            }
+            HIDCommand.CTAPHID_CBOR -> {
+                cborHandler.handle(hidMessage as HIDCBORRequestMessage) {
+                    logger.debug("CTAP Response HID Message: {}", it)
+                    responseCallback(it)
+                }
+            }
+            HIDCommand.CTAPHID_INIT -> {
+                val response = initHandler.handle(hidMessage as HIDINITRequestMessage)
+                logger.debug("CTAP Response HID Message: {}", response)
+                responseCallback(response)
+            }
+            HIDCommand.CTAPHID_PING -> {
+                val response = pingHandler.handle(hidMessage as HIDPINGRequestMessage)
+                logger.debug("CTAP Response HID Message: {}", response)
+                responseCallback(response)
+            }
+            HIDCommand.CTAPHID_CANCEL -> cancelHandler.handle()
+            HIDCommand.CTAPHID_WINK -> {
+                val response = winkHandler.handle(hidMessage as HIDWINKRequestMessage)
+                logger.debug("CTAP Response HID Message: {}", response)
+                responseCallback(response)
+            }
+            HIDCommand.CTAPHID_LOCK -> {
+                val response = lockHandler.handle(hidMessage as HIDLOCKRequestMessage, channelId)
+                logger.debug("CTAP Response HID Message: {}", response)
+                responseCallback(response)
+            }
+            else -> throw HIDProtocolException(HIDErrorCode.INVALID_CMD, "%s is not supported".format(hidMessage.command))
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
@@ -3,44 +3,31 @@ package com.webauthn4j.ctap.authenticator.transport.hid
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
 import com.webauthn4j.ctap.authenticator.transport.Transport
+import com.webauthn4j.ctap.authenticator.transport.hid.handler.*
 import com.webauthn4j.ctap.authenticator.transport.nfc.apdu.U2FAPDUProcessor
 import com.webauthn4j.ctap.core.converter.CtapRequestConverter
 import com.webauthn4j.ctap.core.converter.CtapResponseConverter
 import com.webauthn4j.ctap.core.converter.HIDPacketConverter
-import com.webauthn4j.ctap.core.data.CtapResponse
-import com.webauthn4j.ctap.core.data.U2FStatusCode
 import com.webauthn4j.ctap.core.data.hid.*
 import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.MAX_PACKET_SIZE
-import com.webauthn4j.ctap.core.data.nfc.ResponseAPDU
 import com.webauthn4j.util.HexUtil
 import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 import java.security.SecureRandom
 
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-discovery">8.1. USB Human Interface Device (USB HID)</a>
 class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
 
     companion object {
-        private const val KEEPALIVE_INTERVAL = 100L
-        private const val HID_PROTOCOL_VERSION_NUMBER: Byte = 2
-        private const val MAJOR_DEVICE_VERSION_NUMBER: Byte = 0
-        private const val MINOR_DEVICE_VERSION_NUMBER: Byte = 1
-        private const val BUILD_DEVICE_VERSION_NUMBER: Byte = 0
-        private val CAPABILITIES =
-            HIDCapability((HIDCapability.WINK.value.toInt() or HIDCapability.CBOR.value.toInt()).toByte())
-
         private const val CTAP_REQUEST_HID_PACKET_LOGGING_TEMPLATE = "CTAP Request HID Packet: {}"
         private const val CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE = "CTAP Response HID Packet: {}"
         private const val CTAP_REQUEST_HID_MESSAGE_LOGGING_TEMPLATE = "CTAP Request HID Message: {}"
-        private const val CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE =
-            "CTAP Request HID Message: {}"
+        private const val CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE = "CTAP Request HID Message: {}"
     }
 
     private val logger = LoggerFactory.getLogger(HIDTransport::class.java)
 
     private var ctapAuthenticatorSession: CtapAuthenticatorSession = ctapAuthenticator.createSession() //TODO: revisit
-
-    private val ctapRequestConverter = CtapRequestConverter(ctapAuthenticator.objectConverter)
-    private val ctapResponseConverter = CtapResponseConverter(ctapAuthenticator.objectConverter)
 
     private val u2fAPDUProcessor = U2FAPDUProcessor().also { it.onConnect(ctapAuthenticatorSession) }
 
@@ -48,11 +35,38 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
     private val hidChannels: MutableMap<HIDChannelId, HIDChannel> = HashMap()
     private val secureRandom = SecureRandom()
 
+    //spec| The application channel that manages to get through the first initialization packet when the device
+    //spec| is in idle state will keep the device locked for other channels until the last packet of the response
+    //spec| message has been received or the transaction is aborted.
     @Volatile
     private var activeTransactionChannelId: HIDChannelId? = null
 
+    private val lockState = HIDLockCommandHandler.LockState()
+
     @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     private val u2fConfirmationWorker = newSingleThreadContext("u2f-confirmation-worker")
+
+    private val initHandler = HIDInitCommandHandler(object : HIDInitCommandHandler.ChannelAllocator {
+        override fun allocateChannel(): HIDChannelId {
+            val id = allocateNewChannelId()
+            hidChannels[id] = createChannel(id)
+            return id
+        }
+        override fun resyncChannel(channelId: HIDChannelId) {
+            hidChannels.remove(channelId)
+            hidChannels[channelId] = createChannel(channelId)
+        }
+    })
+    private val pingHandler = HIDPingCommandHandler()
+    private val cancelHandler = HIDCancelCommandHandler(ctapAuthenticatorSession)
+    private val winkHandler = HIDWinkCommandHandler(ctapAuthenticatorSession)
+    private val lockHandler = HIDLockCommandHandler(lockState)
+    private val cborHandler = HIDCborCommandHandler(
+        CtapRequestConverter(ctapAuthenticator.objectConverter),
+        CtapResponseConverter(ctapAuthenticator.objectConverter),
+        ctapAuthenticatorSession,
+        newSingleThreadContext("hid-cbor-keepalive-worker")
+    )
 
     private fun sendError(channelId: HIDChannelId, errorCode: HIDErrorCode, hidPacketHandler: HIDPacketHandler) {
         HIDERRORResponseMessage(channelId, errorCode).toHIDPackets()
@@ -76,12 +90,14 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
                 logger.debug(CTAP_REQUEST_HID_PACKET_LOGGING_TEMPLATE, hidPacket.toString())
                 val channelId = hidPacket.channelId
 
+                //spec| Channel ID 0 is reserved and 0xffffffff is reserved for broadcast commands,
+                //spec| i.e. at the time of channel allocation.
                 if (channelId == HIDChannelId.BROADCAST) {
                     if (hidPacket !is HIDInitializationPacket || hidPacket.command != HIDCommand.CTAPHID_INIT) {
                         sendError(channelId, HIDErrorCode.INVALID_CHANNEL, hidPacketHandler)
                         return
                     }
-                    val tempChannel = HIDChannel(channelId)
+                    val tempChannel = createChannel(channelId)
                     tempChannel.handlePacket(hidPacket) { responsePacket ->
                         logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, responsePacket.toString())
                         hidPacketHandler.onResponse(hidPacketConverter.convert(responsePacket))
@@ -89,20 +105,40 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
                     return
                 }
 
+                //spec| A CTAPHID_CANCEL received while no CTAPHID_CBOR request is being processed,
+                //spec| or on a non-active CID SHALL be ignored by the authenticator.
+                val isCancelCommand = hidPacket is HIDInitializationPacket
+                        && hidPacket.command == HIDCommand.CTAPHID_CANCEL
+
                 var hidChannel = hidChannels[channelId]
                 if (hidChannel == null) {
                     if (hidPacket is HIDContinuationPacket) {
+                        //spec| Spurious continuation packets appearing without a prior initialization packet will be ignored.
                         logger.debug("Unexpected continuation packet on unknown channel. Skipped.")
                         return
                     }
+                    if (isCancelCommand) return
                     sendError(channelId, HIDErrorCode.INVALID_CHANNEL, hidPacketHandler)
                     return
                 }
 
-                if (hidPacket is HIDInitializationPacket) {
-                    val activeChannel = activeTransactionChannelId
-                    if (activeChannel != null && activeChannel != channelId) {
-                        sendError(channelId, HIDErrorCode.CHANNEL_BUSY, hidPacketHandler)
+                //spec| As the CTAPHID_CANCEL command is sent during an ongoing transaction,
+                //spec| transaction semantics do not apply.
+                if (!isCancelCommand) {
+                    //spec| If an application tries to access the device from a different channel while the device
+                    //spec| is busy with a transaction, that request will immediately fail with a busy-error message
+                    //spec| sent to the requesting channel.
+                    if (hidPacket is HIDInitializationPacket) {
+                        val activeChannel = activeTransactionChannelId
+                        if (activeChannel != null && activeChannel != channelId) {
+                            sendError(channelId, HIDErrorCode.CHANNEL_BUSY, hidPacketHandler)
+                            return
+                        }
+                    }
+
+                    //spec| As long as the lock is active, any other channel trying to send a message will fail.
+                    if (lockState.isActive() && lockState.ownerChannelId != channelId) {
+                        sendError(channelId, HIDErrorCode.LOCK_REQUIRED, hidPacketHandler)
                         return
                     }
                 }
@@ -134,244 +170,27 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
         }
     }
 
-    private inner class HIDChannel(private val channelId: HIDChannelId) {
-
-        private val hidRequestMessageBuilder = HIDRequestMessageBuilder()
-
-        @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
-        private val hidKeepAliveWorker =
-            newSingleThreadContext("hid-keepalive-worker-" + HexUtil.encodeToString(channelId.value))
-
-        suspend fun handlePacket(
-            hidPacket: HIDPacket,
-            responseCallback: ResponseCallback<HIDPacket>
-        ) {
-            if (hidPacket is HIDInitializationPacket && hidRequestMessageBuilder.isTimedOut) {
-                logger.debug("Message assembly timed out, resetting builder")
-                hidRequestMessageBuilder.clear()
-            }
-
-            when (hidPacket) {
-                is HIDInitializationPacket -> {
-                    activeTransactionChannelId = channelId
-                    hidRequestMessageBuilder.initialize(hidPacket)
-                }
-                is HIDContinuationPacket -> {
-                    if (hidRequestMessageBuilder.isTimedOut) {
-                        hidRequestMessageBuilder.clear()
-                        activeTransactionChannelId = null
-                        throw HIDProtocolException(HIDErrorCode.MSG_TIMEOUT, "Message assembly timed out")
-                    }
-                    hidRequestMessageBuilder.append(hidPacket)
-                }
-                else -> throw HIDProtocolException(HIDErrorCode.OTHER, "Unknown HIDPacket subclass")
-            }
-            if (hidRequestMessageBuilder.isCompleted) {
-                val hidMessage = hidRequestMessageBuilder.build()
-                hidRequestMessageBuilder.clear()
-                try {
-                    handleMessage(hidMessage) {
-                        it.toHIDPackets().forEach { parameter ->
-                            responseCallback.onResponse(parameter)
-                        }
-                    }
-                } catch (e: HIDProtocolException) {
-                    throw e
-                } catch (e: RuntimeException) {
-                    logger.error("Unexpected exception is thrown while processing HID message", e)
-                    HIDERRORResponseMessage(hidMessage.channelId, HIDErrorCode.OTHER).toHIDPackets()
-                        .forEach { packet ->
-                            responseCallback.onResponse(packet)
-                        }
-                } finally {
-                    activeTransactionChannelId = null
-                }
-            }
-        }
-
-        suspend fun handleMessage(
-            hidMessage: HIDMessage,
-            responseCallback: ResponseCallback<HIDResponseMessage>
-        ) {
-            logger.debug(CTAP_REQUEST_HID_MESSAGE_LOGGING_TEMPLATE, hidMessage.toString())
-            when (hidMessage.command) {
-                HIDCommand.CTAPHID_MSG -> handleMsg(hidMessage as HIDMSGRequestMessage) {
-                    logger.debug(CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE, it.toString())
-                    responseCallback.onResponse(it)
-                }
-                HIDCommand.CTAPHID_CBOR -> handleCbor(hidMessage as HIDCBORRequestMessage) {
-                    logger.debug(CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE, it.toString())
-                    responseCallback.onResponse(it)
-                }
-                HIDCommand.CTAPHID_INIT -> handleInit(hidMessage as HIDINITRequestMessage) {
-                    logger.debug(CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE, it.toString())
-                    responseCallback.onResponse(it)
-                }
-                HIDCommand.CTAPHID_PING -> handlePing(hidMessage as HIDPINGRequestMessage) {
-                    logger.debug(CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE, it.toString())
-                    responseCallback.onResponse(it)
-                }
-                HIDCommand.CTAPHID_CANCEL -> handleCancel(hidMessage as HIDCANCELRequestMessage)
-                HIDCommand.CTAPHID_WINK -> handleWink(hidMessage as HIDWINKRequestMessage) {
-                    logger.debug(CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE, it.toString())
-                    responseCallback.onResponse(it)
-                }
-                HIDCommand.CTAPHID_LOCK -> handleLock(hidMessage as HIDLOCKRequestMessage) {
-                    logger.debug(CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE, it.toString())
-                    responseCallback.onResponse(it)
-                }
-                else -> throw HIDProtocolException(HIDErrorCode.INVALID_CMD, "%s is not supported".format(hidMessage.command))
-            }
-        }
-
-        private var u2fConfirmationStatus: Deferred<HIDMSGResponseMessage>? = null
-        private var activeRequest: HIDMSGRequestMessage? = null
-
-        private suspend fun handleMsg(
-            hidMessage: HIDMSGRequestMessage,
-            responseCallback: ResponseCallback<HIDResponseMessage>
-        ) {
-            coroutineScope {
-
-                val conditionNotSatisfiedMessage = HIDMSGResponseMessage(
-                    hidMessage.channelId,
-                    ResponseAPDU(
-                        U2FStatusCode.CONDITION_NOT_SATISFIED.sw1,
-                        U2FStatusCode.CONDITION_NOT_SATISFIED.sw2
-                    )
-                )
-
-                u2fConfirmationStatus.let {
-                    when {
-                        it == null || it.isCancelled -> {
-                            resetU2FConfirmationStatus(hidMessage)
-                            responseCallback.onResponse(conditionNotSatisfiedMessage)
-                        }
-                        it.isCompleted -> {
-                            if (hidMessage == activeRequest) {
-                                u2fConfirmationStatus = null
-                                activeRequest = null
-                                responseCallback.onResponse(it.await())
-                            } else {
-                                resetU2FConfirmationStatus(hidMessage)
-                                responseCallback.onResponse(conditionNotSatisfiedMessage)
-                            }
-                        }
-                        it.isActive -> {
-                            delay(KEEPALIVE_INTERVAL)
-                            responseCallback.onResponse(conditionNotSatisfiedMessage)
-                        }
-                        else -> throw IllegalStateException()
-                    }
-                }
-            }
-        }
-
-        private suspend fun resetU2FConfirmationStatus(hidMessage: HIDMSGRequestMessage) {
-            u2fConfirmationStatus = CoroutineScope(u2fConfirmationWorker).async {
-                val responseAPDU = u2fAPDUProcessor.process(hidMessage.commandAPDU)
-                HIDMSGResponseMessage(hidMessage.channelId, responseAPDU)
-            }
-            activeRequest = hidMessage
-        }
-
-        private fun handleInit(
-            hidMessage: HIDINITRequestMessage,
-            responseCallback: ResponseCallback<HIDResponseMessage>
-        ) {
-
-            val responseMessage = when (val channelId = hidMessage.channelId) {
-                HIDChannelId.BROADCAST -> {
-                    val newChannelId = allocateNewChannelId()
-                    val nonce = hidMessage.nonce
-                    HIDINITResponseMessage(
-                        channelId,
-                        nonce,
-                        newChannelId,
-                        HID_PROTOCOL_VERSION_NUMBER,
-                        MAJOR_DEVICE_VERSION_NUMBER,
-                        MINOR_DEVICE_VERSION_NUMBER,
-                        BUILD_DEVICE_VERSION_NUMBER,
-                        CAPABILITIES
-                    )
-                }
-                else -> {
-                    hidChannels.remove(channelId)
-                    val nonce = hidMessage.nonce
-                    HIDINITResponseMessage(
-                        channelId,
-                        nonce,
-                        channelId,
-                        HID_PROTOCOL_VERSION_NUMBER,
-                        MAJOR_DEVICE_VERSION_NUMBER,
-                        MINOR_DEVICE_VERSION_NUMBER,
-                        BUILD_DEVICE_VERSION_NUMBER,
-                        CAPABILITIES
-                    )
-                }
-            }
-            responseCallback.onResponse(responseMessage)
-        }
-
-        private suspend fun handleCbor(
-            hidMessage: HIDCBORRequestMessage,
-            responseCallback: ResponseCallback<HIDResponseMessage>
-        ) {
-            coroutineScope {
-                val keepAliveJob = launch(hidKeepAliveWorker) {
-                    while (true) {
-                        val keepAliveMessage = HIDKEEPALIVEResponseMessage(
-                            hidMessage.channelId,
-                            HIDStatusCode.PROCESSING
-                        ) //TODO: provide HIDStatusCode on context
-                        responseCallback.onResponse(keepAliveMessage)
-                        delay(KEEPALIVE_INTERVAL)
-                    }
-                }
-                val ctapCommand = ctapRequestConverter.convert(hidMessage.data)
-                val ctapResponse: CtapResponse = ctapAuthenticatorSession.invokeCommand(ctapCommand)
-                val cbor = ctapResponseConverter.convertToResponseDataBytes(ctapResponse)
-                val responseMessage =
-                    HIDCBORResponseMessage(hidMessage.channelId, ctapResponse.statusCode, cbor)
-                keepAliveJob.cancelAndJoin() // keepAlive must be finished before sending response packets
-                responseCallback.onResponse(responseMessage)
-            }
-        }
-
-        private fun handlePing(
-            hidMessage: HIDPINGRequestMessage,
-            responseCallback: ResponseCallback<HIDResponseMessage>
-        ) {
-            responseCallback.onResponse(
-                HIDPINGResponseMessage(
-                    hidMessage.channelId,
-                    hidMessage.data
-                )
-            )
-        }
-
-        @Suppress("UNUSED_PARAMETER")
-        private fun handleCancel(hidMessage: HIDCANCELRequestMessage) {
-            ctapAuthenticatorSession.cancelOnGoingTransaction()
-        }
-
-        private suspend fun handleWink(
-            hidMessage: HIDWINKRequestMessage,
-            responseCallback: ResponseCallback<HIDWINKResponseMessage>
-        ) {
-            ctapAuthenticatorSession.wink()
-            responseCallback.onResponse(HIDWINKResponseMessage(hidMessage.channelId))
-        }
-
-        private suspend fun handleLock(
-            hidMessage: HIDLOCKRequestMessage,
-            responseCallback: ResponseCallback<HIDLOCKResponseMessage>
-        ) {
-            val timeMillis = hidMessage.seconds.toLong() * 1000L
-            ctapAuthenticatorSession.lock(timeMillis)
-            responseCallback.onResponse(HIDLOCKResponseMessage(hidMessage.channelId))
-        }
-
+    @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+    private fun createChannel(channelId: HIDChannelId): HIDChannel {
+        val keepAliveWorker = newSingleThreadContext("hid-keepalive-worker-" + HexUtil.encodeToString(channelId.value))
+        val msgHandler = HIDMsgCommandHandler(u2fAPDUProcessor, u2fConfirmationWorker)
+        val perChannelCborHandler = HIDCborCommandHandler(
+            CtapRequestConverter(ctapAuthenticatorSession.objectConverter),
+            CtapResponseConverter(ctapAuthenticatorSession.objectConverter),
+            ctapAuthenticatorSession,
+            keepAliveWorker
+        )
+        return HIDChannel(
+            channelId = channelId,
+            activeTransactionChannelIdSetter = { activeTransactionChannelId = it },
+            initHandler = initHandler,
+            cborHandler = perChannelCborHandler,
+            msgHandler = msgHandler,
+            pingHandler = pingHandler,
+            cancelHandler = cancelHandler,
+            winkHandler = winkHandler,
+            lockHandler = lockHandler
+        )
     }
 
     private fun interface ResponseCallback<T> {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCancelCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCancelCommandHandler.kt
@@ -1,0 +1,18 @@
+package com.webauthn4j.ctap.authenticator.transport.hid.handler
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-cancel">8.1.9.1.5. CTAPHID_CANCEL</a>
+//spec| Cancel any outstanding requests on this CID. If there is an outstanding request that can be
+//spec| cancelled, the authenticator MUST cancel it and that cancelled request will reply with the error
+//spec| CTAP2_ERR_KEEPALIVE_CANCEL.
+//spec| Whether a request was cancelled or not, the authenticator MUST NOT reply to the CTAPHID_CANCEL
+//spec| message itself.
+class HIDCancelCommandHandler(
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession
+) {
+
+    fun handle() {
+        ctapAuthenticatorSession.cancelOnGoingTransaction()
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
@@ -1,0 +1,60 @@
+package com.webauthn4j.ctap.authenticator.transport.hid.handler
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.core.converter.CtapRequestConverter
+import com.webauthn4j.ctap.core.converter.CtapResponseConverter
+import com.webauthn4j.ctap.core.data.CtapResponse
+import com.webauthn4j.ctap.core.data.CtapStatusCode
+import com.webauthn4j.ctap.core.data.hid.HIDCBORRequestMessage
+import com.webauthn4j.ctap.core.data.hid.HIDCBORResponseMessage
+import com.webauthn4j.ctap.core.data.hid.HIDKEEPALIVEResponseMessage
+import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
+import com.webauthn4j.ctap.core.data.hid.HIDStatusCode
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-cbor">8.1.9.1.2. CTAPHID_CBOR</a>
+//spec| This command sends an encapsulated CTAP CBOR encoded message. The semantics of the data
+//spec| message is defined in the CTAP Message encoding specification. Please note that keep-alive
+//spec| messages MAY be sent from the device to the client before the response message is returned.
+class HIDCborCommandHandler(
+    private val ctapRequestConverter: CtapRequestConverter,
+    private val ctapResponseConverter: CtapResponseConverter,
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession,
+    private val keepAliveWorker: CoroutineContext
+) {
+
+    companion object {
+        //spec| This command code is sent while processing a CTAPHID_MSG. It should be sent at least
+        //spec| every 100ms and whenever the status changes.
+        private const val KEEPALIVE_INTERVAL = 100L
+    }
+
+    suspend fun handle(
+        hidMessage: HIDCBORRequestMessage,
+        responseCallback: (HIDResponseMessage) -> Unit
+    ) {
+        try {
+            coroutineScope {
+                val keepAliveJob = launch(keepAliveWorker) {
+                    while (true) {
+                        responseCallback(HIDKEEPALIVEResponseMessage(hidMessage.channelId, HIDStatusCode.PROCESSING))
+                        delay(KEEPALIVE_INTERVAL)
+                    }
+                }
+                val ctapCommand = ctapRequestConverter.convert(hidMessage.data)
+                val ctapResponse: CtapResponse = ctapAuthenticatorSession.invokeCommand(ctapCommand)
+                val cbor = ctapResponseConverter.convertToResponseDataBytes(ctapResponse)
+                val responseMessage = HIDCBORResponseMessage(hidMessage.channelId, ctapResponse.statusCode, cbor)
+                keepAliveJob.cancelAndJoin()
+                responseCallback(responseMessage)
+            }
+        } catch (_: CancellationException) {
+            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP2_ERR_KEEPALIVE_CANCEL, ByteArray(0)))
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDInitCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDInitCommandHandler.kt
@@ -1,0 +1,64 @@
+package com.webauthn4j.ctap.authenticator.transport.hid.handler
+
+import com.webauthn4j.ctap.core.data.hid.HIDCapability
+import com.webauthn4j.ctap.core.data.hid.HIDChannelId
+import com.webauthn4j.ctap.core.data.hid.HIDINITRequestMessage
+import com.webauthn4j.ctap.core.data.hid.HIDINITResponseMessage
+import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-init">8.1.9.1.3. CTAPHID_INIT</a>
+class HIDInitCommandHandler(
+    private val channelAllocator: ChannelAllocator
+) {
+
+    companion object {
+        //spec| The protocol version identifies the protocol version implemented by the device.
+        //spec| This version of the CTAPHID protocol is 2.
+        private const val HID_PROTOCOL_VERSION_NUMBER: Byte = 2
+        private const val MAJOR_DEVICE_VERSION_NUMBER: Byte = 0
+        private const val MINOR_DEVICE_VERSION_NUMBER: Byte = 1
+        private const val BUILD_DEVICE_VERSION_NUMBER: Byte = 0
+
+        //spec| CAPABILITY_WINK 0x01 If set to 1, authenticator implements CTAPHID_WINK function
+        //spec| CAPABILITY_CBOR 0x04 If set to 1, authenticator implements CTAPHID_CBOR function
+        //spec| CAPABILITY_NMSG 0x08 If set to 1, authenticator DOES NOT implement CTAPHID_MSG function
+        val CAPABILITIES =
+            HIDCapability((HIDCapability.WINK.value.toInt() or HIDCapability.CBOR.value.toInt()).toByte())
+    }
+
+    fun handle(hidMessage: HIDINITRequestMessage): HIDResponseMessage {
+        val channelId = hidMessage.channelId
+        val nonce = hidMessage.nonce
+
+        return when (channelId) {
+            //spec| If sent on the broadcast CID, it requests the device to allocate a unique 32-bit channel
+            //spec| identifier (CID) that can be used by the requesting application during its lifetime.
+            HIDChannelId.BROADCAST -> {
+                val newChannelId = channelAllocator.allocateChannel()
+                HIDINITResponseMessage(
+                    channelId, nonce, newChannelId,
+                    HID_PROTOCOL_VERSION_NUMBER, MAJOR_DEVICE_VERSION_NUMBER,
+                    MINOR_DEVICE_VERSION_NUMBER, BUILD_DEVICE_VERSION_NUMBER,
+                    CAPABILITIES
+                )
+            }
+            //spec| If sent on an allocated CID, it synchronizes a channel, discarding the current transaction,
+            //spec| buffers and state as quickly as possible. It will then be ready for a new transaction.
+            //spec| The device then responds with the CID of the channel it received the INIT on, using that channel.
+            else -> {
+                channelAllocator.resyncChannel(channelId)
+                HIDINITResponseMessage(
+                    channelId, nonce, channelId,
+                    HID_PROTOCOL_VERSION_NUMBER, MAJOR_DEVICE_VERSION_NUMBER,
+                    MINOR_DEVICE_VERSION_NUMBER, BUILD_DEVICE_VERSION_NUMBER,
+                    CAPABILITIES
+                )
+            }
+        }
+    }
+
+    interface ChannelAllocator {
+        fun allocateChannel(): HIDChannelId
+        fun resyncChannel(channelId: HIDChannelId)
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDLockCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDLockCommandHandler.kt
@@ -1,0 +1,48 @@
+package com.webauthn4j.ctap.authenticator.transport.hid.handler
+
+import com.webauthn4j.ctap.core.data.hid.HIDChannelId
+import com.webauthn4j.ctap.core.data.hid.HIDLOCKRequestMessage
+import com.webauthn4j.ctap.core.data.hid.HIDLOCKResponseMessage
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-lock">8.1.9.2.2. CTAPHID_LOCK</a>
+//spec| The lock command places an exclusive lock for one channel to communicate with the device. As
+//spec| long as the lock is active, any other channel trying to send a message will fail. In order to
+//spec| prevent a stalling or crashing application to lock the device indefinitely, a lock time up to
+//spec| 10 seconds may be set. An application requiring a longer lock has to send repeating lock
+//spec| commands to maintain the lock.
+//spec| Lock time in seconds 0..10. A value of 0 immediately releases the lock
+class HIDLockCommandHandler(
+    private val lockState: LockState
+) {
+
+    companion object {
+        private const val MAX_LOCK_SECONDS = 10
+    }
+
+    fun handle(hidMessage: HIDLOCKRequestMessage, channelId: HIDChannelId): HIDLOCKResponseMessage {
+        val seconds = hidMessage.seconds.toInt().coerceIn(0, MAX_LOCK_SECONDS)
+        if (seconds == 0) {
+            lockState.ownerChannelId = null
+        } else {
+            lockState.ownerChannelId = channelId
+            lockState.expiryTimeMs = System.currentTimeMillis() + seconds * 1000L
+        }
+        return HIDLOCKResponseMessage(hidMessage.channelId)
+    }
+
+    class LockState {
+        @Volatile
+        var ownerChannelId: HIDChannelId? = null
+        @Volatile
+        var expiryTimeMs: Long = 0
+
+        fun isActive(): Boolean {
+            if (ownerChannelId == null) return false
+            if (System.currentTimeMillis() >= expiryTimeMs) {
+                ownerChannelId = null
+                return false
+            }
+            return true
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDMsgCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDMsgCommandHandler.kt
@@ -1,0 +1,77 @@
+package com.webauthn4j.ctap.authenticator.transport.hid.handler
+
+import com.webauthn4j.ctap.authenticator.transport.nfc.apdu.U2FAPDUProcessor
+import com.webauthn4j.ctap.core.data.U2FStatusCode
+import com.webauthn4j.ctap.core.data.hid.HIDMSGRequestMessage
+import com.webauthn4j.ctap.core.data.hid.HIDMSGResponseMessage
+import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
+import com.webauthn4j.ctap.core.data.nfc.ResponseAPDU
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlin.coroutines.CoroutineContext
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-msg">8.1.9.1.1. CTAPHID_MSG</a>
+//spec| This command sends an encapsulated CTAP1/U2F message to the device. The semantics of the
+//spec| data message is defined in the U2F Raw Message Format encoding specification.
+class HIDMsgCommandHandler(
+    private val u2fAPDUProcessor: U2FAPDUProcessor,
+    private val u2fConfirmationWorker: CoroutineContext
+) {
+
+    companion object {
+        private const val KEEPALIVE_INTERVAL = 100L
+    }
+
+    private var u2fConfirmationStatus: Deferred<HIDMSGResponseMessage>? = null
+    private var activeRequest: HIDMSGRequestMessage? = null
+
+    suspend fun handle(
+        hidMessage: HIDMSGRequestMessage,
+        responseCallback: (HIDResponseMessage) -> Unit
+    ) {
+        coroutineScope {
+            val conditionNotSatisfiedMessage = HIDMSGResponseMessage(
+                hidMessage.channelId,
+                ResponseAPDU(
+                    U2FStatusCode.CONDITION_NOT_SATISFIED.sw1,
+                    U2FStatusCode.CONDITION_NOT_SATISFIED.sw2
+                )
+            )
+
+            u2fConfirmationStatus.let {
+                when {
+                    it == null || it.isCancelled -> {
+                        resetU2FConfirmationStatus(hidMessage)
+                        responseCallback(conditionNotSatisfiedMessage)
+                    }
+                    it.isCompleted -> {
+                        if (hidMessage == activeRequest) {
+                            u2fConfirmationStatus = null
+                            activeRequest = null
+                            responseCallback(it.await())
+                        } else {
+                            resetU2FConfirmationStatus(hidMessage)
+                            responseCallback(conditionNotSatisfiedMessage)
+                        }
+                    }
+                    it.isActive -> {
+                        delay(KEEPALIVE_INTERVAL)
+                        responseCallback(conditionNotSatisfiedMessage)
+                    }
+                    else -> throw IllegalStateException()
+                }
+            }
+        }
+    }
+
+    private fun resetU2FConfirmationStatus(hidMessage: HIDMSGRequestMessage) {
+        u2fConfirmationStatus = CoroutineScope(u2fConfirmationWorker).async {
+            val responseAPDU = u2fAPDUProcessor.process(hidMessage.commandAPDU)
+            HIDMSGResponseMessage(hidMessage.channelId, responseAPDU)
+        }
+        activeRequest = hidMessage
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDPingCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDPingCommandHandler.kt
@@ -1,0 +1,15 @@
+package com.webauthn4j.ctap.authenticator.transport.hid.handler
+
+import com.webauthn4j.ctap.core.data.hid.HIDPINGRequestMessage
+import com.webauthn4j.ctap.core.data.hid.HIDPINGResponseMessage
+import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-ping">8.1.9.1.4. CTAPHID_PING</a>
+//spec| Sends a transaction to the device, which immediately echoes the same data back. This command
+//spec| is defined to be a uniform function for debugging, latency and performance measurements.
+class HIDPingCommandHandler {
+
+    fun handle(hidMessage: HIDPINGRequestMessage): HIDResponseMessage {
+        return HIDPINGResponseMessage(hidMessage.channelId, hidMessage.data)
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDWinkCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDWinkCommandHandler.kt
@@ -1,0 +1,19 @@
+package com.webauthn4j.ctap.authenticator.transport.hid.handler
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.core.data.hid.HIDWINKRequestMessage
+import com.webauthn4j.ctap.core.data.hid.HIDWINKResponseMessage
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-wink">8.1.9.2.1. CTAPHID_WINK</a>
+//spec| The wink command performs a vendor-defined action that provides some visual or audible
+//spec| identification a particular authenticator. A typical implementation will do a short burst of
+//spec| flashes with a LED or something similar.
+class HIDWinkCommandHandler(
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession
+) {
+
+    suspend fun handle(hidMessage: HIDWINKRequestMessage): HIDWINKResponseMessage {
+        ctapAuthenticatorSession.wink()
+        return HIDWINKResponseMessage(hidMessage.channelId)
+    }
+}


### PR DESCRIPTION
Fix spec compliance issues:
- Fix INIT re-sync on allocated channel: replace remove-only with remove-and-recreate so the channel remains usable after re-sync (Section 8.1.5.3)
- Bypass BUSY check for CTAPHID_CANCEL since transaction semantics do not apply; ignore CANCEL on unknown/non-active CID (Section 8.1.9.1.5)
- Move LOCK logic from CtapAuthenticatorSession to HIDTransport layer with per-channel ownership tracking, max 10 seconds, ERR_LOCK_REQUIRED for non-owner channels (Section 8.1.9.2.2)

Refactor HIDTransport by extracting each command handler into its own class under handler/ package (Init, Cbor, Msg, Ping, Cancel, Wink, Lock). HIDChannel promoted to top-level class for packet assembly and command routing. Add spec text as //spec| comments.