### PR TITLE
Add toString to MakeCredentialRequest.Options for debugging

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorMakeCredentialRequest.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorMakeCredentialRequest.kt
@@ -100,6 +100,10 @@ class AuthenticatorMakeCredentialRequest @JsonCreator constructor(
             result = 31 * result + (uv?.hashCode() ?: 0)
             return result
         }
+
+        override fun toString(): String {
+            return "Options(rk=$rk, up=$up, uv=$uv)"
+        }
     }
 
 }


### PR DESCRIPTION
Add toString() to AuthenticatorMakeCredentialRequest.Options so option values are visible in debug logs instead of the default Object hash.