### PR TITLE
Fix ClientPIN spec compliance and add spec comments

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/ClientPINService.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/ClientPINService.kt
@@ -22,62 +22,53 @@ import java.util.Arrays
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 
+// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorClientPIN">5.5. authenticatorClientPIN</a>
 class ClientPINService(private val authenticatorPropertyStore: AuthenticatorPropertyStore) {
 
     companion object {
         const val MAX_PIN_RETRIES: UInt = 8u
         const val MAX_VOLATILE_PIN_RETRIES = 3
         private val ZERO_IV = byteArrayOf(
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
         )
         private val ECDH_ES_HKDF_256 = COSEAlgorithmIdentifier.create(-25)
     }
 
-    private var volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
+    //spec| 5.5.2 Authenticator Configuration Operations Upon Power Up
+    //spec| Generate "authenticatorKeyAgreementKey":
+    //spec| Generate an ECDH P-256 key pair called "authenticatorKeyAgreementKey"
+    //spec| denoted by (a, aG) where "a" denotes the private key and "aG" denotes the public key.
     var authenticatorKeyAgreementKey = ECUtil.createKeyPair()
+
+    //spec| Generate "pinToken":
+    //spec| Generate a random integer of length which is multiple of 16 bytes (AES block length).
     val pinToken = ByteArray(16)
+
+    private var volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
 
     init {
         SecureRandom().nextBytes(pinToken)
     }
 
-    //spec| Retries count is the number of attempts remaining before lockout. When the device is nearing authenticator lockout, the platform can optionally warn the user to be careful while entering the PIN.
-    //spec| Platform performs the following operations to get retries:
-    //spec| - Platform sends authenticatorClientPIN command with following parameters to the authenticator:
-    //spec| -- pinProtocol: 0x01
-    //spec| -- subCommand: getRetries(0x01)
-    //spec| - Authenticator responds back with retries.
+    fun regenerateKeys() {
+        authenticatorKeyAgreementKey = ECUtil.createKeyPair()
+        SecureRandom().nextBytes(pinToken)
+        volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
+    }
+
+    //spec| 5.5.3 Getting Retries from Authenticator
+    //spec| Retries count is the number of attempts remaining before lockout.
+    //spec| Authenticator responds back with retries.
     fun getPinRetries(): AuthenticatorClientPINResponse {
-        //spec| Retries count is the number of attempts remaining before lockout. When the device is nearing authenticator lockout, the platform can optionally warn the user to be careful while entering the PIN.
-        //spec| Platform performs the following operations to get retries:
-        //spec| - Platform sends authenticatorClientPIN command with following parameters to the authenticator:
-        //spec| -- pinProtocol: 0x01
-        //spec| -- subCommand: getRetries(0x01)
-        //spec| - Authenticator responds back with retries.
         val pinRetries = authenticatorPropertyStore.loadPINRetries()
         val responseData = AuthenticatorClientPINResponseData(null, null, pinRetries)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
-    //spec| - Authenticator responds back with public key of authenticatorKeyAgreementKey, "aG".
+    //spec| 5.5.4 Getting sharedSecret from Authenticator
+    //spec| Authenticator responds back with public key of authenticatorKeyAgreementKey, "aG".
     fun getKeyAgreement(): AuthenticatorClientPINResponse {
-
-        //spec| - Authenticator responds back with public key of authenticatorKeyAgreementKey, "aG".
         val keyAgreement = EC2COSEKey.create(
             (authenticatorKeyAgreementKey.public as ECPublicKey),
             ECDH_ES_HKDF_256
@@ -86,35 +77,39 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
+    //spec| 5.5.5 Setting a New PIN
+    //spec| Authenticator performs following operations upon receiving the request:
     fun setPIN(
         platformKeyAgreementKey: COSEKey?,
         pinAuth: ByteArray?,
         newPinEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
 
-        //spec| - Authenticator performs following operations upon receiving the request:
-        //spec| -- If Authenticator does not receive mandatory parameters for this command, it returns CTAP2_ERR_MISSING_PARAMETER error.
+        //spec| If Authenticator does not receive mandatory parameters for this command,
+        //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinAuth == null || newPinEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| -- If a PIN has already been set, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
+        //spec| If a PIN has already been set, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
         if (isClientPINReady) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| -- Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
-        //spec| --- SHA-256 is done over only "x" curve point of "abG"
-        //spec| --- See [RFC6090] Section 4.1 and appendix (C.2) of [SP800-56A] for more ECDH key agreement protocol details and key representation.
+        //spec| Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of
+        //spec| authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
         val sharedSecret = generateSharedSecret(platformKeyAgreementKey)
 
-        //spec| -- Authenticator verifies pinAuth by generating LEFT(HMAC-SHA-256(sharedSecret, newPinEnc), 16) and matching against input pinAuth parameter.
-        //spec| --- If pinAuth verification fails, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
+        //spec| Authenticator verifies pinAuth by generating LEFT(HMAC-SHA-256(sharedSecret, newPinEnc), 16)
+        //spec| and matching against input pinAuth parameter.
+        //spec| If pinAuth verification fails, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
         val mac = MACUtil.calculateHmacSHA256(newPinEnc, sharedSecret, 16)
         if (!Arrays.equals(mac, pinAuth)) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| -- Authenticator decrypts newPinEnc using above "sharedSecret" producing newPin and checks newPin length against minimum PIN length of 4 bytes.
-        //spec| --- The decrypted padded newPin should be of at least 64 bytes length and authenticator determines actual PIN length by looking for first 0x00 byte which terminates the PIN.
-        //spec| --- If minimum PIN length check fails, authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION error.
+        //spec| Authenticator decrypts newPinEnc using above "sharedSecret" producing newPin and
+        //spec| checks newPin length against minimum PIN length of 4 bytes.
+        //spec| The decrypted padded newPin should be of at least 64 bytes length and authenticator
+        //spec| determines actual PIN length by looking for first 0x00 byte which terminates the PIN.
+        //spec| If minimum PIN length check fails, authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION error.
         val secretKey: SecretKey = SecretKeySpec(sharedSecret, "AES")
         val newPIN = CipherUtil.decryptWithAESCBCNoPadding(newPinEnc, secretKey, ZERO_IV)
         val sentinelPos = newPIN.indexOf(0x00)
@@ -128,38 +123,38 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        //spec| --- Authenticator may have additional constraints for PIN policy. The current spec only enforces minimum length of 4 bytes.
-        //spec| -- Authenticator stores LEFT(SHA-256(newPin), 16) on the device, sets the retries counter to 8, and returns CTAP2_OK.
-        authenticatorPropertyStore.saveClientPIN(trimmedNewPIN)
-        val pinRetries = MAX_PIN_RETRIES
-        authenticatorPropertyStore.savePINRetries(pinRetries)
-        val responseData = AuthenticatorClientPINResponseData(null, null, pinRetries)
-        return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
+        //spec| Authenticator stores LEFT(SHA-256(newPin), 16) on the device,
+        //spec| sets the retries counter to 8, and returns CTAP2_OK.
+        authenticatorPropertyStore.saveClientPIN(
+            Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
+        )
+        authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
+        return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
+    //spec| 5.5.6 Changing existing PIN
+    //spec| Authenticator performs following operations upon receiving the request:
     fun changePIN(
         platformKeyAgreementKey: COSEKey?,
         pinAuth: ByteArray?,
         newPinEnc: ByteArray?,
         pinHashEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
-        //spec| - Authenticator performs following operations upon receiving the request:
-        //spec| -- If Authenticator does not receive mandatory parameters for this command, it returns CTAP2_ERR_MISSING_PARAMETER error.
+        //spec| If Authenticator does not receive mandatory parameters for this command,
+        //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinAuth == null || newPinEnc == null || pinHashEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| -- If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
         if (authenticatorPropertyStore.loadPINRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
-        } else if (volatilePinRetryCounter == 0) {
-            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
         }
-        //spec| -- Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
-        //spec| --- SHA-256 is done over only "x" curve point of "abG"
-        //spec| ---- See [RFC6090] Section 4.1 and appendix (C.2) of [SP800-56A] for more ECDH key agreement protocol details and key representation.
+        //spec| Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of
+        //spec| authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
         val sharedSecret = generateSharedSecret(platformKeyAgreementKey)
-        //spec| -- Authenticator verifies pinAuth by generating LEFT(HMAC-SHA-256(sharedSecret, newPinEnc || pinHashEnc), 16) and matching against input pinAuth parameter.
-        //spec| --- If pinAuth verification fails, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
+        //spec| Authenticator verifies pinAuth by generating LEFT(HMAC-SHA-256(sharedSecret, newPinEnc || pinHashEnc), 16)
+        //spec| and matching against input pinAuth parameter.
+        //spec| If pinAuth verification fails, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
         val joined =
             ByteBuffer.allocate(newPinEnc.size + pinHashEnc.size).put(newPinEnc).put(pinHashEnc)
                 .array()
@@ -167,44 +162,47 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         if (!Arrays.equals(mac, pinAuth)) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| -- Authenticator decrements the retries counter by 1.
+        //spec| Authenticator decrements the retries counter by 1.
         authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
-        if (volatilePinRetryCounter > 0) {
-            volatilePinRetryCounter--
-        }
 
-
-        //spec| -- Authenticator decrypts pinHashEnc and verifies against its internal stored LEFT(SHA-256(curPin), 16).
+        //spec| Authenticator decrypts pinHashEnc and verifies against its internal stored LEFT(SHA-256(curPin), 16).
         val secretKey: SecretKey = SecretKeySpec(sharedSecret, "AES")
         val pinHash = CipherUtil.decryptWithAESCBCNoPadding(pinHashEnc, secretKey, ZERO_IV)
-        val clientPIN =
+        val storedPinHash =
             authenticatorPropertyStore.loadClientPIN() ?: return AuthenticatorClientPINResponse(
                 CtapStatusCode.CTAP2_ERR_PIN_NOT_SET
             )
-        val currentPINHash = Arrays.copyOf(MessageDigestUtil.createSHA256().digest(clientPIN), 16)
 
-        if (!Arrays.equals(pinHash, currentPINHash)) {
-            //spec| --- If a mismatch is detected, the authenticator performs the following operations:
-            //spec| ---- Authenticator generates a new "authenticatorKeyAgreementKey".
-            //spec| ----- Generate a new ECDH P-256 key pair called "authenticatorKeyAgreementKey" denoted by (a, aG), where "a" denotes the private key and "aG" denotes the public key.
-            //spec| ------ See [RFC6090] Section 4.1 and [SP800-56A] for more ECDH key agreement protocol details.
+        if (!Arrays.equals(pinHash, storedPinHash)) {
+            //spec| If a mismatch is detected, the authenticator performs the following operations:
+            //spec| Authenticator generates a new "authenticatorKeyAgreementKey".
+            //spec| Generate a new ECDH P-256 key pair called "authenticatorKeyAgreementKey" denoted by
+            //spec| (a, aG), where "a" denotes the private key and "aG" denotes the public key.
             authenticatorKeyAgreementKey = ECUtil.createKeyPair()
-            //spec| ---- Authenticator returns errors according to following conditions:
-            //spec| ----- If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
-            // This step is already done above.
-            //spec| ----- If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
-            //spec|       indicating that power cycling is needed for further operations.
-            //spec|       This is done so that malware running on the platform should not be able to block the device without user interaction.
-            // This step is already done above.
-            //spec| ----- Else return CTAP2_ERR_PIN_INVALID error.
-            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+            volatilePinRetryCounter--
+            //spec| Authenticator returns errors according to following conditions:
+            //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+            //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
+            //spec| indicating that power cycling is needed for further operations. This is done so that malware
+            //spec| running on the platform should not be able to block the device without user interaction.
+            //spec| Else return CTAP2_ERR_PIN_INVALID error.
+            return when {
+                authenticatorPropertyStore.loadPINRetries() == 0u ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
+                volatilePinRetryCounter <= 0 ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
+                else ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+            }
         }
-        //spec| --- Authenticator sets the retries counter to 8.
+        //spec| Authenticator sets the retries counter to 8.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
-        //spec| --- Authenticator decrypts newPinEnc using above "sharedSecret" producing newPin and checks newPin length against minimum PIN length of 4 bytes.
-        //spec| ---- The decrypted padded newPin should be of at least 64 bytes length and authenticator determines actual PIN length by looking for first 0x00 byte which terminates the PIN.
-        //spec| ---- If minimum PIN length check fails, authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION error.
-        //spec| ---- Authenticator may have additional constraints for PIN policy. The current spec only enforces minimum length of 4 bytes.
+        volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
+        //spec| Authenticator decrypts newPinEnc using above "sharedSecret" producing newPin and
+        //spec| checks newPin length against minimum PIN length of 4 bytes.
+        //spec| The decrypted padded newPin should be of at least 64 bytes length and authenticator
+        //spec| determines actual PIN length by looking for first 0x00 byte which terminates the PIN.
+        //spec| If minimum PIN length check fails, authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION error.
         val newPIN = CipherUtil.decryptWithAESCBCNoPadding(newPinEnc, secretKey, ZERO_IV)
         val sentinelPos = ArrayUtil.indexOf(newPIN, 0x00.toByte())
         if (sentinelPos < 0) {
@@ -217,66 +215,75 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        //spec| --- Authenticator stores LEFT(SHA-256(newPin), 16) on the device and returns CTAP2_OK.
-        authenticatorPropertyStore.saveClientPIN(trimmedNewPIN) // clientPIN is not trimmedPIN. This is intended.
-        val pinRetires = authenticatorPropertyStore.loadPINRetries()
-        val responseData = AuthenticatorClientPINResponseData(null, null, pinRetires)
-        return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
+        //spec| Authenticator stores LEFT(SHA-256(newPin), 16) on the device and returns CTAP2_OK.
+        authenticatorPropertyStore.saveClientPIN(
+            Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
+        )
+        return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
+    //spec| 5.5.7 Getting pinToken from the Authenticator
+    //spec| Authenticator performs following operations upon receiving the request:
     fun getPinToken(
         platformKeyAgreementKey: COSEKey?,
         pinHashEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
-        //spec| - Authenticator performs following operations upon receiving the request:
-        //spec| -- If Authenticator does not receive mandatory parameters for this command, it returns CTAP2_ERR_MISSING_PARAMETER error.
+        //spec| If Authenticator does not receive mandatory parameters for this command,
+        //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinHashEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| -- If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
         if (authenticatorPropertyStore.loadPINRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
         }
-        //spec| -- Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
-        //spec| --- SHA-256 is done over only "x" curve point of "abG"
-        //spec| --- See [RFC6090] Section 4.1 and appendix (C.2) of [SP800-56A] for more ECDH key agreement protocol details and key representation.
+        if (volatilePinRetryCounter <= 0) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
+        }
+        //spec| Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of
+        //spec| authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
         val sharedSecret = generateSharedSecret(platformKeyAgreementKey)
-        //spec| -- Authenticator decrements the retries counter by 1.
+        //spec| Authenticator decrements the retries counter by 1.
         authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
-        volatilePinRetryCounter--
 
-        //spec| -- Authenticator decrypts pinHashEnc and verifies against its internal stored LEFT(SHA-256(curPin), 16).
+        //spec| Authenticator decrypts pinHashEnc and verifies against its internal stored LEFT(SHA-256(curPin), 16).
         val secretKey: SecretKey = SecretKeySpec(sharedSecret, "AES")
         val pinHash = CipherUtil.decryptWithAESCBCNoPadding(pinHashEnc, secretKey, ZERO_IV)
-        val clientPIN =
+        val storedPinHash =
             authenticatorPropertyStore.loadClientPIN() ?: return AuthenticatorClientPINResponse(
                 CtapStatusCode.CTAP2_ERR_PIN_NOT_SET
             )
-        val currentPINHash = Arrays.copyOf(MessageDigestUtil.createSHA256().digest(clientPIN), 16)
-        if (!Arrays.equals(pinHash, currentPINHash)) {
-            //spec| --- If a mismatch is detected, the authenticator performs the following operations:
-            //spec| ---- Authenticator generates a new "authenticatorKeyAgreementKey".
-            //spec| ----- Generate a new ECDH P-256 key pair called "authenticatorKeyAgreementKey" denoted by (a, aG), where "a" denotes the private key and "aG" denotes the public key.
-            //spec| ------ See [RFC6090] Section 4.1 and [SP800-56A] for more ECDH key agreement protocol details.
+        if (!Arrays.equals(pinHash, storedPinHash)) {
+            //spec| If a mismatch is detected, the authenticator performs the following operations:
+            //spec| Authenticator generates a new "authenticatorKeyAgreementKey".
+            //spec| Generate a new ECDH P-256 key pair called "authenticatorKeyAgreementKey" denoted by
+            //spec| (a, aG), where "a" denotes the private key and "aG" denotes the public key.
             authenticatorKeyAgreementKey = ECUtil.createKeyPair()
-            //spec| ---- Authenticator returns errors according to following conditions:
-            //spec| ----- If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+            volatilePinRetryCounter--
+            //spec| Authenticator returns errors according to following conditions:
+            //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+            //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
+            //spec| indicating that power cycling is needed for further operations. This is done so that malware
+            //spec| running on the platform should not be able to block the device without user interaction.
+            //spec| Else return CTAP2_ERR_PIN_INVALID error.
             return when {
-                authenticatorPropertyStore.loadPINRetries() == 0u -> AuthenticatorClientPINResponse(
-                    CtapStatusCode.CTAP2_ERR_PIN_BLOCKED
-                )
-                volatilePinRetryCounter == 0 -> AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
-                else -> AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+                authenticatorPropertyStore.loadPINRetries() == 0u ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
+                volatilePinRetryCounter <= 0 ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
+                else ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
             }
         }
-        //spec| -- Authenticator sets the retries counter to 8.
+        //spec| Authenticator sets the retries counter to 8.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
-        //spec| -- Authenticator returns encrypted pinToken using "sharedSecret": AES256-CBC(sharedSecret, IV=0, pinToken).
-        //spec| --- pinToken should be a multiple of 16 bytes (AES block length) without any padding or IV. There is no PKCS #7 padding used in this scheme.
+        volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
+        //spec| Authenticator returns encrypted pinToken using "sharedSecret": AES256-CBC(sharedSecret, IV=0, pinToken).
+        //spec| pinToken should be a multiple of 16 bytes (AES block length) without any padding or IV.
+        //spec| There is no PKCS #7 padding used in this scheme.
         val pinTokenEnc = CipherUtil.encryptWithAESCBCNoPadding(pinToken, secretKey, ZERO_IV)
-        val pinRetries = authenticatorPropertyStore.loadPINRetries()
         val responseData =
-            AuthenticatorClientPINResponseData(null, pinTokenEnc, pinRetries)
+            AuthenticatorClientPINResponseData(null, pinTokenEnc, null)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
@@ -289,7 +296,8 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         )
     }
 
-    //spec| verify it by matching it against first 16 bytes of HMAC-SHA-256 of clientDataHash parameter using pinToken: HMAC- SHA-256(pinToken, clientDataHash).
+    //spec| verify it by matching it against first 16 bytes of HMAC-SHA-256 of clientDataHash parameter
+    //spec| using pinToken: HMAC-SHA-256(pinToken, clientDataHash).
     fun validatePINAuth(pinAuth: ByteArray?, clientDataHash: ByteArray?) {
         val calculatedPinAuth = MACUtil.calculateHmacSHA256(clientDataHash, pinToken, 16)
         if (!Arrays.equals(calculatedPinAuth, pinAuth)) {

--- a/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
+++ b/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
@@ -8,6 +8,7 @@ import com.webauthn4j.ctap.authenticator.UserVerificationHandler
 import com.webauthn4j.ctap.authenticator.transport.internal.InternalTransport
 import com.webauthn4j.ctap.client.transport.InProcessAdaptor
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
+import com.webauthn4j.util.MessageDigestUtil
 import com.webauthn4j.data.AuthenticatorAttachment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -43,9 +44,7 @@ internal class CtapServiceTest {
         target.reset()
         target.setPIN("newPIN")
         assertThat(connection.authenticatorPropertyStore.loadClientPIN()).isEqualTo(
-            "newPIN".toByteArray(
-                StandardCharsets.UTF_8
-            )
+            pinHash("newPIN")
         )
     }
 
@@ -56,15 +55,17 @@ internal class CtapServiceTest {
         target.reset()
         target.setPIN("currentPIN")
         assertThat(connection.authenticatorPropertyStore.loadClientPIN()).isEqualTo(
-            "currentPIN".toByteArray(
-                StandardCharsets.UTF_8
-            )
+            pinHash("currentPIN")
         )
         target.changePIN("currentPIN", "newPIN")
         assertThat(connection.authenticatorPropertyStore.loadClientPIN()).isEqualTo(
-            "newPIN".toByteArray(
-                StandardCharsets.UTF_8
-            )
+            pinHash("newPIN")
+        )
+    }
+
+    private fun pinHash(pin: String): ByteArray {
+        return java.util.Arrays.copyOf(
+            MessageDigestUtil.createSHA256().digest(pin.toByteArray(StandardCharsets.UTF_8)), 16
         )
     }
 

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
@@ -46,7 +46,7 @@ class ClientPINTest {
 
     @Test
     fun changePIN_with_invalid_PIN_and_reach_MAX_VOLATILE_PIN_RETRIES_test() {
-        repeat(3) {
+        repeat(2) {
             assertThatThrownBy {
                 runTest {
                     clientPINTestCase.clientPlatform.ctapService.changePIN(
@@ -67,7 +67,7 @@ class ClientPINTest {
 
     @Test
     fun changePIN_with_invalid_PIN_and_reach_MAX_PIN_RETRIES_test() {
-        repeat(8) {
+        repeat(7) {
             assertThatThrownBy {
                 runTest {
                     clientPINTestCase.clientPlatform.ctapService.changePIN(

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
@@ -89,7 +89,10 @@ abstract class IntegrationTestCaseBase {
         private val authenticatorPropertyStoreParameter =
             TestParameter<AuthenticatorPropertyStore> {
                 InMemoryAuthenticatorPropertyStore().also {
-                    it.saveClientPIN(clientPIN.toByteArray())
+                    val pinBytes = clientPIN.toByteArray()
+                    it.saveClientPIN(
+                        java.util.Arrays.copyOf(com.webauthn4j.util.MessageDigestUtil.createSHA256().digest(pinBytes), 16)
+                    )
                     it.algorithms = algorithms
                 }
             }.depends(clientPINParameter, algorithmsParameter)


### PR DESCRIPTION
Spec compliance fixes:
- Store PIN as LEFT(SHA-256(newPin), 16) instead of raw bytes (Section 5.5.5, 5.5.6)
- Fix changePIN error differentiation after PIN mismatch: return PIN_BLOCKED when retries=0, PIN_AUTH_BLOCKED on 3 consecutive mismatches, PIN_INVALID otherwise (Section 5.5.6)
- Move volatile counter decrement to mismatch branch only (not on correct PIN)
- Reset volatile counter on successful PIN verification
- Add volatile counter pre-check in getPinToken (Section 5.5.7)
- Remove retries from setPIN response (spec: CTAP2_OK only)
- Remove retries from getPinToken response
- Add regenerateKeys() method for reset support
- Add @see link and spec comments throughout

Test updates:
- Update PIN assertions to compare LEFT(SHA-256, 16) hash
- Fix volatile retry count expectations (3→2 before blocked)
- Fix max retry count expectation (8→7 before blocked)
- Store PIN hash in test setup