### PR TITLE
Add UHID bridge module for virtual FIDO2 devices on Linux

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ plugins {
     id(libs.plugins.sonarqube.get().pluginId) version libs.versions.sonarqube
     id(libs.plugins.jreleaser.get().pluginId) version libs.versions.jreleaser
     id(libs.plugins.ksp.get().pluginId) version libs.versions.ksp apply false
+    id(libs.plugins.kotlin.plugin.allopen.get().pluginId) version libs.versions.kotlin apply false
+    id(libs.plugins.quarkus.get().pluginId) version libs.versions.quarkus apply false
 }
 
 private val webAuthn4JCTAPVersion: String by project
@@ -39,14 +41,16 @@ repositories {
 
 
 subprojects {
+    if (name.endsWith("-sample") || name.startsWith("unifidokey-")) return@subprojects
+
     apply(plugin = "signing")
     apply(plugin = "maven-publish")
-
     apply(plugin = "java-library")
+    apply(plugin = "org.jreleaser")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "jacoco")
-    apply(plugin = "org.jreleaser")
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
         maven(url = "https://jitpack.io")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
 kotlin = "2.4.0"
 
-kotlinx-coroutines = "1.11.0"
+kotlinx-coroutines = "1.10.2"
+
+quarkus = "3.35.4"
 
 webauthn4j = "0.31.6.RELEASE"
 
@@ -71,3 +73,4 @@ asciidoctor = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor"}
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+quarkus = { id = "io.quarkus", version.ref = "quarkus" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
 include(":webauthn4j-ctap-core")
 include(":webauthn4j-ctap-authenticator")
 include(":webauthn4j-ctap-client")
+include(":webauthn4j-ctap-authenticator-uhid")
+include(":unifidokey-uhid")

--- a/unifidokey-uhid/README.md
+++ b/unifidokey-uhid/README.md
@@ -1,0 +1,40 @@
+# unifidokey-uhid
+
+CLI application that creates a virtual FIDO2 security key on Linux via UHID.
+
+## Quick Start
+
+```bash
+# Build
+./gradlew :unifidokey-uhid:quarkusBuild
+
+# Run (requires root or udev rules for /dev/uhid access)
+sudo java -jar unifidokey-uhid/build/unifidokey-uhid.jar
+```
+
+## CLI Options
+
+```
+Usage: webauthn4j-uhid [-hV] [-d=<devicePath>]
+  -d, --device=<devicePath>   UHID device path (default: /dev/uhid)
+  -h, --help                  Show this help message and exit.
+  -V, --version               Print version information and exit.
+```
+
+## Verifying the Device
+
+```bash
+ls /dev/hidraw*
+fido2-token -L
+```
+
+## Permissions
+
+Run with `sudo`, or create a udev rule:
+
+```bash
+sudo usermod -a -G input $USER
+echo 'KERNEL=="uhid", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/99-uhid.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+# Log out and back in
+```

--- a/unifidokey-uhid/build.gradle.kts
+++ b/unifidokey-uhid/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+    id(libs.plugins.kotlin.plugin.allopen.get().pluginId)
+    id(libs.plugins.quarkus.get().pluginId)
+}
+
+description = "Sample application demonstrating CTAP UHID bridge on Linux"
+
+repositories {
+    mavenCentral()
+}
+
+allOpen {
+    annotation("jakarta.enterprise.context.ApplicationScoped")
+}
+
+dependencies {
+    implementation(project(":webauthn4j-ctap-authenticator-uhid"))
+    implementation(project(":webauthn4j-ctap-authenticator"))
+    implementation(libs.kotlinx.coroutines.core)
+
+    implementation(enforcedPlatform("io.quarkus.platform:quarkus-bom:${libs.versions.quarkus.get()}"))
+    implementation("io.quarkus:quarkus-kotlin")
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-picocli")
+}

--- a/unifidokey-uhid/src/main/kotlin/com/webauthn4j/unifidokey/uhid/UniFIDOKeyUHID.kt
+++ b/unifidokey-uhid/src/main/kotlin/com/webauthn4j/unifidokey/uhid/UniFIDOKeyUHID.kt
@@ -1,0 +1,59 @@
+package com.webauthn4j.unifidokey.uhid
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDDevice
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDDeviceConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.jboss.logging.Logger
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import java.io.File
+import kotlin.system.exitProcess
+
+@Command(name = "unifidokey-uhid", mixinStandardHelpOptions = true,
+    description = ["Virtual FIDO2 security key via Linux UHID"])
+class UniFIDOKeyUHID : Runnable {
+
+    @Option(names = ["-d", "--device"], description = ["UHID device path (default: /dev/uhid)"])
+    var devicePath: String = "/dev/uhid"
+
+    private val logger = Logger.getLogger(UniFIDOKeyUHID::class.java)
+
+    override fun run() {
+        checkDeviceAccess()
+
+        val config = UHIDDeviceConfig(devicePath = devicePath)
+        val authenticator = CtapAuthenticator()
+        val device = UHIDDevice(authenticator, config)
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        Runtime.getRuntime().addShutdownHook(Thread {
+            runBlocking { device.stop() }
+        })
+
+        runBlocking {
+            device.start(scope)
+        }
+
+        logger.info("UHID Virtual FIDO2 Device is running")
+        logger.infof("  Device path: %s", config.devicePath)
+
+        // Keep running until interrupted
+        Thread.currentThread().join()
+    }
+
+    private fun checkDeviceAccess() {
+        val uhidFile = File(devicePath)
+        if (!uhidFile.exists()) {
+            logger.errorf("%s does not exist. Make sure your kernel has UHID support (Linux 3.6+).", devicePath)
+            exitProcess(1)
+        }
+        if (!uhidFile.canRead() || !uhidFile.canWrite()) {
+            logger.errorf("No read/write permission on %s. Try running with sudo or configure udev rules.", devicePath)
+            exitProcess(1)
+        }
+    }
+}

--- a/unifidokey-uhid/src/main/resources/application.properties
+++ b/unifidokey-uhid/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.package.jar.type=uber-jar
+quarkus.package.jar.add-runner-suffix=false
+quarkus.package.output-name=unifidokey-uhid
+quarkus.banner.enabled=false
+quarkus.log.console.stderr=true

--- a/webauthn4j-ctap-authenticator-uhid/README.md
+++ b/webauthn4j-ctap-authenticator-uhid/README.md
@@ -24,5 +24,6 @@ device.start(scope)
 | Class | Description |
 |---|---|
 | `UHIDDevice` | Lifecycle management and UHID event loop |
-| `UHIDConnection` | Low-level `/dev/uhid` I/O |
+| `UHIDConnection` | Low-level `/dev/uhid` I/O wrapper |
 | `UHIDDeviceConfig` | Device metadata (name, VID, PID, etc.) |
+| `FidoHIDReportDescriptor` | Standard FIDO HID report descriptor |

--- a/webauthn4j-ctap-authenticator-uhid/README.md
+++ b/webauthn4j-ctap-authenticator-uhid/README.md
@@ -1,0 +1,28 @@
+# webauthn4j-ctap-authenticator-uhid
+
+Library that exposes a `CtapAuthenticator` as a virtual USB HID FIDO2 device via the Linux UHID subsystem.
+
+## Requirements
+
+- Linux kernel 3.6+ with UHID support
+- Java 17+
+- Read/write access to `/dev/uhid`
+
+## Usage
+
+```kotlin
+val authenticator = CtapAuthenticator()
+val device = UHIDDevice(authenticator)
+val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+device.start(scope)
+// The device is now visible as /dev/hidrawN
+```
+
+## Key Classes
+
+| Class | Description |
+|---|---|
+| `UHIDDevice` | Lifecycle management and UHID event loop |
+| `UHIDConnection` | Low-level `/dev/uhid` I/O |
+| `UHIDDeviceConfig` | Device metadata (name, VID, PID, etc.) |

--- a/webauthn4j-ctap-authenticator-uhid/build.gradle.kts
+++ b/webauthn4j-ctap-authenticator-uhid/build.gradle.kts
@@ -1,0 +1,56 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+}
+
+description = "CTAP UHID bridge library for Linux"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions{
+        jvmTarget = JvmTarget.JVM_17
+        javaParameters = true
+    }
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+    jacocoTestReport {
+        reports {
+            xml.required.set(true)
+        }
+    }
+}
+
+dependencies {
+
+    // Project dependencies
+    api(project(":webauthn4j-ctap-authenticator"))
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.slf4j.api)
+
+    // Test dependencies
+    testImplementation(platform(libs.junit.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.logback.classic)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.assertj.core)
+
+    testImplementation(libs.jackson.module.kotlin)
+    testImplementation(libs.jackson.dataformat.cbor)
+    testImplementation(project(":webauthn4j-ctap-client"))
+    testImplementation(libs.webauthn4j.test)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/FidoHIDReportDescriptor.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/FidoHIDReportDescriptor.kt
@@ -1,4 +1,4 @@
-package com.webauthn4j.ctap.authenticator.transport.uhid.usb
+package com.webauthn4j.ctap.authenticator.transport.uhid
 
 /**
  * Standard FIDO HID report descriptor as defined in the CTAP specification.

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDConnection.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDConnection.kt
@@ -1,4 +1,4 @@
-package com.webauthn4j.ctap.authenticator.transport.uhid.usb
+package com.webauthn4j.ctap.authenticator.transport.uhid
 
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
 import java.nio.ByteBuffer

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
@@ -1,0 +1,110 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDTransport
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CreateDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.DestroyDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.InputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CloseEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OpenEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.StartEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.StopEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UnknownEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.FidoHIDReportDescriptor
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.UHIDConnection
+import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.nio.channels.AsynchronousCloseException
+import java.nio.channels.ClosedChannelException
+
+/**
+ * Virtual USB FIDO2 security key backed by the Linux UHID subsystem.
+ *
+ * Exposes a [CtapAuthenticator] to the OS as if it were a physical USB HID
+ * FIDO2 device.
+ */
+class UHIDDevice(
+    ctapAuthenticator: CtapAuthenticator,
+    private val config: UHIDDeviceConfig = UHIDDeviceConfig(),
+    private val connection: UHIDConnection = UHIDConnection(config.devicePath)
+) : AutoCloseable {
+
+    private val logger = LoggerFactory.getLogger(UHIDDevice::class.java)
+    private val hidTransport = HIDTransport(ctapAuthenticator)
+
+    private var readJob: Job? = null
+    private var deviceCreated = false
+
+    suspend fun start(scope: CoroutineScope) {
+        connection.open()
+        createDevice()
+        hidTransport.start(scope)
+        readJob = scope.launch(Dispatchers.IO) {
+            readLoop()
+        }
+    }
+
+    suspend fun stop() {
+        readJob?.cancelAndJoin()
+        readJob = null
+        hidTransport.close()
+        if (deviceCreated) {
+            destroyDevice()
+        }
+        connection.close()
+    }
+
+    override fun close() {
+        runBlocking { stop() }
+    }
+
+    private fun createDevice() {
+        connection.writeEvent(CreateDeviceEvent(config, FidoHIDReportDescriptor.DESCRIPTOR))
+        deviceCreated = true
+        logger.info("Virtual FIDO2 device created: {}", config.deviceName)
+    }
+
+    private fun destroyDevice() {
+        try {
+            connection.writeEvent(DestroyDeviceEvent)
+            logger.info("Virtual FIDO2 device destroyed")
+        } catch (e: IOException) {
+            logger.debug("Failed to send destroy event", e)
+        }
+        deviceCreated = false
+    }
+
+    private suspend fun readLoop() {
+        try {
+            while (currentCoroutineContext().isActive && connection.isOpen) {
+                when (val event = connection.readEvent()) {
+                    is OutputReportEvent -> handleOutput(event)
+                    is StartEvent -> logger.debug("UHID device started")
+                    is StopEvent -> logger.debug("UHID device stopped")
+                    is OpenEvent -> logger.debug("UHID device opened by host")
+                    is CloseEvent -> logger.debug("UHID device closed by host")
+                    is UnknownEvent -> logger.debug("Unknown UHID event type: {}", event.type)
+                    is CreateDeviceEvent, is DestroyDeviceEvent, is InputReportEvent -> {}
+                }
+            }
+        } catch (_: ClosedChannelException) {
+            logger.debug("UHID connection closed")
+        } catch (_: AsynchronousCloseException) {
+            logger.debug("UHID connection closed asynchronously")
+        } catch (e: IOException) {
+            logger.error("I/O error in UHID read loop", e)
+        }
+    }
+
+    private fun handleOutput(output: OutputReportEvent) {
+        logger.debug("UHID_OUTPUT: size={} (actual HID report: {} bytes), rtype={}",
+            output.size, output.data.size, output.rtype)
+        hidTransport.onHIDDataReceived(output.data) { responseBytes ->
+            synchronized(connection) {
+                connection.writeEvent(InputReportEvent(responseBytes))
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDevice.kt
@@ -11,8 +11,8 @@ import com.webauthn4j.ctap.authenticator.transport.uhid.event.OpenEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.StartEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.StopEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.UnknownEvent
-import com.webauthn4j.ctap.authenticator.transport.uhid.usb.FidoHIDReportDescriptor
-import com.webauthn4j.ctap.authenticator.transport.uhid.usb.UHIDConnection
+import com.webauthn4j.ctap.authenticator.transport.uhid.FidoHIDReportDescriptor
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDConnection
 import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 import java.io.IOException
@@ -102,9 +102,9 @@ class UHIDDevice(
         logger.debug("UHID_OUTPUT: size={} (actual HID report: {} bytes), rtype={}",
             output.size, output.data.size, output.rtype)
         hidTransport.onHIDDataReceived(output.data) { responseBytes ->
-            synchronized(connection) {
-                connection.writeEvent(InputReportEvent(responseBytes))
-            }
+            // synchronized: callback fires from HIDTransport's consumer thread,
+            // concurrent with the read loop on Dispatchers.IO
+            synchronized(connection) { connection.writeEvent(InputReportEvent(responseBytes)) }
         }
     }
 }

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceConfig.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceConfig.kt
@@ -1,0 +1,11 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+data class UHIDDeviceConfig(
+    val deviceName: String = "WebAuthn4J Virtual FIDO2 Key",
+    val vendorId: Int = 0x1234,
+    val productId: Int = 0xF1D0,
+    val version: Int = 0x0100,
+    val devicePath: String = "/dev/uhid",
+    val physicalAddress: String = "",
+    val uniqueId: String = ""
+)

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CloseEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CloseEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_CLOSE event: userspace closed the device.
+ */
+data object CloseEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_CLOSE)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CreateDeviceEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/CreateDeviceEvent.kt
@@ -1,0 +1,101 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDDeviceConfig
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * UHID_CREATE2 event: creates a virtual HID device.
+ */
+data class CreateDeviceEvent(
+    val config: UHIDDeviceConfig,
+    val reportDescriptor: ByteArray
+) : UHIDEvent {
+    override fun toBytes(): ByteArray {
+        require(reportDescriptor.size <= RD_DATA_SIZE) {
+            "Report descriptor must not exceed $RD_DATA_SIZE bytes"
+        }
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(UHIDEvent.TYPE_CREATE2)
+        putFixedString(buf, NAME_OFFSET, config.deviceName, NAME_SIZE)
+        putFixedString(buf, PHYS_OFFSET, config.physicalAddress, PHYS_SIZE)
+        putFixedString(buf, UNIQ_OFFSET, config.uniqueId, UNIQ_SIZE)
+        buf.position(RD_SIZE_OFFSET)
+        buf.putShort(reportDescriptor.size.toShort())
+        buf.position(BUS_OFFSET)
+        buf.putShort(BUS_USB)
+        buf.position(VENDOR_OFFSET)
+        buf.putInt(config.vendorId)
+        buf.position(PRODUCT_OFFSET)
+        buf.putInt(config.productId)
+        buf.position(VERSION_OFFSET)
+        buf.putInt(config.version)
+        buf.position(COUNTRY_OFFSET)
+        buf.putInt(0)
+        buf.position(RD_DATA_OFFSET)
+        buf.put(reportDescriptor)
+        return buf.array()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CreateDeviceEvent) return false
+        return config == other.config && reportDescriptor.contentEquals(other.reportDescriptor)
+    }
+
+    override fun hashCode(): Int = 31 * config.hashCode() + reportDescriptor.contentHashCode()
+
+    companion object {
+        private const val NAME_OFFSET = 4
+        private const val NAME_SIZE = 128
+        private const val PHYS_OFFSET = 132
+        private const val PHYS_SIZE = 64
+        private const val UNIQ_OFFSET = 196
+        private const val UNIQ_SIZE = 64
+        private const val RD_SIZE_OFFSET = 260
+        private const val BUS_OFFSET = 262
+        private const val VENDOR_OFFSET = 264
+        private const val PRODUCT_OFFSET = 268
+        private const val VERSION_OFFSET = 272
+        private const val COUNTRY_OFFSET = 276
+        private const val RD_DATA_OFFSET = 280
+        private const val RD_DATA_SIZE = 4096
+        private const val BUS_USB: Short = 0x03
+
+        fun parse(eventBytes: ByteArray): CreateDeviceEvent {
+            require(eventBytes.size == UHIDEvent.EVENT_SIZE) { "Event must be ${UHIDEvent.EVENT_SIZE} bytes" }
+            val buf = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN)
+            val name = readFixedString(buf, NAME_OFFSET, NAME_SIZE)
+            val phys = readFixedString(buf, PHYS_OFFSET, PHYS_SIZE)
+            val uniq = readFixedString(buf, UNIQ_OFFSET, UNIQ_SIZE)
+            val rdSize = buf.getShort(RD_SIZE_OFFSET).toInt() and 0xFFFF
+            val vendorId = buf.getInt(VENDOR_OFFSET)
+            val productId = buf.getInt(PRODUCT_OFFSET)
+            val version = buf.getInt(VERSION_OFFSET)
+            val rdData = ByteArray(rdSize)
+            buf.position(RD_DATA_OFFSET)
+            buf.get(rdData)
+            val config = UHIDDeviceConfig(
+                deviceName = name, vendorId = vendorId, productId = productId,
+                version = version, physicalAddress = phys, uniqueId = uniq
+            )
+            return CreateDeviceEvent(config, rdData)
+        }
+
+        private fun readFixedString(buf: ByteBuffer, offset: Int, maxLen: Int): String {
+            val bytes = ByteArray(maxLen)
+            buf.position(offset)
+            buf.get(bytes)
+            val nullIndex = bytes.indexOf(0)
+            val endIndex = if (nullIndex >= 0) nullIndex else bytes.size
+            return String(bytes, 0, endIndex, Charsets.UTF_8)
+        }
+
+        private fun putFixedString(buf: ByteBuffer, offset: Int, str: String, maxLen: Int) {
+            val bytes = str.toByteArray(Charsets.UTF_8)
+            val len = minOf(bytes.size, maxLen - 1)
+            buf.position(offset)
+            buf.put(bytes, 0, len)
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/DestroyDeviceEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/DestroyDeviceEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_DESTROY event: removes the virtual HID device.
+ */
+data object DestroyDeviceEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_DESTROY)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/InputReportEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/InputReportEvent.kt
@@ -1,0 +1,44 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * UHID_INPUT2 event: sends a HID report from device to host.
+ */
+data class InputReportEvent(
+    val data: ByteArray
+) : UHIDEvent {
+    override fun toBytes(): ByteArray {
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(UHIDEvent.TYPE_INPUT2)
+        buf.position(SIZE_OFFSET)
+        buf.putShort(data.size.toShort())
+        buf.position(DATA_OFFSET)
+        buf.put(data)
+        return buf.array()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InputReportEvent) return false
+        return data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int = data.contentHashCode()
+
+    companion object {
+        private const val SIZE_OFFSET = 4
+        private const val DATA_OFFSET = 6
+
+        fun parse(eventBytes: ByteArray): InputReportEvent {
+            require(eventBytes.size == UHIDEvent.EVENT_SIZE) { "Event must be ${UHIDEvent.EVENT_SIZE} bytes" }
+            val buf = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN)
+            val size = buf.getShort(SIZE_OFFSET).toInt() and 0xFFFF
+            val data = ByteArray(size)
+            buf.position(DATA_OFFSET)
+            buf.get(data)
+            return InputReportEvent(data)
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OpenEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OpenEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_OPEN event: userspace opened the device.
+ */
+data object OpenEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_OPEN)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OutputReportEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/OutputReportEvent.kt
@@ -1,0 +1,57 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * UHID_OUTPUT event: receives a HID report from host to device.
+ */
+data class OutputReportEvent(
+    val data: ByteArray,
+    val size: Int,
+    val rtype: Byte
+) : UHIDEvent {
+    override fun toBytes(): ByteArray {
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(UHIDEvent.TYPE_OUTPUT)
+        buf.position(DATA_OFFSET)
+        buf.put(data)
+        buf.position(SIZE_OFFSET)
+        buf.putShort(size.toShort())
+        buf.put(rtype)
+        return buf.array()
+    }
+
+    companion object {
+        private const val DATA_OFFSET = 4
+        private const val SIZE_OFFSET = 4100
+        private const val RTYPE_OFFSET = 4102
+
+        fun parse(eventBytes: ByteArray): OutputReportEvent {
+            require(eventBytes.size == UHIDEvent.EVENT_SIZE) { "Event must be ${UHIDEvent.EVENT_SIZE} bytes" }
+            val buf = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN)
+            val size = buf.getShort(SIZE_OFFSET).toInt() and 0xFFFF
+            val rtype = buf.get(RTYPE_OFFSET)
+
+            val reportSize = minOf(size, 64)
+            val data = ByteArray(reportSize)
+            buf.position(DATA_OFFSET)
+            buf.get(data, 0, reportSize)
+
+            return OutputReportEvent(data, size, rtype)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OutputReportEvent) return false
+        return size == other.size && rtype == other.rtype && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int {
+        var result = data.contentHashCode()
+        result = 31 * result + size
+        result = 31 * result + rtype.hashCode()
+        return result
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StartEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StartEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_START event: kernel started the device.
+ */
+data object StartEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_START)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StopEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/StopEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * UHID_STOP event: kernel stopped the device.
+ */
+data object StopEvent : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(UHIDEvent.TYPE_STOP)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UHIDEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UHIDEvent.kt
@@ -1,0 +1,48 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Base type for all UHID events.
+ * All uhid_event structs are fixed-size (4380 bytes), little-endian.
+ */
+sealed interface UHIDEvent {
+
+    fun toBytes(): ByteArray
+
+    companion object {
+        const val EVENT_SIZE = 4380
+
+        internal const val TYPE_DESTROY = 1
+        internal const val TYPE_START = 2
+        internal const val TYPE_STOP = 3
+        internal const val TYPE_OPEN = 4
+        internal const val TYPE_CLOSE = 5
+        internal const val TYPE_OUTPUT = 6
+        internal const val TYPE_CREATE2 = 11
+        internal const val TYPE_INPUT2 = 12
+
+        fun parse(eventBytes: ByteArray): UHIDEvent {
+            require(eventBytes.size == EVENT_SIZE) { "Event must be $EVENT_SIZE bytes" }
+            val type = ByteBuffer.wrap(eventBytes).order(ByteOrder.LITTLE_ENDIAN).getInt(0)
+            return when (type) {
+                TYPE_DESTROY -> DestroyDeviceEvent
+                TYPE_START -> StartEvent
+                TYPE_STOP -> StopEvent
+                TYPE_OPEN -> OpenEvent
+                TYPE_CLOSE -> CloseEvent
+                TYPE_OUTPUT -> OutputReportEvent.parse(eventBytes)
+                TYPE_CREATE2 -> CreateDeviceEvent.parse(eventBytes)
+                TYPE_INPUT2 -> InputReportEvent.parse(eventBytes)
+                else -> UnknownEvent(type)
+            }
+        }
+
+        internal fun createSimpleEvent(type: Int): ByteArray {
+            val buf = ByteBuffer.allocate(EVENT_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+            buf.putInt(type)
+            return buf.array()
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UnknownEvent.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/event/UnknownEvent.kt
@@ -1,0 +1,8 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.event
+
+/**
+ * Unknown UHID event type.
+ */
+data class UnknownEvent(val type: Int) : UHIDEvent {
+    override fun toBytes(): ByteArray = UHIDEvent.createSimpleEvent(type)
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/FidoHIDReportDescriptor.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/FidoHIDReportDescriptor.kt
@@ -1,0 +1,26 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.usb
+
+/**
+ * Standard FIDO HID report descriptor as defined in the CTAP specification.
+ * Registers a FIDO Alliance Usage Page (0xF1D0) device with 64-byte input and output reports.
+ */
+object FidoHIDReportDescriptor {
+    val DESCRIPTOR: ByteArray = byteArrayOf(
+        0x06, 0xD0.toByte(), 0xF1.toByte(),   // Usage Page (FIDO Alliance = 0xF1D0)
+        0x09, 0x01,                             // Usage (U2F HID Authenticator Device)
+        0xA1.toByte(), 0x01,                    // Collection (Application)
+        0x09, 0x20,                             //   Usage (Input Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x81.toByte(), 0x02,                    //   Input (Data, Var, Abs)
+        0x09, 0x21,                             //   Usage (Output Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x91.toByte(), 0x02,                    //   Output (Data, Var, Abs)
+        0xC0.toByte()                           // End Collection
+    )
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/UHIDConnection.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/usb/UHIDConnection.kt
@@ -1,0 +1,60 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid.usb
+
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * Low-level I/O wrapper for /dev/uhid.
+ * Reads and writes fixed-size uhid_event structs via FileChannel.
+ */
+open class UHIDConnection(private val devicePath: String = "/dev/uhid") : AutoCloseable {
+
+    private var channel: FileChannel? = null
+
+    open fun open() {
+        channel = FileChannel.open(
+            Path.of(devicePath),
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE
+        )
+    }
+
+    open fun writeEvent(event: UHIDEvent) {
+        writeBytes(event.toBytes())
+    }
+
+    open fun readEvent(): UHIDEvent {
+        return UHIDEvent.parse(readBytes())
+    }
+
+    open val isOpen: Boolean
+        get() = channel?.isOpen == true
+
+    override fun close() {
+        channel?.close()
+        channel = null
+    }
+
+    private fun writeBytes(bytes: ByteArray) {
+        val ch = channel ?: throw IllegalStateException("Connection is not open")
+        val buf = ByteBuffer.wrap(bytes)
+        while (buf.hasRemaining()) {
+            ch.write(buf)
+        }
+    }
+
+    private fun readBytes(): ByteArray {
+        val ch = channel ?: throw IllegalStateException("Connection is not open")
+        val buf = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+        while (buf.hasRemaining()) {
+            val bytesRead = ch.read(buf)
+            if (bytesRead == -1) {
+                throw java.io.IOException("End of stream reached on $devicePath")
+            }
+        }
+        return buf.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceTest.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceTest.kt
@@ -1,0 +1,307 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDResponseMessageBuilder
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CreateDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.InputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.UHIDConnection
+import com.webauthn4j.ctap.core.converter.CtapRequestConverter
+import com.webauthn4j.ctap.core.data.*
+import com.webauthn4j.ctap.core.data.hid.*
+import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.DEFAULT_PACKET_SIZE
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialParameters
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorInputs
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorInput
+import kotlinx.coroutines.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+internal class UHIDDeviceTest {
+
+    private class FakeUHIDConnection : UHIDConnection() {
+        val writtenEvents = ConcurrentLinkedQueue<UHIDEvent>()
+        private val inputQueue = LinkedBlockingQueue<UHIDEvent>()
+        @Volatile
+        private var opened = false
+        @Volatile
+        private var closed = false
+
+        override fun open() { opened = true }
+
+        fun enqueueEvent(event: UHIDEvent) { inputQueue.put(event) }
+
+        override fun readEvent(): UHIDEvent {
+            while (!closed) {
+                val event = inputQueue.poll(100, TimeUnit.MILLISECONDS)
+                if (event != null) return event
+            }
+            throw java.io.IOException("Connection closed")
+        }
+
+        override fun writeEvent(event: UHIDEvent) {
+            writtenEvents.add(event)
+        }
+
+        override val isOpen: Boolean get() = opened && !closed
+
+        override fun close() { closed = true }
+    }
+
+    /**
+     * Helper that handles UHID ↔ HID packet translation for tests.
+     */
+    private class TestHIDClient(private val connection: FakeUHIDConnection) {
+
+        fun sendHIDPackets(packets: List<HIDPacket>) {
+            for (packet in packets) {
+                val packetBytes = packet.toBytes()
+                connection.enqueueEvent(OutputReportEvent(packetBytes, packetBytes.size, 0x00))
+            }
+        }
+
+        fun collectResponseHIDPackets(timeoutMs: Long = 2000): List<ByteArray> {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            val packets = mutableListOf<ByteArray>()
+            Thread.sleep(minOf(timeoutMs, 500))
+            while (System.currentTimeMillis() < deadline) {
+                val event = connection.writtenEvents.poll() ?: break
+                if (event is InputReportEvent) {
+                    packets.add(event.data)
+                }
+            }
+            return packets
+        }
+
+        fun performCtapHIDInit(): HIDChannelId {
+            val nonce = ByteArray(8) { (it + 1).toByte() }
+            val initMessage = HIDINITRequestMessage(HIDChannelId.BROADCAST, nonce)
+            sendHIDPackets(initMessage.toHIDPackets(DEFAULT_PACKET_SIZE))
+            val responsePackets = collectResponseHIDPackets()
+            assertThat(responsePackets).isNotEmpty()
+
+            // Parse the INIT response to extract channel ID
+            val hidPacket = responsePackets.first()
+            // Channel ID is at bytes 15-18 of the INIT response data
+            // Packet layout: CID(4) + CMD(1) + LEN(2) + DATA(...)
+            // INIT response data: nonce(8) + channelId(4) + ...
+            val channelIdBytes = hidPacket.copyOfRange(15, 19)
+            return HIDChannelId(channelIdBytes)
+        }
+
+        fun sendCborCommand(channelId: HIDChannelId, ctapCommand: CtapCommand, cborData: ByteArray) {
+            val message = HIDCBORRequestMessage(channelId, ctapCommand, cborData)
+            sendHIDPackets(message.toHIDPackets(DEFAULT_PACKET_SIZE))
+        }
+
+        fun collectCborResponse(timeoutMs: Long = 3000): Pair<Byte, ByteArray> {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            val builder = HIDResponseMessageBuilder()
+
+            // Wait for processing to begin
+            Thread.sleep(500)
+
+            while (System.currentTimeMillis() < deadline) {
+                val event = connection.writtenEvents.poll()
+                if (event == null) {
+                    Thread.sleep(50)
+                    continue
+                }
+
+                if (event !is InputReportEvent) continue
+                val packetBytes = event.data
+
+                // Check if this is a keepalive (command 0xBB = KEEPALIVE | 0x80)
+                if (packetBytes.size >= 5 && packetBytes[4] == (HIDCommand.CTAPHID_KEEPALIVE.value.toInt() or 0x80).toByte()) {
+                    continue // Skip keepalive
+                }
+
+                // Parse HID packet
+                val hidPacket = com.webauthn4j.ctap.core.converter.HIDPacketConverter().convert(packetBytes)
+                when (hidPacket) {
+                    is HIDInitializationPacket -> builder.initialize(hidPacket)
+                    is HIDContinuationPacket -> builder.append(hidPacket)
+                }
+
+                if (builder.isCompleted) {
+                    val message = builder.build()
+                    val data = message.data
+                    // data[0] = status code, data[1..] = CBOR response
+                    val statusCode = data[0]
+                    val cborResponse = if (data.size > 1) data.copyOfRange(1, data.size) else ByteArray(0)
+                    return Pair(statusCode, cborResponse)
+                }
+            }
+            throw AssertionError("Timed out waiting for CBOR response")
+        }
+    }
+
+    private val objectConverter = ObjectConverter()
+    private val ctapRequestConverter = CtapRequestConverter(objectConverter)
+
+    @Test
+    fun start_createsDevice() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+
+            val createEvent = fakeConnection.writtenEvents.poll()
+            assertThat(createEvent).isInstanceOf(CreateDeviceEvent::class.java)
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun ctaphidInit_returnsResponse() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+            fakeConnection.writtenEvents.clear()
+
+            val client = TestHIDClient(fakeConnection)
+            val channelId = client.performCtapHIDInit()
+
+            assertThat(channelId).isNotEqualTo(HIDChannelId.BROADCAST)
+            assertThat(channelId.value).isNotEqualTo(ByteArray(4)) // Not all zeros
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun makeCredential_returnsSuccess() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+            fakeConnection.writtenEvents.clear()
+
+            val client = TestHIDClient(fakeConnection)
+
+            // Step 1: CTAPHID_INIT to allocate a channel
+            val channelId = client.performCtapHIDInit()
+
+            // Step 2: Build MakeCredential request
+            val request = AuthenticatorMakeCredentialRequest(
+                clientDataHash = ByteArray(32),
+                rp = CtapPublicKeyCredentialRpEntity("example.com", "Example", null),
+                user = CtapPublicKeyCredentialUserEntity(
+                    byteArrayOf(0x01, 0x02, 0x03), "user@example.com", "Test User", null
+                ),
+                pubKeyCredParams = listOf(
+                    PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                    )
+                ),
+                excludeList = emptyList(),
+                extensions = AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>(),
+                options = AuthenticatorMakeCredentialRequest.Options(rk = false, uv = false),
+                pinAuth = null,
+                pinProtocol = null
+            )
+            val requestBytes = ctapRequestConverter.convertToBytes(request)
+            val ctapCommandByte = requestBytes[0]
+            val cborData = requestBytes.copyOfRange(1, requestBytes.size)
+
+            // Step 3: Send CTAPHID_CBOR command
+            client.sendCborCommand(channelId, CtapCommand(ctapCommandByte), cborData)
+
+            // Step 4: Collect response
+            val (statusCode, _) = client.collectCborResponse()
+
+            // Step 5: Verify
+            assertThat(statusCode).isEqualTo(CtapStatusCode.CTAP2_OK.byte)
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun getAssertion_afterMakeCredential_returnsSuccess() = runBlocking {
+        val authenticator = CtapAuthenticator()
+        val fakeConnection = FakeUHIDConnection()
+        val bridge = UHIDDevice(authenticator, connection = fakeConnection)
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            bridge.start(scope)
+            delay(100)
+            fakeConnection.writtenEvents.clear()
+
+            val client = TestHIDClient(fakeConnection)
+            val channelId = client.performCtapHIDInit()
+
+            // -- MakeCredential --
+            val rpId = "example.com"
+            val makeCredRequest = AuthenticatorMakeCredentialRequest(
+                clientDataHash = ByteArray(32),
+                rp = CtapPublicKeyCredentialRpEntity(rpId, "Example", null),
+                user = CtapPublicKeyCredentialUserEntity(
+                    byteArrayOf(0x01, 0x02, 0x03), "user@example.com", "Test User", null
+                ),
+                pubKeyCredParams = listOf(
+                    PublicKeyCredentialParameters(
+                        PublicKeyCredentialType.PUBLIC_KEY,
+                        COSEAlgorithmIdentifier.ES256
+                    )
+                ),
+                excludeList = emptyList(),
+                extensions = AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>(),
+                options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = false),
+                pinAuth = null,
+                pinProtocol = null
+            )
+            val makeCredBytes = ctapRequestConverter.convertToBytes(makeCredRequest)
+            client.sendCborCommand(channelId, CtapCommand(makeCredBytes[0]), makeCredBytes.copyOfRange(1, makeCredBytes.size))
+            val (makeCredStatus, _) = client.collectCborResponse()
+            assertThat(makeCredStatus).isEqualTo(CtapStatusCode.CTAP2_OK.byte)
+
+            // -- GetAssertion --
+            val getAssertionRequest = AuthenticatorGetAssertionRequest(
+                rpId = rpId,
+                clientDataHash = ByteArray(32),
+                allowList = emptyList(),
+                extensions = null,
+                options = AuthenticatorGetAssertionRequest.Options(up = true, uv = false),
+                pinAuth = null,
+                pinProtocol = null
+            )
+            val getAssertionBytes = ctapRequestConverter.convertToBytes(getAssertionRequest)
+            client.sendCborCommand(channelId, CtapCommand(getAssertionBytes[0]), getAssertionBytes.copyOfRange(1, getAssertionBytes.size))
+            val (getAssertionStatus, _) = client.collectCborResponse()
+            assertThat(getAssertionStatus).isEqualTo(CtapStatusCode.CTAP2_OK.byte)
+        } finally {
+            bridge.stop()
+            scope.cancel()
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceTest.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDDeviceTest.kt
@@ -7,7 +7,7 @@ import com.webauthn4j.ctap.authenticator.transport.uhid.event.CreateDeviceEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.InputReportEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
-import com.webauthn4j.ctap.authenticator.transport.uhid.usb.UHIDConnection
+import com.webauthn4j.ctap.authenticator.transport.uhid.UHIDConnection
 import com.webauthn4j.ctap.core.converter.CtapRequestConverter
 import com.webauthn4j.ctap.core.data.*
 import com.webauthn4j.ctap.core.data.hid.*

--- a/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDEventTest.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDEventTest.kt
@@ -1,0 +1,161 @@
+package com.webauthn4j.ctap.authenticator.transport.uhid
+
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.CreateDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.DestroyDeviceEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.InputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.StartEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.event.UnknownEvent
+import com.webauthn4j.ctap.authenticator.transport.uhid.usb.FidoHIDReportDescriptor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+internal class UHIDEventTest {
+
+    @Test
+    fun createDeviceEvent_setsTypeAndFields() {
+        val config = UHIDDeviceConfig(
+            deviceName = "TestDevice",
+            vendorId = 0x0525,
+            productId = 0xF025,
+            version = 0x0100,
+            physicalAddress = "phys",
+            uniqueId = "uniq"
+        )
+        val rdesc = FidoHIDReportDescriptor.DESCRIPTOR
+
+        val event = CreateDeviceEvent(config, rdesc).toBytes()
+
+        assertThat(event.size).isEqualTo(UHIDEvent.EVENT_SIZE)
+
+        val buf = ByteBuffer.wrap(event).order(ByteOrder.LITTLE_ENDIAN)
+
+        // type = UHID_CREATE2 (11)
+        assertThat(buf.getInt(0)).isEqualTo(11)
+
+        // name
+        val nameBytes = ByteArray(128)
+        buf.position(4)
+        buf.get(nameBytes)
+        val name = String(nameBytes, Charsets.UTF_8).trimEnd('\u0000')
+        assertThat(name).isEqualTo("TestDevice")
+
+        // phys
+        val physBytes = ByteArray(64)
+        buf.position(132)
+        buf.get(physBytes)
+        val phys = String(physBytes, Charsets.UTF_8).trimEnd('\u0000')
+        assertThat(phys).isEqualTo("phys")
+
+        // uniq
+        val uniqBytes = ByteArray(64)
+        buf.position(196)
+        buf.get(uniqBytes)
+        val uniq = String(uniqBytes, Charsets.UTF_8).trimEnd('\u0000')
+        assertThat(uniq).isEqualTo("uniq")
+
+        // rd_size
+        val rdSize = buf.getShort(260).toInt() and 0xFFFF
+        assertThat(rdSize).isEqualTo(rdesc.size)
+
+        // bus
+        assertThat(buf.getShort(262)).isEqualTo(0x03.toShort()) // BUS_USB
+
+        // vendor, product, version
+        assertThat(buf.getInt(264)).isEqualTo(0x0525)
+        assertThat(buf.getInt(268)).isEqualTo(0xF025)
+        assertThat(buf.getInt(272)).isEqualTo(0x0100)
+
+        // country
+        assertThat(buf.getInt(276)).isEqualTo(0)
+
+        // rd_data
+        val rdData = ByteArray(rdesc.size)
+        buf.position(280)
+        buf.get(rdData)
+        assertThat(rdData).isEqualTo(rdesc)
+    }
+
+    @Test
+    fun inputReportEvent_setsTypeAndData() {
+        val data = ByteArray(64) { it.toByte() }
+        val event = InputReportEvent(data).toBytes()
+
+        assertThat(event.size).isEqualTo(UHIDEvent.EVENT_SIZE)
+
+        val buf = ByteBuffer.wrap(event).order(ByteOrder.LITTLE_ENDIAN)
+        // type = UHID_INPUT2 (12)
+        assertThat(buf.getInt(0)).isEqualTo(12)
+        assertThat(buf.getShort(4).toInt() and 0xFFFF).isEqualTo(64)
+
+        val readData = ByteArray(64)
+        buf.position(6)
+        buf.get(readData)
+        assertThat(readData).isEqualTo(data)
+    }
+
+    @Test
+    fun destroyDeviceEvent_setsType() {
+        val event = DestroyDeviceEvent.toBytes()
+
+        assertThat(event.size).isEqualTo(UHIDEvent.EVENT_SIZE)
+
+        val buf = ByteBuffer.wrap(event).order(ByteOrder.LITTLE_ENDIAN)
+        // type = UHID_DESTROY (1)
+        assertThat(buf.getInt(0)).isEqualTo(1)
+    }
+
+    @Test
+    fun parse_returnsOutputReportEvent() {
+        val reportData = ByteArray(64) { (it + 0x10).toByte() }
+        val eventBytes = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .apply {
+                putInt(6) // UHID_OUTPUT
+                position(4)
+                put(reportData)
+                position(4100)
+                putShort(64)
+                put(0x00)
+            }
+            .array()
+
+        val event = UHIDEvent.parse(eventBytes)
+
+        assertThat(event).isInstanceOf(OutputReportEvent::class.java)
+        val output = event as OutputReportEvent
+        assertThat(output.size).isEqualTo(64)
+        assertThat(output.data).isEqualTo(reportData)
+        assertThat(output.rtype).isEqualTo(0x00.toByte())
+    }
+
+    @Test
+    fun parse_returnsStartEvent() {
+        val eventBytes = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(2) // UHID_START
+            .array()
+
+        assertThat(UHIDEvent.parse(eventBytes)).isEqualTo(StartEvent)
+    }
+
+    @Test
+    fun parse_returnsUnknownForUnknownType() {
+        val eventBytes = ByteBuffer.allocate(UHIDEvent.EVENT_SIZE)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(99)
+            .array()
+
+        val event = UHIDEvent.parse(eventBytes)
+        assertThat(event).isInstanceOf(UnknownEvent::class.java)
+        assertThat((event as UnknownEvent).type).isEqualTo(99)
+    }
+
+    @Test
+    fun fidoHIDReportDescriptor_hasExpectedSize() {
+        assertThat(FidoHIDReportDescriptor.DESCRIPTOR.size).isEqualTo(34)
+    }
+}

--- a/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDEventTest.kt
+++ b/webauthn4j-ctap-authenticator-uhid/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/uhid/UHIDEventTest.kt
@@ -7,7 +7,7 @@ import com.webauthn4j.ctap.authenticator.transport.uhid.event.OutputReportEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.StartEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.UHIDEvent
 import com.webauthn4j.ctap.authenticator.transport.uhid.event.UnknownEvent
-import com.webauthn4j.ctap.authenticator.transport.uhid.usb.FidoHIDReportDescriptor
+import com.webauthn4j.ctap.authenticator.transport.uhid.FidoHIDReportDescriptor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer


### PR DESCRIPTION
Add webauthn4j-ctap-authenticator-uhid library and unifidokey-uhid application that expose a CtapAuthenticator as a native USB HID device via the Linux UHID kernel interface (/dev/uhid).

- UHIDDevice: manages /dev/uhid lifecycle (CREATE, DESTROY, INPUT events)
- UHIDConnection: reads OUTPUT events from the kernel and bridges to HIDTransport
- FIDO HID report descriptor for standard 64-byte HID packets
- unifidokey-uhid: Quarkus CLI app with auto-approve user verification
- Unit tests for UHID event serialization and device lifecycle

Depends on #270 (USB-IP bridge).