### PR TITLE
Make HID packet size configurable and fix MAX_PACKET_SIZE

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDMessageBuilderBase.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDMessageBuilderBase.kt
@@ -6,12 +6,13 @@ import com.webauthn4j.ctap.core.data.hid.HIDContinuationPacket
 import com.webauthn4j.ctap.core.data.hid.HIDErrorCode
 import com.webauthn4j.ctap.core.data.hid.HIDInitializationPacket
 import com.webauthn4j.ctap.core.data.hid.HIDMessage
-import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.MAX_CONT_PACKET_DATA_SIZE
-import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.MAX_INIT_PACKET_DATA_SIZE
+import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.DEFAULT_PACKET_SIZE
 import java.nio.ByteBuffer
 import kotlin.math.min
 
-abstract class HIDMessageBuilderBase<T : HIDMessage> {
+abstract class HIDMessageBuilderBase<T : HIDMessage>(
+    private val packetSize: Int = DEFAULT_PACKET_SIZE
+) {
 
     companion object {
         private const val MESSAGE_TIMEOUT_MS = 500L
@@ -25,11 +26,12 @@ abstract class HIDMessageBuilderBase<T : HIDMessage> {
 
     fun initialize(initializationPacket: HIDInitializationPacket) {
         buffer = ByteBuffer.allocate(initializationPacket.length.toInt())
+        val initDataSize = HIDMessage.initPacketDataSize(packetSize)
         buffer.put(
             initializationPacket.data,
             0,
             min(
-                min(initializationPacket.length.toInt(), MAX_INIT_PACKET_DATA_SIZE),
+                min(initializationPacket.length.toInt(), initDataSize),
                 initializationPacket.data.size
             )
         )
@@ -45,10 +47,11 @@ abstract class HIDMessageBuilderBase<T : HIDMessage> {
         if (counter != continuationPacket.sec) {
             throw HIDProtocolException(HIDErrorCode.INVALID_SEQ, "ContinuationPacket with an unexpected sequence number arrived.")
         }
+        val contDataSize = HIDMessage.contPacketDataSize(packetSize)
         buffer.put(
             continuationPacket.data,
             0,
-            min(min(buffer.remaining(), MAX_CONT_PACKET_DATA_SIZE), continuationPacket.data.size)
+            min(min(buffer.remaining(), contDataSize), continuationPacket.data.size)
         )
         counter++
     }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/hid/HIDContinuationPacket.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/hid/HIDContinuationPacket.kt
@@ -1,6 +1,5 @@
 package com.webauthn4j.ctap.core.data.hid
 
-import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.MAX_PACKET_SIZE
 import com.webauthn4j.ctap.core.util.internal.HexUtil
 import com.webauthn4j.util.ArrayUtil
 import java.nio.ByteBuffer
@@ -20,7 +19,9 @@ class HIDContinuationPacket : HIDPacket {
 
 
     override fun toBytes(): ByteArray {
-        return ByteBuffer.allocate(MAX_PACKET_SIZE).put(channelId.value).put(sec).put(data).array()
+        // 4 (channelId) + 1 (seq) + data
+        val packetSize = 4 + 1 + data.size
+        return ByteBuffer.allocate(packetSize).put(channelId.value).put(sec).put(data).array()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/hid/HIDInitializationPacket.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/hid/HIDInitializationPacket.kt
@@ -1,6 +1,5 @@
 package com.webauthn4j.ctap.core.data.hid
 
-import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.MAX_PACKET_SIZE
 import com.webauthn4j.ctap.core.util.internal.HexUtil
 import com.webauthn4j.util.ArrayUtil
 import java.nio.ByteBuffer
@@ -30,8 +29,10 @@ class HIDInitializationPacket : HIDPacket {
 
     override fun toBytes(): ByteArray {
         val commandByte = command.value or HIDCommand.CMD_BIT
+        // 4 (channelId) + 1 (command) + 2 (length) + data
+        val packetSize = 4 + 1 + 2 + data.size
 
-        return ByteBuffer.allocate(MAX_PACKET_SIZE)
+        return ByteBuffer.allocate(packetSize)
             .put(channelId.value)
             .put(commandByte)
             .putShort(length.toShort())

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/hid/HIDMessage.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/hid/HIDMessage.kt
@@ -7,22 +7,36 @@ interface HIDMessage {
     companion object {
         private const val INIT_PACKET_HEADER_SIZE = 7
         private const val CONT_PACKET_HEADER_SIZE = 5
-        const val MAX_PACKET_SIZE = 62
+        const val DEFAULT_PACKET_SIZE = 64
+
+        // Kept for backward compatibility; derived from DEFAULT_PACKET_SIZE
+        const val MAX_PACKET_SIZE = DEFAULT_PACKET_SIZE
         const val MAX_INIT_PACKET_DATA_SIZE = MAX_PACKET_SIZE - INIT_PACKET_HEADER_SIZE
         const val MAX_CONT_PACKET_DATA_SIZE = MAX_PACKET_SIZE - CONT_PACKET_HEADER_SIZE
+
+        fun initPacketDataSize(packetSize: Int): Int = packetSize - INIT_PACKET_HEADER_SIZE
+        fun contPacketDataSize(packetSize: Int): Int = packetSize - CONT_PACKET_HEADER_SIZE
+        fun maxMessageDataSize(packetSize: Int): Int {
+            val initDataSize = initPacketDataSize(packetSize)
+            val contDataSize = contPacketDataSize(packetSize)
+            return initDataSize + contDataSize * 128
+        }
     }
 
     val channelId: HIDChannelId
     val command: HIDCommand
     val data: ByteArray
 
-    fun toHIDPackets(): List<HIDPacket> {
-        require(data.size <= 7609) { "data must not exceed 7609 bytes, which is the max HID message size." }
+    fun toHIDPackets(packetSize: Int = DEFAULT_PACKET_SIZE): List<HIDPacket> {
+        val maxDataSize = maxMessageDataSize(packetSize)
+        require(data.size <= maxDataSize) { "data must not exceed $maxDataSize bytes, which is the max HID message size for packet size $packetSize." }
 
         var pos = 0
+        val initDataSize = initPacketDataSize(packetSize)
+        val contDataSize = contPacketDataSize(packetSize)
 
-        val initPacketData = ByteArray(MAX_INIT_PACKET_DATA_SIZE)
-        val initPacketActualDataSize = min(data.size, MAX_INIT_PACKET_DATA_SIZE)
+        val initPacketData = ByteArray(initDataSize)
+        val initPacketActualDataSize = min(data.size, initDataSize)
         data.copyInto(initPacketData, 0, 0, initPacketActualDataSize)
         val initializationPacket =
             HIDInitializationPacket(channelId, command, data.size.toUShort(), initPacketData)
@@ -35,8 +49,8 @@ interface HIDMessage {
             if (remainingDataSize == 0) {
                 break
             }
-            val contPacketData = ByteArray(MAX_CONT_PACKET_DATA_SIZE)
-            val contPacketActualDataSize = min(remainingDataSize, MAX_CONT_PACKET_DATA_SIZE)
+            val contPacketData = ByteArray(contDataSize)
+            val contPacketActualDataSize = min(remainingDataSize, contDataSize)
             data.copyInto(contPacketData, 0, pos, pos + contPacketActualDataSize)
             val continuationPacket = HIDContinuationPacket(channelId, index, contPacketData)
             pos += contPacketActualDataSize


### PR DESCRIPTION
Fix MAX_PACKET_SIZE from incorrect value 62 to 64 (matching the standard USB HID full-speed packet size). Add DEFAULT_PACKET_SIZE constant and packetSize parameter to HIDMessageBuilderBase and toHIDPackets for configurability. Add helper functions initPacketDataSize/contPacketDataSize/maxMessageDataSize.