### PR TITLE
Add spec text comments to GetInfoExecution

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -17,9 +17,10 @@ import com.webauthn4j.ctap.core.data.options.UserPresenceOption
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
 import org.slf4j.LoggerFactory
 
-/**
- * GetInfo command execution
- */
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorGetInfo">5.4. authenticatorGetInfo</a>
+//spec| Using this method, the host can request that the authenticator report a list of all supported
+//spec| protocol versions, supported extensions, AAGUID of the device, and its capabilities.
+//spec| This method takes no inputs.
 internal class GetInfoExecution(
     private val ctapAuthenticatorSession: CtapAuthenticatorSession,
     authenticatorGetInfoRequest: AuthenticatorGetInfoRequest
@@ -36,14 +37,26 @@ internal class GetInfoExecution(
     }
 
     override suspend fun doExecute(): AuthenticatorGetInfoResponse {
+        //spec| plat: platform device: Indicates that the device is attached to the client and therefore
+        //spec| can't be removed and used on another client.
         val plat: PlatformOption = when (ctapAuthenticatorSession.platform) {
             AttachmentSetting.CROSS_PLATFORM -> PlatformOption.CROSS_PLATFORM
             AttachmentSetting.PLATFORM -> PlatformOption.PLATFORM
         }
+        //spec| rk: resident key: Indicates that the device is capable of storing keys on the device
+        //spec| itself and therefore can satisfy the authenticatorGetAssertion request with allowList
+        //spec| parameter not specified or empty.
         val rk: ResidentKeyOption = when (ctapAuthenticatorSession.residentKey) {
             ResidentKeySetting.ALWAYS, ResidentKeySetting.IF_REQUIRED -> ResidentKeyOption.SUPPORTED
             ResidentKeySetting.NEVER -> ResidentKeyOption.NOT_SUPPORTED
         }
+        //spec| clientPin: Client PIN:
+        //spec| If present and set to true, it indicates that the device is capable of accepting a PIN
+        //spec| from the client and PIN has been set.
+        //spec| If present and set to false, it indicates that the device is capable of accepting a PIN
+        //spec| from the client and PIN has not been set yet.
+        //spec| If absent, it indicates that the device is not capable of accepting a PIN from the client.
+        //spec| Client PIN is one of the ways to do user verification.
         val clientPin: ClientPINOption? = when (ctapAuthenticatorSession.clientPIN) {
             ClientPINSetting.ENABLED -> when {
                 ctapAuthenticatorSession.clientPINService.isClientPINReady -> ClientPINOption.SET
@@ -51,21 +64,31 @@ internal class GetInfoExecution(
             }
             ClientPINSetting.DISABLED -> ClientPINOption.NOT_SUPPORTED
         }
+        //spec| up: user presence: Indicates that the device is capable of testing user presence.
         val up: UserPresenceOption = when (ctapAuthenticatorSession.userPresence) {
             UserPresenceSetting.SUPPORTED -> UserPresenceOption.SUPPORTED
             UserPresenceSetting.NOT_SUPPORTED -> UserPresenceOption.NOT_SUPPORTED
         }
+        //spec| uv: user verification: Indicates that the device is capable of verifying the user within
+        //spec| itself. For example, devices with UI, biometrics fall into this category.
+        //spec| If present and set to true, it indicates that the device is capable of user verification
+        //spec| within itself and has been configured.
+        //spec| If present and set to false, it indicates that the device is capable of user verification
+        //spec| within itself and has not been yet configured. For example, a biometric device that has
+        //spec| not yet been configured will return this parameter set to false.
+        //spec| If absent, it indicates that the device is not capable of user verification within itself.
+        //spec| A device that can only do Client PIN will not return the "uv" parameter.
         val uv: UserVerificationOption? = ctapAuthenticatorSession.userVerificationHandler.getUserVerificationOption(null)
         val extensions = ctapAuthenticatorSession.extensionProcessors.map { it.extensionId }
         return AuthenticatorGetInfoResponse(
             CtapStatusCode.CTAP2_OK,
             AuthenticatorGetInfoResponseData(
-                CtapAuthenticator.VERSIONS,
-                extensions,
-                ctapAuthenticatorSession.aaguid,
-                AuthenticatorGetInfoResponseData.Options(plat, rk, clientPin, up, uv),
-                2048u,
-                CtapAuthenticator.PIN_PROTOCOLS,
+                CtapAuthenticator.VERSIONS,       // versions (0x01): Required
+                extensions,                        // extensions (0x02): Optional
+                ctapAuthenticatorSession.aaguid,   // aaguid (0x03): Required
+                AuthenticatorGetInfoResponseData.Options(plat, rk, clientPin, up, uv), // options (0x04): Optional
+                2048u,                             // maxMsgSize (0x05): Optional
+                CtapAuthenticator.PIN_PROTOCOLS,   // pinProtocols (0x06): Optional
                 null,
                 null,
                 ctapAuthenticatorSession.transports


### PR DESCRIPTION
Add //spec| comments with exact CTAP 2.0 Section 5.4 text for each option (plat, rk, clientPin, up, uv) and the class-level description. Add @see link to the spec section URL.