### PR TITLE
Reject up=false in MakeCredential as unsupported

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -232,8 +232,8 @@ internal class MakeCredentialExecution :
                 residentKeyPlan = ctapAuthenticatorSession.residentKey == ResidentKeySetting.ALWAYS
             }
             else -> {
-                if(requestOptions.up == true){
-                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+                if(requestOptions.up == false){
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
                 }
                 residentKeyPlan = when (requestOptions.rk) {
                     true -> when (ctapAuthenticatorSession.residentKey) {


### PR DESCRIPTION
MakeCredential always requires user presence (up defaults to true). Explicitly setting up=false is unsupported, so return CTAP2_ERR_UNSUPPORTED_OPTION. up=true is accepted as it matches the default behavior.