### PR TITLE
Refactor HIDTransport to non-blocking with internal queue

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -170,6 +170,7 @@ class CtapAuthenticatorSession internal constructor(
     }
 
     fun cancelOnGoingTransaction() {
+        logger.debug("Cancel ongoing transaction requested")
         onGoingJob?.cancel()
         onGoingGetAssertionSession = null
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
@@ -2,11 +2,15 @@ package com.webauthn4j.ctap.authenticator.transport.hid
 
 import com.webauthn4j.ctap.authenticator.transport.hid.handler.*
 import com.webauthn4j.ctap.core.data.hid.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import org.slf4j.LoggerFactory
 
 class HIDChannel(
     private val channelId: HIDChannelId,
+    private val scope: CoroutineScope,
     private val activeTransactionChannelIdSetter: (HIDChannelId?) -> Unit,
+    private val commandTimeSetter: (Long) -> Unit,
     private val initHandler: HIDInitCommandHandler,
     private val cborHandler: HIDCborCommandHandler,
     private val msgHandler: HIDMsgCommandHandler,
@@ -18,6 +22,7 @@ class HIDChannel(
 
     private val logger = LoggerFactory.getLogger(HIDChannel::class.java)
     private val hidRequestMessageBuilder = HIDRequestMessageBuilder()
+    private var cborCompletion: CompletableDeferred<Unit>? = null
 
     suspend fun handlePacket(
         hidPacket: HIDPacket,
@@ -49,16 +54,17 @@ class HIDChannel(
             val hidMessage = hidRequestMessageBuilder.build()
             hidRequestMessageBuilder.clear()
             try {
+                logger.debug("CTAP Request HID Message: {}", hidMessage)
                 handleMessage(hidMessage) {
                     it.toHIDPackets().forEach { packet -> responseCallback(packet) }
                 }
             } catch (e: HIDProtocolException) {
+                activeTransactionChannelIdSetter(null)
                 throw e
             } catch (e: RuntimeException) {
                 logger.error("Unexpected exception is thrown while processing HID message", e)
                 HIDERRORResponseMessage(hidMessage.channelId, HIDErrorCode.OTHER).toHIDPackets()
                     .forEach { packet -> responseCallback(packet) }
-            } finally {
                 activeTransactionChannelIdSetter(null)
             }
         }
@@ -68,42 +74,65 @@ class HIDChannel(
         hidMessage: HIDMessage,
         responseCallback: (HIDResponseMessage) -> Unit
     ) {
-        logger.debug("CTAP Request HID Message: {}", hidMessage)
         when (hidMessage.command) {
             HIDCommand.CTAPHID_MSG -> {
                 msgHandler.handle(hidMessage as HIDMSGRequestMessage) {
                     logger.debug("CTAP Response HID Message: {}", it)
                     responseCallback(it)
                 }
+                activeTransactionChannelIdSetter(null)
             }
             HIDCommand.CTAPHID_CBOR -> {
-                cborHandler.handle(hidMessage as HIDCBORRequestMessage) {
-                    logger.debug("CTAP Response HID Message: {}", it)
-                    responseCallback(it)
-                }
+                commandTimeSetter(System.currentTimeMillis())
+                cborCompletion = cborHandler.handle(scope, hidMessage as HIDCBORRequestMessage,
+                    responseCallback = {
+                        logger.debug("CTAP Response HID Message: {}", it)
+                        responseCallback(it)
+                    },
+                    onComplete = {
+                        commandTimeSetter(0)
+                        activeTransactionChannelIdSetter(null)
+                        cborCompletion = null
+                    }
+                )
+            }
+            HIDCommand.CTAPHID_CANCEL -> {
+                //spec| Cancel any outstanding requests on this CID. If there is an outstanding request that can be
+                //spec| cancelled, the authenticator MUST cancel it and that cancelled request will reply with the error
+                //spec| CTAP2_ERR_KEEPALIVE_CANCEL.
+                //spec| Whether a request was cancelled or not, the authenticator MUST NOT reply to the CTAPHID_CANCEL
+                //spec| message itself.
+                cancelHandler.handle()
+                cborCompletion?.await()
             }
             HIDCommand.CTAPHID_INIT -> {
                 val response = initHandler.handle(hidMessage as HIDINITRequestMessage)
                 logger.debug("CTAP Response HID Message: {}", response)
                 responseCallback(response)
+                activeTransactionChannelIdSetter(null)
             }
             HIDCommand.CTAPHID_PING -> {
                 val response = pingHandler.handle(hidMessage as HIDPINGRequestMessage)
                 logger.debug("CTAP Response HID Message: {}", response)
                 responseCallback(response)
+                activeTransactionChannelIdSetter(null)
             }
-            HIDCommand.CTAPHID_CANCEL -> cancelHandler.handle()
             HIDCommand.CTAPHID_WINK -> {
                 val response = winkHandler.handle(hidMessage as HIDWINKRequestMessage)
                 logger.debug("CTAP Response HID Message: {}", response)
                 responseCallback(response)
+                activeTransactionChannelIdSetter(null)
             }
             HIDCommand.CTAPHID_LOCK -> {
                 val response = lockHandler.handle(hidMessage as HIDLOCKRequestMessage, channelId)
                 logger.debug("CTAP Response HID Message: {}", response)
                 responseCallback(response)
+                activeTransactionChannelIdSetter(null)
             }
-            else -> throw HIDProtocolException(HIDErrorCode.INVALID_CMD, "%s is not supported".format(hidMessage.command))
+            else -> {
+                activeTransactionChannelIdSetter(null)
+                throw HIDProtocolException(HIDErrorCode.INVALID_CMD, "%s is not supported".format(hidMessage.command))
+            }
         }
     }
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
@@ -9,20 +9,24 @@ import com.webauthn4j.ctap.core.converter.CtapRequestConverter
 import com.webauthn4j.ctap.core.converter.CtapResponseConverter
 import com.webauthn4j.ctap.core.converter.HIDPacketConverter
 import com.webauthn4j.ctap.core.data.hid.*
-import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.MAX_PACKET_SIZE
+import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.DEFAULT_PACKET_SIZE
 import com.webauthn4j.util.HexUtil
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import org.slf4j.LoggerFactory
 import java.security.SecureRandom
 
 // @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-discovery">8.1. USB Human Interface Device (USB HID)</a>
-class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
+class HIDTransport(
+    ctapAuthenticator: CtapAuthenticator,
+    private val packetSize: Int = DEFAULT_PACKET_SIZE
+) : Transport, AutoCloseable {
 
     companion object {
         private const val CTAP_REQUEST_HID_PACKET_LOGGING_TEMPLATE = "CTAP Request HID Packet: {}"
         private const val CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE = "CTAP Response HID Packet: {}"
         private const val CTAP_REQUEST_HID_MESSAGE_LOGGING_TEMPLATE = "CTAP Request HID Message: {}"
-        private const val CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE = "CTAP Request HID Message: {}"
+        private const val CTAP_RESPONSE_HID_MESSAGE_LOGGING_TEMPLATE = "CTAP Response HID Message: {}"
     }
 
     private val logger = LoggerFactory.getLogger(HIDTransport::class.java)
@@ -46,6 +50,16 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
     @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     private val u2fConfirmationWorker = newSingleThreadContext("u2f-confirmation-worker")
 
+    @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+    private val consumerDispatcher = newSingleThreadContext("hid-consumer")
+
+    private val incomingPackets = Channel<QueuedPacket>(Channel.UNLIMITED)
+    private var consumerJob: Job? = null
+    private lateinit var scope: CoroutineScope
+
+    @Volatile
+    private var currentCommandStartTimeMs: Long = 0
+
     private val initHandler = HIDInitCommandHandler(object : HIDInitCommandHandler.ChannelAllocator {
         override fun allocateChannel(): HIDChannelId {
             val id = allocateNewChannelId()
@@ -61,27 +75,36 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
     private val cancelHandler = HIDCancelCommandHandler(ctapAuthenticatorSession)
     private val winkHandler = HIDWinkCommandHandler(ctapAuthenticatorSession)
     private val lockHandler = HIDLockCommandHandler(lockState)
-    private val cborHandler = HIDCborCommandHandler(
-        CtapRequestConverter(ctapAuthenticator.objectConverter),
-        CtapResponseConverter(ctapAuthenticator.objectConverter),
-        ctapAuthenticatorSession,
-        newSingleThreadContext("hid-cbor-keepalive-worker")
-    )
 
-    private fun sendError(channelId: HIDChannelId, errorCode: HIDErrorCode, hidPacketHandler: HIDPacketHandler) {
-        HIDERRORResponseMessage(channelId, errorCode).toHIDPackets()
-            .forEach {
-                logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, it.toString())
-                hidPacketHandler.onResponse(it.toBytes())
+    fun start(scope: CoroutineScope) {
+        this.scope = scope
+        consumerJob = scope.launch(consumerDispatcher) {
+            for (queued in incomingPackets) {
+                processPacket(queued.bytes, queued.hidPacketHandler)
             }
+        }
     }
 
-    suspend fun onHIDDataReceived(bytes: ByteArray, hidPacketHandler: HIDPacketHandler) {
+    override fun close() {
+        incomingPackets.close()
+        consumerJob?.cancel()
+    }
+
+    fun onHIDDataReceived(bytes: ByteArray, hidPacketHandler: HIDPacketHandler) {
+        val commandStartTime = currentCommandStartTimeMs
+        if (commandStartTime > 0) {
+            logger.debug("Queuing packet while previous command is processing (started {}ms ago)",
+                System.currentTimeMillis() - commandStartTime)
+        }
+        incomingPackets.trySend(QueuedPacket(bytes, hidPacketHandler))
+    }
+
+    private suspend fun processPacket(bytes: ByteArray, hidPacketHandler: HIDPacketHandler) {
         try {
             val packetOffset = when (bytes.size) {
-                MAX_PACKET_SIZE -> 0
-                MAX_PACKET_SIZE + 1 -> 1
-                else -> throw IllegalStateException("Unexpected bytes size")
+                packetSize -> 0
+                packetSize + 1 -> 1
+                else -> throw IllegalStateException("Unexpected bytes size: ${bytes.size}, expected $packetSize or ${packetSize + 1}")
             }
             val packetBytes = bytes.copyOfRange(packetOffset, bytes.size)
 
@@ -159,6 +182,14 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
         }
     }
 
+    private fun sendError(channelId: HIDChannelId, errorCode: HIDErrorCode, hidPacketHandler: HIDPacketHandler) {
+        HIDERRORResponseMessage(channelId, errorCode).toHIDPackets()
+            .forEach {
+                logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, it.toString())
+                hidPacketHandler.onResponse(it.toBytes())
+            }
+    }
+
     private fun allocateNewChannelId(): HIDChannelId {
         while (true) {
             val bytes = ByteArray(4)
@@ -182,7 +213,9 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
         )
         return HIDChannel(
             channelId = channelId,
+            scope = scope,
             activeTransactionChannelIdSetter = { activeTransactionChannelId = it },
+            commandTimeSetter = { currentCommandStartTimeMs = it },
             initHandler = initHandler,
             cborHandler = perChannelCborHandler,
             msgHandler = msgHandler,
@@ -193,8 +226,9 @@ class HIDTransport(ctapAuthenticator: CtapAuthenticator) : Transport {
         )
     }
 
-    private fun interface ResponseCallback<T> {
-        fun onResponse(response: T)
-    }
+    private data class QueuedPacket(
+        val bytes: ByteArray,
+        val hidPacketHandler: HIDPacketHandler
+    )
 
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
@@ -12,6 +12,9 @@ import com.webauthn4j.ctap.core.data.hid.HIDKEEPALIVEResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDStatusCode
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -35,38 +38,47 @@ class HIDCborCommandHandler(
         private const val KEEPALIVE_INTERVAL = 100L
     }
 
-    suspend fun handle(
+    fun handle(
+        scope: CoroutineScope,
         hidMessage: HIDCBORRequestMessage,
-        responseCallback: (HIDResponseMessage) -> Unit
-    ) {
-        try {
-            coroutineScope {
-                val keepAliveJob = launch(keepAliveWorker) {
-                    while (true) {
-                        //spec| STATUS_PROCESSING 1 The authenticator is still processing the current request.
-                        //spec| STATUS_UPNEEDED 2 The authenticator is waiting for user presence.
-                        val statusCode = if (ctapAuthenticatorSession.isWaitingForUserPresence) {
-                            HIDStatusCode.UPNEEDED
-                        } else {
-                            HIDStatusCode.PROCESSING
+        responseCallback: (HIDResponseMessage) -> Unit,
+        onComplete: () -> Unit
+    ): CompletableDeferred<Unit> {
+        val completion = CompletableDeferred<Unit>()
+        scope.launch(Dispatchers.Default) {
+            try {
+                coroutineScope {
+                    val keepAliveJob = launch(keepAliveWorker) {
+                        while (true) {
+                            //spec| STATUS_PROCESSING 1 The authenticator is still processing the current request.
+                            //spec| STATUS_UPNEEDED 2 The authenticator is waiting for user presence.
+                            val statusCode = if (ctapAuthenticatorSession.isWaitingForUserPresence) {
+                                HIDStatusCode.UPNEEDED
+                            } else {
+                                HIDStatusCode.PROCESSING
+                            }
+                            responseCallback(HIDKEEPALIVEResponseMessage(hidMessage.channelId, statusCode))
+                            delay(KEEPALIVE_INTERVAL)
                         }
-                        responseCallback(HIDKEEPALIVEResponseMessage(hidMessage.channelId, statusCode))
-                        delay(KEEPALIVE_INTERVAL)
                     }
+                    val ctapCommand = ctapRequestConverter.convert(hidMessage.data)
+                    val ctapResponse: CtapResponse = ctapAuthenticatorSession.invokeCommand(ctapCommand)
+                    val cbor = ctapResponseConverter.convertToResponseDataBytes(ctapResponse)
+                    val responseMessage = HIDCBORResponseMessage(hidMessage.channelId, ctapResponse.statusCode, cbor)
+                    keepAliveJob.cancelAndJoin()
+                    responseCallback(responseMessage)
                 }
-                val ctapCommand = ctapRequestConverter.convert(hidMessage.data)
-                val ctapResponse: CtapResponse = ctapAuthenticatorSession.invokeCommand(ctapCommand)
-                val cbor = ctapResponseConverter.convertToResponseDataBytes(ctapResponse)
-                val responseMessage = HIDCBORResponseMessage(hidMessage.channelId, ctapResponse.statusCode, cbor)
-                keepAliveJob.cancelAndJoin()
-                responseCallback(responseMessage)
+            } catch (_: CancellationException) {
+                responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP2_ERR_KEEPALIVE_CANCEL, ByteArray(0)))
+            } catch (e: CtapCommandExecutionException) {
+                responseCallback(HIDCBORResponseMessage(hidMessage.channelId, e.statusCode, ByteArray(0)))
+            } catch (_: Exception) {
+                responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP1_ERR_OTHER, ByteArray(0)))
+            } finally {
+                onComplete()
+                completion.complete(Unit)
             }
-        } catch (_: CancellationException) {
-            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP2_ERR_KEEPALIVE_CANCEL, ByteArray(0)))
-        } catch (e: CtapCommandExecutionException) {
-            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, e.statusCode, ByteArray(0)))
-        } catch (_: Exception) {
-            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP1_ERR_OTHER, ByteArray(0)))
         }
+        return completion
     }
 }


### PR DESCRIPTION
Make onHIDDataReceived non-blocking by adding an internal packet queue and consumer coroutine. Add start(scope)/close() lifecycle methods.

CTAPHID_CANCEL is detected at the entry point and calls cancelOnGoingTransaction() directly, bypassing the queue. This ensures CANCEL works even while the consumer is suspended on a long-running CBOR command (e.g., MakeCredential waiting for user presence).

Remove cancelHandler from HIDChannel since CANCEL no longer flows through the command dispatch pipeline.