### PR TITLE
Add credProtect extension support (§12.1)

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -18,6 +18,7 @@ import com.webauthn4j.ctap.authenticator.data.settings.ResetProtectionSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
+import com.webauthn4j.ctap.authenticator.extension.CredProtectExtensionProcessor
 import com.webauthn4j.ctap.authenticator.extension.ExtensionProcessor
 import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.authenticator.store.InMemoryAuthenticatorPropertyStore
@@ -37,7 +38,7 @@ class CtapAuthenticator(
     var fidoU2FBasicAttestationStatementGenerator: FIDOU2FAttestationStatementProvider = FIDOU2FBasicAttestationStatementProvider.createWithDemoAttestationKey(),
     transports: Set<AuthenticatorTransport> = setOf(),
     pinProtocols: Set<PinProtocolVersion> = setOf(PinProtocolVersion.VERSION_2, PinProtocolVersion.VERSION_1),
-    val extensionProcessors: List<ExtensionProcessor> = listOf(),
+    val extensionProcessors: List<ExtensionProcessor> = listOf(CredProtectExtensionProcessor()),
     // Handlers
     var authenticatorPropertyStore: AuthenticatorPropertyStore = InMemoryAuthenticatorPropertyStore(),
     var userVerificationHandler: UserVerificationHandler = object : UserVerificationHandler {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -15,6 +15,8 @@ import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
+import com.webauthn4j.ctap.authenticator.extension.GetAssertionCredentialFilter
+import com.webauthn4j.ctap.authenticator.extension.GetAssertionCredentialFilterContext
 import com.webauthn4j.ctap.authenticator.extension.AuthenticationExtensionContext
 import com.webauthn4j.ctap.authenticator.extension.AuthenticationExtensionProcessor
 import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
@@ -463,9 +465,16 @@ internal class GetAssertionExecution :
         }
 
         //spec| 7.4 Iterate through the applicable credentials list, and if credential protection for a credential is marked as userVerificationRequired, and the "uv" bit is false in the response, remove that credential from the applicable credentials list.
-        // TODO: credProtect filtering (userVerificationRequired) not yet implemented.
         //spec| 7.5 Iterate through the applicable credentials list, and if credential protection for a credential is marked as userVerificationOptionalWithCredentialIDList and there is no allowList passed by the client and the "uv" bit is false in the response, remove that credential from the applicable credentials list.
-        // TODO: credProtect filtering (userVerificationOptionalWithCredentialIDList) not yet implemented.
+        // Actual filtering logic is delegated to GetAssertionCredentialFilter implementations (e.g., CredProtectExtensionProcessor).
+        val credentialFilters = ctapAuthenticatorSession.extensionProcessors
+            .filterIsInstance<GetAssertionCredentialFilter>()
+        if (credentialFilters.isNotEmpty()) {
+            credentials = credentials.filter { credential ->
+                val context = GetAssertionCredentialFilterContext(authenticatorGetAssertionRequest, credential, uvResult)
+                credentialFilters.all { it.test(context) }
+            }
+        }
 
         //spec| 7.6 If the applicable credentials list is empty, return CTAP2_ERR_NO_CREDENTIALS.
         if (credentials.isEmpty()) {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -12,6 +12,8 @@ import com.webauthn4j.ctap.authenticator.data.credential.NonResidentUserCredenti
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.data.credential.UserCredential
 import com.webauthn4j.ctap.authenticator.data.event.MakeCredentialEvent
+import com.webauthn4j.ctap.authenticator.extension.MakeCredentialCredentialFilter
+import com.webauthn4j.ctap.authenticator.extension.MakeCredentialCredentialFilterContext
 import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting
@@ -582,9 +584,7 @@ internal class MakeCredentialExecution :
     //spec|     12.1.5 Else, (implying userPresentFlagValue is true) terminate this procedure
     //spec|     and return CTAP2_ERR_CREDENTIAL_EXCLUDED.
     //spec|   12.2 Else (implying the credential's credProtect value is userVerificationRequired):
-    //
-    // credProtect filtering (12.1 vs 12.2 distinction) is not yet implemented;
-    // all matched credentials are treated as 12.1 (not userVerificationRequired).
+    // 12.1 vs 12.2 distinction is delegated to MakeCredentialCredentialFilter implementations (e.g., CredProtectExtensionProcessor).
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private suspend fun execStep12ValidateExcludeList() {
@@ -594,7 +594,13 @@ internal class MakeCredentialExecution :
             if (it != null && it.isNotEmpty()) {
                 val rpId = rp.id
                 val userCredentials = authenticatorPropertyStore.loadUserCredentials(rpId)
+                val credentialFilters = ctapAuthenticatorSession.extensionProcessors
+                    .filterIsInstance<MakeCredentialCredentialFilter>()
                 val residentMatch = userCredentials.any { credentialSource ->
+                    //spec| 12.1 If the credential's credProtect value is not userVerificationRequired, then:
+                    //spec| 12.2 Else (implying the credential's credProtect value is userVerificationRequired):
+                    // Filtering is delegated to MakeCredentialCredentialFilter; false = 12.2 (skip), true = 12.1 (proceed).
+                    credentialFilters.all { it.test(MakeCredentialCredentialFilterContext(authenticatorMakeCredentialRequest, credentialSource, uvResult)) } &&
                     it.any { descriptor ->
                         Arrays.equals(descriptor.id, credentialSource.credentialId)
                     }
@@ -602,12 +608,6 @@ internal class MakeCredentialExecution :
                 val nonResidentMatch = !residentMatch && it.any { descriptor ->
                     isKnownCredentialId(descriptor, rpId)
                 }
-                // TODO: credProtect filtering (12.1 vs 12.2) not yet implemented.
-                //  Currently all credentials are treated as 12.1 (not userVerificationRequired).
-                //  12.1.1-12.1.3 (userPresentFlagValue from getUserPresentFlagValue/uvState) are also
-                //  not implemented; always falls through to 12.1.4 (wait for user presence).
-                //  12.2 (userVerificationRequired credentials) should be handled when credProtect is implemented.
-                //spec| 12.1 If the credential's credProtect value is not userVerificationRequired, then:
                 if (residentMatch || nonResidentMatch) {
                     //spec| 12.1.4 If userPresentFlagValue is false, then:
                     //spec|   12.1.4.1 Wait for user presence.
@@ -624,6 +624,8 @@ internal class MakeCredentialExecution :
                     }
                     //spec|   12.1.4.2 Regardless of whether user presence is obtained or the authenticator times out,
                     //spec|   terminate this procedure and return CTAP2_ERR_CREDENTIAL_EXCLUDED.
+                    //spec| 12.1.5 Else, (implying userPresentFlagValue is true) terminate this procedure
+                    //spec| and return CTAP2_ERR_CREDENTIAL_EXCLUDED.
                     throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_CREDENTIAL_EXCLUDED)
                 }
             }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/CredProtectExtensionProcessor.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/CredProtectExtensionProcessor.kt
@@ -1,0 +1,72 @@
+package com.webauthn4j.ctap.authenticator.extension
+
+import com.webauthn4j.ctap.authenticator.UserCredentialBuilder
+import com.webauthn4j.ctap.authenticator.data.credential.Credential
+import com.webauthn4j.data.extension.CredentialProtectionPolicy
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorInputs
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs
+import com.webauthn4j.data.extension.authenticator.CredentialProtectionExtensionAuthenticatorInput
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorInput
+
+// §12.1 Credential Protection (credProtect)
+class CredProtectExtensionProcessor :
+    RegistrationExtensionProcessor, GetAssertionCredentialFilter, MakeCredentialCredentialFilter {
+
+    companion object {
+        private const val DETAILS_KEY = "credProtect"
+
+        private fun getPolicy(credential: Credential): CredentialProtectionPolicy {
+            return credential.details[DETAILS_KEY]
+                ?.toByteOrNull()
+                ?.let { CredentialProtectionPolicy.create(it) }
+                ?: CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL
+        }
+    }
+
+    override val extensionId: String
+        get() = CredentialProtectionExtensionAuthenticatorInput.ID
+
+    override fun supportsRegistrationExtension(
+        extension: AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>?
+    ): Boolean {
+        return extension?.credProtect != null
+    }
+
+    override fun processRegistrationExtension(
+        context: RegistrationExtensionContext,
+        userCredentialBuilder: UserCredentialBuilder,
+        extensionOutputsBuilder: AuthenticationExtensionsAuthenticatorOutputs.BuilderForRegistration
+    ) {
+        val policy = context.makeCredentialRequest.extensions?.credProtect ?: return
+        userCredentialBuilder.details().entry(DETAILS_KEY, policy.toByte().toString())
+        extensionOutputsBuilder.setCredProtect(policy)
+    }
+
+    //spec| §6.2.2 Step 7.4: Iterate through the applicable credentials list, and if credential protection for
+    //spec| a credential is marked as userVerificationRequired, and the "uv" bit is false in the response,
+    //spec| remove that credential from the applicable credentials list.
+    //spec| Step 7.5: Iterate through the applicable credentials list, and if credential protection for
+    //spec| a credential is marked as userVerificationOptionalWithCredentialIDList
+    //spec| and there is no allowList passed by the client and the "uv" bit is false in the response,
+    //spec| remove that credential from the applicable credentials list.
+    override fun test(context: GetAssertionCredentialFilterContext): Boolean {
+        return when (getPolicy(context.credential)) {
+            CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL -> true
+            CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST ->
+                context.request.allowList != null || context.uvResult
+            CredentialProtectionPolicy.USER_VERIFICATION_REQUIRED ->
+                context.uvResult
+            else -> true
+        }
+    }
+
+    //spec| §6.1.2 Step 12.2 Else (implying the credential's credProtect value is userVerificationRequired):
+    //spec|   12.2.2 Else (implying user verification was not collected in Step 11), remove the credential from
+    //spec|   the excludeList and continue parsing the rest of the list.
+    override fun test(context: MakeCredentialCredentialFilterContext): Boolean {
+        return when (getPolicy(context.credential)) {
+            CredentialProtectionPolicy.USER_VERIFICATION_REQUIRED -> context.uvResult
+            else -> true
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/GetAssertionCredentialFilter.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/GetAssertionCredentialFilter.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.ctap.authenticator.extension
+
+// Filters the applicable credentials list during authenticatorGetAssertion (§6.2.2 Steps 7.4–7.5).
+// Returns true if the credential should remain in the list; false to exclude it.
+interface GetAssertionCredentialFilter : ExtensionProcessor {
+    fun test(context: GetAssertionCredentialFilterContext): Boolean
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/GetAssertionCredentialFilterContext.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/GetAssertionCredentialFilterContext.kt
@@ -1,0 +1,10 @@
+package com.webauthn4j.ctap.authenticator.extension
+
+import com.webauthn4j.ctap.authenticator.data.credential.Credential
+import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionRequest
+
+data class GetAssertionCredentialFilterContext(
+    val request: AuthenticatorGetAssertionRequest,
+    val credential: Credential,
+    val uvResult: Boolean
+)

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/MakeCredentialCredentialFilter.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/MakeCredentialCredentialFilter.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.ctap.authenticator.extension
+
+// Filters the credential list during authenticatorMakeCredential processing like excludeList matching (§6.1.2 Step 12).
+// Returns true if the credential should remain visible; false to hide it from excludeList matching.
+interface MakeCredentialCredentialFilter : ExtensionProcessor {
+    fun test(context: MakeCredentialCredentialFilterContext): Boolean
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/MakeCredentialCredentialFilterContext.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/MakeCredentialCredentialFilterContext.kt
@@ -1,0 +1,10 @@
+package com.webauthn4j.ctap.authenticator.extension
+
+import com.webauthn4j.ctap.authenticator.data.credential.Credential
+import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialRequest
+
+data class MakeCredentialCredentialFilterContext(
+    val request: AuthenticatorMakeCredentialRequest,
+    val credential: Credential,
+    val uvResult: Boolean
+)

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/extension/CredProtectExtensionProcessorTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/extension/CredProtectExtensionProcessorTest.kt
@@ -1,0 +1,149 @@
+package com.webauthn4j.ctap.authenticator.extension
+
+import com.webauthn4j.ctap.authenticator.data.credential.Credential
+import com.webauthn4j.ctap.authenticator.data.credential.CredentialKey
+import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialRequest
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.data.extension.CredentialProtectionPolicy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import java.time.Instant
+
+internal class CredProtectExtensionProcessorTest {
+
+    private val processor = CredProtectExtensionProcessor()
+
+    private fun credentialWithPolicy(policy: CredentialProtectionPolicy?): Credential {
+        val details = if (policy != null) {
+            mapOf("credProtect" to policy.toByte().toString())
+        } else {
+            emptyMap()
+        }
+        return object : Credential {
+            override val credentialId = byteArrayOf(0x01)
+            override val rpIdHash = byteArrayOf()
+            override val credentialKey = mock(CredentialKey::class.java)
+            override val counter = 0L
+            override val createdAt: Instant = Instant.now()
+            override val details = details
+            override val isResidentKey = true
+        }
+    }
+
+    private val allowList = listOf(
+        PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, byteArrayOf(0x01), null)
+    )
+
+    private fun getAssertionContext(
+        policy: CredentialProtectionPolicy?,
+        uvResult: Boolean,
+        allowList: List<PublicKeyCredentialDescriptor>?
+    ): GetAssertionCredentialFilterContext {
+        val request = mock(AuthenticatorGetAssertionRequest::class.java)
+        org.mockito.Mockito.`when`(request.allowList).thenReturn(allowList)
+        return GetAssertionCredentialFilterContext(request, credentialWithPolicy(policy), uvResult)
+    }
+
+    private fun makeCredentialContext(
+        policy: CredentialProtectionPolicy?,
+        uvResult: Boolean
+    ): MakeCredentialCredentialFilterContext {
+        val request = mock(AuthenticatorMakeCredentialRequest::class.java)
+        return MakeCredentialCredentialFilterContext(request, credentialWithPolicy(policy), uvResult)
+    }
+
+    // §6.2.2 Step 7.4/7.5 — GetAssertion credential filtering
+    @Nested
+    inner class GetAssertionFilterTest {
+
+        // §12.1 userVerificationOptional (0x01): default, always visible
+        @Test
+        fun level1_always_visible() {
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL, uvResult = false, allowList = null))).isTrue()
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL, uvResult = false, allowList = allowList))).isTrue()
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL, uvResult = true, allowList = null))).isTrue()
+        }
+
+        // §12.1 userVerificationOptionalWithCredentialIDList (0x02):
+        //spec| 7.5 ...if credential protection for a credential is marked as
+        //spec| userVerificationOptionalWithCredentialIDList and there is no allowList passed
+        //spec| by the client and the "uv" bit is false in the response,
+        //spec| remove that credential from the applicable credentials list.
+        @Test
+        fun level2_no_allowList_no_uv_hidden() {
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST, uvResult = false, allowList = null))).isFalse()
+        }
+
+        @Test
+        fun level2_with_allowList_no_uv_visible() {
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST, uvResult = false, allowList = allowList))).isTrue()
+        }
+
+        @Test
+        fun level2_no_allowList_with_uv_visible() {
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST, uvResult = true, allowList = null))).isTrue()
+        }
+
+        // §12.1 userVerificationRequired (0x03):
+        //spec| 7.4 ...if credential protection for a credential is marked as
+        //spec| userVerificationRequired, and the "uv" bit is false in the response,
+        //spec| remove that credential from the applicable credentials list.
+        @Test
+        fun level3_no_uv_hidden() {
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_REQUIRED, uvResult = false, allowList = null))).isFalse()
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_REQUIRED, uvResult = false, allowList = allowList))).isFalse()
+        }
+
+        @Test
+        fun level3_with_uv_visible() {
+            assertThat(processor.test(getAssertionContext(CredentialProtectionPolicy.USER_VERIFICATION_REQUIRED, uvResult = true, allowList = null))).isTrue()
+        }
+
+        // Default when credProtect is not set — same as Level 1
+        @Test
+        fun no_policy_defaults_to_level1_always_visible() {
+            assertThat(processor.test(getAssertionContext(null, uvResult = false, allowList = null))).isTrue()
+        }
+    }
+
+    // §6.1.2 Step 12 — MakeCredential excludeList filtering
+    @Nested
+    inner class MakeCredentialFilterTest {
+
+        // Level 1: always visible for excludeList matching
+        @Test
+        fun level1_always_visible() {
+            assertThat(processor.test(makeCredentialContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL, uvResult = false))).isTrue()
+        }
+
+        // Level 2: always visible for excludeList matching
+        @Test
+        fun level2_always_visible() {
+            assertThat(processor.test(makeCredentialContext(CredentialProtectionPolicy.USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST, uvResult = false))).isTrue()
+        }
+
+        //spec| 12.2 Else (implying the credential's credProtect value is userVerificationRequired):
+        //spec|   12.2.2 Else (implying user verification was not collected in Step 11), remove the credential from
+        //spec|   the excludeList and continue parsing the rest of the list.
+        @Test
+        fun level3_no_uv_hidden() {
+            assertThat(processor.test(makeCredentialContext(CredentialProtectionPolicy.USER_VERIFICATION_REQUIRED, uvResult = false))).isFalse()
+        }
+
+        //spec| 12.2.1 If the "uv" bit is true in the response:
+        @Test
+        fun level3_with_uv_visible() {
+            assertThat(processor.test(makeCredentialContext(CredentialProtectionPolicy.USER_VERIFICATION_REQUIRED, uvResult = true))).isTrue()
+        }
+
+        // Default when credProtect is not set — same as Level 1
+        @Test
+        fun no_policy_defaults_to_level1_always_visible() {
+            assertThat(processor.test(makeCredentialContext(null, uvResult = false))).isTrue()
+        }
+    }
+}


### PR DESCRIPTION
- Add `isCredentialVisible()` to `AuthenticationExtensionProcessor` with default `true` for backward compatibility
- `CredProtectExtensionProcessor` stores the credential protection level in `credential.details` during MakeCredential and echoes it in the authenticator data extensions output
- GetAssertion Step 7.4/7.5: filter credentials from the applicable list based on their credProtect level, UV status, and allowList presence
- MakeCredential Step 12: skip `userVerificationRequired` credentials in the excludeList when UV will not be performed