### PR TITLE
Add error handling for CBOR command exceptions

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
@@ -1,6 +1,7 @@
 package com.webauthn4j.ctap.authenticator.transport.hid.handler
 
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.authenticator.execution.CtapCommandExecutionException
 import com.webauthn4j.ctap.core.converter.CtapRequestConverter
 import com.webauthn4j.ctap.core.converter.CtapResponseConverter
 import com.webauthn4j.ctap.core.data.CtapResponse
@@ -55,6 +56,10 @@ class HIDCborCommandHandler(
             }
         } catch (_: CancellationException) {
             responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP2_ERR_KEEPALIVE_CANCEL, ByteArray(0)))
+        } catch (e: CtapCommandExecutionException) {
+            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, e.statusCode, ByteArray(0)))
+        } catch (_: Exception) {
+            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP1_ERR_OTHER, ByteArray(0)))
         }
     }
 }


### PR DESCRIPTION
Add catch blocks for CtapCommandExecutionException and general Exception in HIDCborCommandHandler. Previously, exceptions from CBOR command parsing or execution (e.g., malformed request data) would cause no response to be sent, resulting in client timeouts.