### PR TITLE
Return INVALID_CMD instead of OTHER for unknown HID commands

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDRequestMessageBuilder.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDRequestMessageBuilder.kt
@@ -5,6 +5,7 @@ import com.webauthn4j.ctap.core.data.hid.HIDCANCELRequestMessage
 import com.webauthn4j.ctap.core.data.hid.HIDCBORRequestMessage
 import com.webauthn4j.ctap.core.data.hid.HIDChannelId
 import com.webauthn4j.ctap.core.data.hid.HIDCommand
+import com.webauthn4j.ctap.core.data.hid.HIDErrorCode
 import com.webauthn4j.ctap.core.data.hid.HIDINITRequestMessage
 import com.webauthn4j.ctap.core.data.hid.HIDKEEPALIVEResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDLOCKRequestMessage
@@ -50,7 +51,8 @@ class HIDRequestMessageBuilder : HIDMessageBuilderBase<HIDRequestMessage>() {
             HIDCommand.CTAPHID_LOCK -> {
                 HIDLOCKRequestMessage(channelId, data.first())
             }
-            else -> throw IllegalStateException(
+            else -> throw HIDProtocolException(
+                HIDErrorCode.INVALID_CMD,
                 String.format(
                     "Unexpected HIDCommand received: 0x%02X",
                     command.value

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDResponseMessageBuilder.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDResponseMessageBuilder.kt
@@ -5,6 +5,7 @@ import com.webauthn4j.ctap.core.data.hid.HIDCBORResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDCapability
 import com.webauthn4j.ctap.core.data.hid.HIDChannelId
 import com.webauthn4j.ctap.core.data.hid.HIDCommand
+import com.webauthn4j.ctap.core.data.hid.HIDErrorCode
 import com.webauthn4j.ctap.core.data.hid.HIDINITResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDKEEPALIVEResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDLOCKResponseMessage
@@ -59,7 +60,8 @@ class HIDResponseMessageBuilder : HIDMessageBuilderBase<HIDResponseMessage>() {
             HIDCommand.CTAPHID_LOCK -> {
                 HIDLOCKResponseMessage(channelId)
             }
-            else -> throw IllegalStateException(
+            else -> throw HIDProtocolException(
+                HIDErrorCode.INVALID_CMD,
                 String.format(
                     "Unexpected HIDCommand received: 0x%02X",
                     command.value


### PR DESCRIPTION
Use HIDProtocolException with INVALID_CMD error code instead of IllegalStateException in HID message builders. IllegalStateException was caught as a generic RuntimeException and returned as ERR_OTHER (0x7F), but the spec requires ERR_INVALID_CMD (0x01) for unsupported commands.