### PR TITLE
Implement cancelOnGoingTransaction and add isWaitingForUserPresence flag

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -18,9 +18,11 @@ import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.core.data.*
 import com.webauthn4j.data.AuthenticatorTransport
 import com.webauthn4j.data.attestation.authenticator.AAGUID
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.coroutineContext
 import org.slf4j.LoggerFactory
 
 /**
@@ -66,25 +68,36 @@ class CtapAuthenticatorSession internal constructor(
 
     var onGoingGetAssertionSession: GetAssertionSession? = null
 
+    @Volatile
+    private var onGoingJob: Job? = null
+
+    @Volatile
+    var isWaitingForUserPresence: Boolean = false
+
     suspend fun <TC : AuthenticatorRequest, TR : AuthenticatorResponse?> invokeCommand(request: TC): TR {
-        val response = when (request) {
-            is AuthenticatorMakeCredentialRequest -> makeCredential(request)
-            is AuthenticatorGetAssertionRequest -> getAssertion(request)
-            is AuthenticatorGetNextAssertionRequest -> getNextAssertion(request)
-            is AuthenticatorGetInfoRequest -> getInfo(request)
-            is AuthenticatorClientPINRequest -> clientPIN(request)
-            is AuthenticatorResetRequest -> reset(request)
-            is U2FRegistrationRequest -> u2fRegister(request)
-            is U2FAuthenticationRequest -> u2fSign(request)
-            else -> throw IllegalStateException(
-                String.format(
-                    "unknown command %s is invoked.",
-                    request::class.java.toString()
+        onGoingJob = coroutineContext[Job]
+        try {
+            val response = when (request) {
+                is AuthenticatorMakeCredentialRequest -> makeCredential(request)
+                is AuthenticatorGetAssertionRequest -> getAssertion(request)
+                is AuthenticatorGetNextAssertionRequest -> getNextAssertion(request)
+                is AuthenticatorGetInfoRequest -> getInfo(request)
+                is AuthenticatorClientPINRequest -> clientPIN(request)
+                is AuthenticatorResetRequest -> reset(request)
+                is U2FRegistrationRequest -> u2fRegister(request)
+                is U2FAuthenticationRequest -> u2fSign(request)
+                else -> throw IllegalStateException(
+                    String.format(
+                        "unknown command %s is invoked.",
+                        request::class.java.toString()
+                    )
                 )
-            )
+            }
+            @Suppress("UNCHECKED_CAST")
+            return response as TR
+        } finally {
+            onGoingJob = null
         }
-        @Suppress("UNCHECKED_CAST")
-        return response as TR
     }
 
     suspend fun makeCredential(authenticatorMakeCredentialCommand: AuthenticatorMakeCredentialRequest): AuthenticatorMakeCredentialResponse {
@@ -147,10 +160,8 @@ class CtapAuthenticatorSession internal constructor(
     }
 
     fun cancelOnGoingTransaction() {
-        TODO()
-//        mutex.withLock {
-//            transaction?.cancel()
-//        }
+        onGoingJob?.cancel()
+        onGoingGetAssertionSession = null
     }
 
     internal fun publishEvent(event: Event) {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/CtapCommandExecutionBase.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/CtapCommandExecutionBase.kt
@@ -5,6 +5,7 @@ import com.webauthn4j.ctap.core.data.CtapRequest
 import com.webauthn4j.ctap.core.data.CtapResponse
 import com.webauthn4j.ctap.core.data.CtapStatusCode
 import org.slf4j.LoggerFactory
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Base class for Ctap command execution
@@ -20,6 +21,8 @@ abstract class CtapCommandExecutionBase<TC : CtapRequest, TR : CtapResponse>(pri
 
         val ctapResponse = try {
             doExecute()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: CtapCommandExecutionException) {
             onFailure(e)
         } catch (e: RuntimeException) {


### PR DESCRIPTION
Implement cancelOnGoingTransaction() by tracking the ongoing Job and cancelling it. Add isWaitingForUserPresence volatile flag for KEEPALIVE STATUS_UPNEEDED support. Re-throw CancellationException in CtapCommandExecutionBase to prevent swallowing coroutine cancellation.