### PR TITLE
Send KEEPALIVE STATUS_UPNEEDED while waiting for user presence

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -73,6 +73,16 @@ class CtapAuthenticatorSession internal constructor(
 
     @Volatile
     var isWaitingForUserPresence: Boolean = false
+        private set
+
+    suspend fun <T> withUserPresenceWait(block: suspend () -> T): T {
+        isWaitingForUserPresence = true
+        try {
+            return block()
+        } finally {
+            isWaitingForUserPresence = false
+        }
+    }
 
     suspend fun <TC : AuthenticatorRequest, TR : AuthenticatorResponse?> invokeCommand(request: TC): TR {
         onGoingJob = coroutineContext[Job]

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -332,7 +332,9 @@ internal class GetAssertionExecution :
         //spec| - If the "up" option was specified and set to true, collect the user’s consent.
         //spec|   - If no consent is obtained and a timeout occurs, return the CTAP2_ERR_OPERATION_DENIED error.
         val options = GetAssertionConsentRequest(rpId, userPresencePlan, userVerificationPlan)
-        val consent = ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(options)
+        val consent = ctapAuthenticatorSession.withUserPresenceWait {
+            ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(options)
+        }
         if (consent) {
             if (userVerificationPlan) {
                 userVerificationResult = true

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -184,9 +184,11 @@ internal class MakeCredentialExecution :
                         isUserPresence = true,
                         isUserVerification = false
                     )
-                    ctapAuthenticatorSession.userVerificationHandler.onMakeCredentialConsentRequested(
-                        makeCredentialConsentRequest
-                    )
+                    ctapAuthenticatorSession.withUserPresenceWait {
+                        ctapAuthenticatorSession.userVerificationHandler.onMakeCredentialConsentRequested(
+                            makeCredentialConsentRequest
+                        )
+                    }
                     throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_CREDENTIAL_EXCLUDED)
                 }
             }
@@ -348,7 +350,9 @@ internal class MakeCredentialExecution :
             userPresencePlan,
             userVerificationPlan
         )
-        return ctapAuthenticatorSession.userVerificationHandler.onMakeCredentialConsentRequested(makeCredentialConsentRequest)
+        return ctapAuthenticatorSession.withUserPresenceWait {
+            ctapAuthenticatorSession.userVerificationHandler.onMakeCredentialConsentRequested(makeCredentialConsentRequest)
+        }
     }
 
     //spec| Step9-11

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/U2FAuthenticationExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/U2FAuthenticationExecution.kt
@@ -123,6 +123,8 @@ class U2FAuthenticationExecution(
 
     private suspend fun requestUserPresence(applicationParameter: ByteArray, userPresencePlan: Boolean): Boolean{
         val options = GetAssertionConsentRequest(applicationParameter, userPresencePlan, false)
-        return ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(options)
+        return ctapAuthenticatorSession.withUserPresenceWait {
+            ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(options)
+        }
     }
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/U2FRegisterExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/U2FRegisterExecution.kt
@@ -95,7 +95,9 @@ class U2FRegisterExecution(
             isUserPresenceRequired = true,
             isUserVerificationRequired = false
         )
-        return ctapAuthenticatorSession.userVerificationHandler.onMakeCredentialConsentRequested(makeCredentialConsentRequest)
+        return ctapAuthenticatorSession.withUserPresenceWait {
+            ctapAuthenticatorSession.userVerificationHandler.onMakeCredentialConsentRequested(makeCredentialConsentRequest)
+        }
     }
 
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
@@ -42,7 +42,14 @@ class HIDCborCommandHandler(
             coroutineScope {
                 val keepAliveJob = launch(keepAliveWorker) {
                     while (true) {
-                        responseCallback(HIDKEEPALIVEResponseMessage(hidMessage.channelId, HIDStatusCode.PROCESSING))
+                        //spec| STATUS_PROCESSING 1 The authenticator is still processing the current request.
+                        //spec| STATUS_UPNEEDED 2 The authenticator is waiting for user presence.
+                        val statusCode = if (ctapAuthenticatorSession.isWaitingForUserPresence) {
+                            HIDStatusCode.UPNEEDED
+                        } else {
+                            HIDStatusCode.PROCESSING
+                        }
+                        responseCallback(HIDKEEPALIVEResponseMessage(hidMessage.channelId, statusCode))
                         delay(KEEPALIVE_INTERVAL)
                     }
                 }


### PR DESCRIPTION
Send KEEPALIVE STATUS_UPNEEDED (0x02) instead of STATUS_PROCESSING (0x01) while the authenticator is waiting for user presence during MakeCredential, GetAssertion, and U2F operations. The isWaitingForUserPresence flag (added in PR #262) is set before consent requests and cleared in finally blocks.