### PR TITLE
Fix MakeCredential spec compliance issues

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -293,7 +293,7 @@ internal class MakeCredentialExecution :
                 if (it.isEmpty()) {
                     requestUserConsent()
                     if (ctapAuthenticatorSession.clientPINService.isClientPINReady) {
-                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
                     } else {
                         throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
                     }
@@ -353,7 +353,7 @@ internal class MakeCredentialExecution :
 
     //spec| Step9-11
     //spec| Generate a new credential key pair for the algorithm specified.
-    //spec| If "rk" in authenticatorOptions parameter is set to true:
+    //spec| If "rk" in options parameter is set to true:
     //spec| - If a credential for the same RP ID and account ID already exists on the authenticator, overwrite that credential.
     //spec| - Store the user parameter along the newly-created key pair.
     //spec| - If authenticator does not have enough internal storage to persist the new credential, return CTAP2_ERR_KEY_STORE_FULL.
@@ -391,6 +391,7 @@ internal class MakeCredentialExecution :
             )
             if (userCredential is ResidentUserCredential) {
                 try {
+                    removeExistingCredentialForSameAccount(userCredential)
                     authenticatorPropertyStore.saveUserCredential(userCredential)
                 } catch (e: StoreFullException) {
                     throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_KEY_STORE_FULL)
@@ -434,6 +435,13 @@ internal class MakeCredentialExecution :
         userCredentialBuilder.userCredentialKey(credentialKey)
         userCredentialBuilder.createdAt(Instant.now())
         return userCredentialBuilder.build()
+    }
+
+    private fun removeExistingCredentialForSameAccount(newCredential: ResidentUserCredential) {
+        val existingCredentials = authenticatorPropertyStore.loadUserCredentials(newCredential.rpId)
+        existingCredentials
+            .filter { Arrays.equals(it.userHandle, newCredential.userHandle) }
+            .forEach { authenticatorPropertyStore.removeUserCredential(it.credentialId) }
     }
 
     private fun removeInCompleteUserCredential(userCredential: ResidentUserCredential?) {

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
@@ -44,8 +44,8 @@ class GetNextAssertionExecutionTest {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         val connection = ctapAuthenticator.createSession()
-        makeCredential(connection)
-        makeCredential(connection)
+        makeCredential(connection, userId = byteArrayOf(0x01))
+        makeCredential(connection, userId = byteArrayOf(0x02))
 
         val clientDataHash = ByteArray(0)
         val allowList: List<PublicKeyCredentialDescriptor> = emptyList()
@@ -85,8 +85,8 @@ class GetNextAssertionExecutionTest {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         val connection = ctapAuthenticator.createSession()
-        makeCredential(connection)
-        makeCredential(connection)
+        makeCredential(connection, userId = byteArrayOf(0x01))
+        makeCredential(connection, userId = byteArrayOf(0x02))
 
         val clientDataHash = ByteArray(0)
         val allowList: List<PublicKeyCredentialDescriptor> = emptyList()
@@ -117,8 +117,8 @@ class GetNextAssertionExecutionTest {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         val connection = ctapAuthenticator.createSession()
-        makeCredential(connection)
-        makeCredential(connection)
+        makeCredential(connection, userId = byteArrayOf(0x01))
+        makeCredential(connection, userId = byteArrayOf(0x02))
 
         val instant = Instant.parse("2020-01-01T00:00:00Z")
         val expiredInstant = Instant.parse("2020-01-01T00:00:30Z")
@@ -161,11 +161,12 @@ class GetNextAssertionExecutionTest {
     suspend fun makeCredential(
         ctapAuthenticatorSession: CtapAuthenticatorSession,
         rk: Boolean = true,
-        uv: Boolean = true
+        uv: Boolean = true,
+        userId: ByteArray = byteArrayOf(0x01, 0x23)
     ) {
         val clientDataHash = ByteArray(0)
         val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val user = CtapPublicKeyCredentialUserEntity(userId, "John.doe", "John Doe", "icon")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/CredentialSelectorSettingTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/CredentialSelectorSettingTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 @Suppress("EXPERIMENTAL_API_USAGE", "ClassName")
 class CredentialSelectorSettingTest {
     private val passwordlessTestCase = PasswordlessTestCase()
+    private val secondUserId = byteArrayOf(0x02)
 
     @Nested
     inner class credentialSelector_authenticator {
@@ -34,7 +35,7 @@ class CredentialSelectorSettingTest {
             }
             passwordlessTestCase.step1_createCredential() // create a credential (1st)
             publicKeyCredential =
-                passwordlessTestCase.step1_createCredential() // create a credential (2nd)
+                passwordlessTestCase.step1_createCredential(userId = secondUserId) // create a credential (2nd)
             passwordlessTestCase.step2_validateCredentialForRegistration()
             passwordlessTestCase.step3_getCredential()
             passwordlessTestCase.step4_validateCredentialForAuthentication()
@@ -55,7 +56,7 @@ class CredentialSelectorSettingTest {
             }
             publicKeyCredential =
                 passwordlessTestCase.step1_createCredential() // create a credential (1st)
-            passwordlessTestCase.step1_createCredential() // create a credential (2nd)
+            passwordlessTestCase.step1_createCredential(userId = secondUserId) // create a credential (2nd)
             passwordlessTestCase.step2_validateCredentialForRegistration()
             passwordlessTestCase.step3_getCredential()
             Assertions.assertThatThrownBy {
@@ -82,7 +83,7 @@ class CredentialSelectorSettingTest {
 
             passwordlessTestCase.step1_createCredential() // create a credential (1st)
             publicKeyCredential =
-                passwordlessTestCase.step1_createCredential() // create a credential (2nd)
+                passwordlessTestCase.step1_createCredential(userId = secondUserId) // create a credential (2nd)
             passwordlessTestCase.step2_validateCredentialForRegistration()
             passwordlessTestCase.step3_getCredential()
             passwordlessTestCase.step4_validateCredentialForAuthentication()
@@ -100,7 +101,7 @@ class CredentialSelectorSettingTest {
 
             publicKeyCredential =
                 passwordlessTestCase.step1_createCredential() // create a credential (1st)
-            passwordlessTestCase.step1_createCredential() // create a credential (2nd)
+            passwordlessTestCase.step1_createCredential(userId = secondUserId) // create a credential (2nd)
             passwordlessTestCase.step2_validateCredentialForRegistration()
             passwordlessTestCase.step3_getCredential()
             Assertions.assertThatThrownBy {

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/PasswordlessTestCase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/PasswordlessTestCase.kt
@@ -70,7 +70,10 @@ class PasswordlessTestCase : IntegrationTestCaseBase() {
         step4_validateCredentialForAuthentication()
     }
 
-    suspend fun step1_createCredential(): PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> {
+    suspend fun step1_createCredential(userId: ByteArray? = null): PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput> {
+        if (userId != null) {
+            relyingParty.registration.frontend.userId = userId
+        }
         step1Result = clientPlatform.webAuthnAPIClient.create(
             relyingParty.registration.frontend.publicKeyCredentialCreationOptions,
             relyingParty.registration.frontend.publicKeyCredentialCreationContext


### PR DESCRIPTION
- Fix zero-length pinAuth error code: return CTAP2_ERR_PIN_INVALID (not PIN_AUTH_INVALID) when PIN is set, matching spec Section 5.5.8.1
- Overwrite existing resident credential with same RP ID and account ID before saving new one, as required by spec Section 5.1 Step 10
- Fix spec comment: "authenticatorOptions" -> "options" to match actual spec text
- Update tests to use distinct user IDs when creating multiple credentials for the same RP