### PR TITLE
Disable implicit type coercion in CBOR deserialization

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -70,6 +70,24 @@ class CtapAuthenticator(
                 .addModule(CtapCBORModule())
                 .addModule(PublicKeyCredentialSourceCBORModule())
                 .addModule(KotlinModule.Builder().build())
+                .withCoercionConfigDefaults { config ->
+                    config.setCoercion(
+                        tools.jackson.databind.cfg.CoercionInputShape.Integer,
+                        tools.jackson.databind.cfg.CoercionAction.Fail
+                    )
+                    config.setCoercion(
+                        tools.jackson.databind.cfg.CoercionInputShape.Boolean,
+                        tools.jackson.databind.cfg.CoercionAction.Fail
+                    )
+                    config.setCoercion(
+                        tools.jackson.databind.cfg.CoercionInputShape.Float,
+                        tools.jackson.databind.cfg.CoercionAction.Fail
+                    )
+                    config.setCoercion(
+                        tools.jackson.databind.cfg.CoercionInputShape.Array,
+                        tools.jackson.databind.cfg.CoercionAction.Fail
+                    )
+                }
                 .build()
             return ObjectConverter(jsonMapper, cborMapper)
         }


### PR DESCRIPTION
Disable Jackson CBOR implicit type coercion (Integer, Boolean, Float, Array to incompatible types) by setting CoercionAction.Fail. This ensures malformed CTAP requests with wrong field types are rejected instead of silently coerced.