### PR TITLE
Fix HIDTransport robustness and thread safety

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -175,6 +175,10 @@ class CtapAuthenticatorSession internal constructor(
         onGoingGetAssertionSession = null
     }
 
+    fun resetVolatileState() {
+        clientPINService.resetVolatilePinRetryCounter()
+    }
+
     internal fun publishEvent(event: Event) {
         eventListeners.forEach { it.onEvent(event) }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
@@ -2,13 +2,18 @@ package com.webauthn4j.ctap.authenticator.transport.hid
 
 import com.webauthn4j.ctap.authenticator.transport.hid.handler.*
 import com.webauthn4j.ctap.core.data.hid.*
+import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.DEFAULT_PACKET_SIZE
+import kotlinx.coroutines.CloseableCoroutineDispatcher
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import org.slf4j.LoggerFactory
+import java.io.Closeable
 
 class HIDChannel(
     private val channelId: HIDChannelId,
     private val scope: CoroutineScope,
+    private val packetSize: Int = DEFAULT_PACKET_SIZE,
+    private val keepAliveWorker: CloseableCoroutineDispatcher,
     private val activeTransactionChannelIdSetter: (HIDChannelId?) -> Unit,
     private val commandTimeSetter: (Long) -> Unit,
     private val initHandler: HIDInitCommandHandler,
@@ -18,10 +23,10 @@ class HIDChannel(
     private val cancelHandler: HIDCancelCommandHandler,
     private val winkHandler: HIDWinkCommandHandler,
     private val lockHandler: HIDLockCommandHandler
-) {
+) : Closeable {
 
     private val logger = LoggerFactory.getLogger(HIDChannel::class.java)
-    private val hidRequestMessageBuilder = HIDRequestMessageBuilder()
+    private val hidRequestMessageBuilder = HIDRequestMessageBuilder(packetSize)
     private var cborCompletion: CompletableDeferred<Unit>? = null
 
     suspend fun handlePacket(
@@ -56,14 +61,14 @@ class HIDChannel(
             try {
                 logger.debug("CTAP Request HID Message: {}", hidMessage)
                 handleMessage(hidMessage) {
-                    it.toHIDPackets().forEach { packet -> responseCallback(packet) }
+                    it.toHIDPackets(packetSize).forEach { packet -> responseCallback(packet) }
                 }
             } catch (e: HIDProtocolException) {
                 activeTransactionChannelIdSetter(null)
                 throw e
             } catch (e: RuntimeException) {
                 logger.error("Unexpected exception is thrown while processing HID message", e)
-                HIDERRORResponseMessage(hidMessage.channelId, HIDErrorCode.OTHER).toHIDPackets()
+                HIDERRORResponseMessage(hidMessage.channelId, HIDErrorCode.OTHER).toHIDPackets(packetSize)
                     .forEach { packet -> responseCallback(packet) }
                 activeTransactionChannelIdSetter(null)
             }
@@ -134,5 +139,15 @@ class HIDChannel(
                 throw HIDProtocolException(HIDErrorCode.INVALID_CMD, "%s is not supported".format(hidMessage.command))
             }
         }
+    }
+
+    suspend fun cancelAndAwaitCbor() {
+        val completion = cborCompletion ?: return
+        cancelHandler.handle()
+        completion.await()
+    }
+
+    override fun close() {
+        keepAliveWorker.close()
     }
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDRequestMessageBuilder.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDRequestMessageBuilder.kt
@@ -16,7 +16,9 @@ import com.webauthn4j.ctap.core.data.hid.HIDStatusCode
 import com.webauthn4j.ctap.core.data.hid.HIDWINKRequestMessage
 import com.webauthn4j.ctap.core.data.nfc.CommandAPDU
 
-class HIDRequestMessageBuilder : HIDMessageBuilderBase<HIDRequestMessage>() {
+class HIDRequestMessageBuilder(
+    packetSize: Int = com.webauthn4j.ctap.core.data.hid.HIDMessage.DEFAULT_PACKET_SIZE
+) : HIDMessageBuilderBase<HIDRequestMessage>(packetSize) {
 
     override fun createMessage(
         channelId: HIDChannelId,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDResponseMessageBuilder.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDResponseMessageBuilder.kt
@@ -14,7 +14,9 @@ import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDStatusCode
 import com.webauthn4j.ctap.core.data.hid.HIDWINKResponseMessage
 
-class HIDResponseMessageBuilder : HIDMessageBuilderBase<HIDResponseMessage>() {
+class HIDResponseMessageBuilder(
+    packetSize: Int = com.webauthn4j.ctap.core.data.hid.HIDMessage.DEFAULT_PACKET_SIZE
+) : HIDMessageBuilderBase<HIDResponseMessage>(packetSize) {
     override fun createMessage(
         channelId: HIDChannelId,
         command: HIDCommand,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
@@ -66,8 +66,10 @@ class HIDTransport(
             hidChannels[id] = createChannel(id)
             return id
         }
-        override fun resyncChannel(channelId: HIDChannelId) {
-            hidChannels.remove(channelId)
+        override suspend fun resyncChannel(channelId: HIDChannelId) {
+            val old = hidChannels.remove(channelId)
+            old?.cancelAndAwaitCbor()
+            old?.close()
             hidChannels[channelId] = createChannel(channelId)
         }
     })
@@ -88,6 +90,8 @@ class HIDTransport(
     override fun close() {
         incomingPackets.close()
         consumerJob?.cancel()
+        hidChannels.values.forEach { it.close() }
+        hidChannels.clear()
     }
 
     fun onHIDDataReceived(bytes: ByteArray, hidPacketHandler: HIDPacketHandler) {
@@ -120,6 +124,12 @@ class HIDTransport(
                         sendError(channelId, HIDErrorCode.INVALID_CHANNEL, hidPacketHandler)
                         return
                     }
+                    val activeChannel = activeTransactionChannelId
+                    if (activeChannel != null) {
+                        logger.debug("Cancelling ongoing CBOR on channel {} before processing broadcast INIT", activeChannel)
+                        hidChannels[activeChannel]?.cancelAndAwaitCbor()
+                    }
+                    ctapAuthenticatorSession.resetVolatileState()
                     val tempChannel = createChannel(channelId)
                     tempChannel.handlePacket(hidPacket) { responsePacket ->
                         logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, responsePacket.toString())
@@ -183,7 +193,7 @@ class HIDTransport(
     }
 
     private fun sendError(channelId: HIDChannelId, errorCode: HIDErrorCode, hidPacketHandler: HIDPacketHandler) {
-        HIDERRORResponseMessage(channelId, errorCode).toHIDPackets()
+        HIDERRORResponseMessage(channelId, errorCode).toHIDPackets(packetSize)
             .forEach {
                 logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, it.toString())
                 hidPacketHandler.onResponse(it.toBytes())
@@ -214,6 +224,8 @@ class HIDTransport(
         return HIDChannel(
             channelId = channelId,
             scope = scope,
+            packetSize = packetSize,
+            keepAliveWorker = keepAliveWorker,
             activeTransactionChannelIdSetter = { activeTransactionChannelId = it },
             commandTimeSetter = { currentCommandStartTimeMs = it },
             initHandler = initHandler,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDInitCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDInitCommandHandler.kt
@@ -26,7 +26,7 @@ class HIDInitCommandHandler(
             HIDCapability((HIDCapability.WINK.value.toInt() or HIDCapability.CBOR.value.toInt()).toByte())
     }
 
-    fun handle(hidMessage: HIDINITRequestMessage): HIDResponseMessage {
+    suspend fun handle(hidMessage: HIDINITRequestMessage): HIDResponseMessage {
         val channelId = hidMessage.channelId
         val nonce = hidMessage.nonce
 
@@ -59,6 +59,6 @@ class HIDInitCommandHandler(
 
     interface ChannelAllocator {
         fun allocateChannel(): HIDChannelId
-        fun resyncChannel(channelId: HIDChannelId)
+        suspend fun resyncChannel(channelId: HIDChannelId)
     }
 }


### PR DESCRIPTION
- Propagate packetSize to HIDChannel and all toHIDPackets() calls
- Fix keepAliveWorker thread leak on channel resync (Closeable on HIDChannel)
- Cancel ongoing CBOR on broadcast CTAPHID_INIT and channel resync to prevent concurrent command execution
- Add resetVolatileState() on CtapAuthenticatorSession for power cycle simulation (volatile PIN retry counter)
- Make resyncChannel suspend to support CBOR cancellation await