### PR TITLE
Add USB-IP bridge module for virtual FIDO2 devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ nbdist/
 ### Project Files ###
 
 .claude/
-metadata.json

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ nbdist/
 
 ### Project Files ###
 
+.claude/
+metadata.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ plugins {
     id(libs.plugins.sonarqube.get().pluginId) version libs.versions.sonarqube
     id(libs.plugins.jreleaser.get().pluginId) version libs.versions.jreleaser
     id(libs.plugins.ksp.get().pluginId) version libs.versions.ksp apply false
+    id(libs.plugins.kotlin.plugin.allopen.get().pluginId) version libs.versions.kotlin apply false
+    id(libs.plugins.quarkus.get().pluginId) version libs.versions.quarkus apply false
 }
 
 private val webAuthn4JCTAPVersion: String by project
@@ -39,13 +41,14 @@ repositories {
 
 
 subprojects {
+    if (name.startsWith("unifidokey-")) return@subprojects
+
     apply(plugin = "signing")
     apply(plugin = "maven-publish")
-
     apply(plugin = "java-library")
+    apply(plugin = "org.jreleaser")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "jacoco")
-    apply(plugin = "org.jreleaser")
     repositories {
         google()
         mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,11 @@
 [versions]
 kotlin = "2.4.0"
 
-kotlinx-coroutines = "1.11.0"
+kotlinx-coroutines = "1.10.2"
+
+ktor = "3.1.3"
+
+quarkus = "3.35.4"
 
 webauthn4j = "0.31.6.RELEASE"
 
@@ -36,8 +40,12 @@ jreleaser = "1.25.0"
 # Kotlin
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
+# Ktor
+ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
+
 # WebAuthn4J
 webauthn4j-core = { module = "com.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
+webauthn4j-metadata = { module = "com.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
 webauthn4j-test = { module = "com.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
 
 # Third-party libraries
@@ -71,3 +79,4 @@ asciidoctor = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor"}
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+quarkus = { id = "io.quarkus", version.ref = "quarkus" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
 include(":webauthn4j-ctap-core")
 include(":webauthn4j-ctap-authenticator")
 include(":webauthn4j-ctap-client")
+include(":webauthn4j-ctap-authenticator-usbip")
+include(":unifidokey-usbip")

--- a/unifidokey-usbip/README.md
+++ b/unifidokey-usbip/README.md
@@ -1,0 +1,54 @@
+# unifidokey-usbip
+
+CLI application that creates a virtual FIDO2 security key over USB/IP. Remote machines (Windows, Linux) can attach it over the network.
+
+## Quick Start
+
+```bash
+# Build
+./gradlew :unifidokey-usbip:quarkusBuild
+
+# Start USB-IP server
+java -jar unifidokey-usbip/build/unifidokey-usbip.jar serve
+
+# Generate FIDO MetadataStatement for Conformance Tools
+java -jar unifidokey-usbip/build/unifidokey-usbip.jar generate-metadata /tmp/metadata.json
+```
+
+## Commands
+
+### serve
+
+Starts the USB-IP server exposing a virtual FIDO2 security key.
+
+```
+Usage: webauthn4j-usbip serve [-hV] [-H=<host>] [-p=<port>]
+  -H, --host=<host>   Bind address (default: 0.0.0.0)
+  -p, --port=<port>   TCP port (default: 3240)
+```
+
+### generate-metadata
+
+Generates a FIDO MetadataStatement JSON file for use with FIDO Conformance Tools.
+The authenticatorGetInfo section is derived from an actual authenticator session.
+
+```
+Usage: webauthn4j-usbip generate-metadata <outputFile>
+```
+
+## Connecting from Linux
+
+```bash
+sudo modprobe vhci-hcd
+usbip list -r <server-ip>
+sudo usbip attach -r <server-ip> -b 1-1
+```
+
+## Connecting from Windows
+
+Install [usbip-win2](https://github.com/vadimgrn/usbip-win2), then:
+
+```powershell
+usbip.exe list -r <server-ip>
+usbip.exe attach -r <server-ip> -b 1-1
+```

--- a/unifidokey-usbip/build.gradle.kts
+++ b/unifidokey-usbip/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+    id(libs.plugins.quarkus.get().pluginId)
+}
+
+description = "Sample application demonstrating CTAP USB-IP server"
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":webauthn4j-ctap-authenticator-usbip"))
+    implementation(project(":webauthn4j-ctap-authenticator"))
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.webauthn4j.metadata)
+
+    implementation(platform("io.quarkus.platform:quarkus-bom:${libs.versions.quarkus.get()}"))
+    implementation("io.quarkus:quarkus-kotlin")
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-picocli")
+}

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserVerificationHandler.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserVerificationHandler.kt
@@ -1,0 +1,42 @@
+package com.webauthn4j.unifidokey.usbip
+
+import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
+import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
+import com.webauthn4j.ctap.authenticator.UserVerificationHandler
+import com.webauthn4j.ctap.core.data.options.UserVerificationOption
+import kotlinx.coroutines.delay
+import org.slf4j.LoggerFactory
+
+/**
+ * A UserVerificationHandler that auto-approves after a delay.
+ * The delay ensures CTAPHID_KEEPALIVE messages are sent by the HID transport layer.
+ */
+class ConsoleUserVerificationHandler : UserVerificationHandler {
+
+    private val logger = LoggerFactory.getLogger(ConsoleUserVerificationHandler::class.java)
+
+    companion object {
+        private const val APPROVAL_DELAY_MS = 1000L
+    }
+
+    override fun getUserVerificationOption(rpId: String?): UserVerificationOption =
+        UserVerificationOption.READY
+
+    override suspend fun onMakeCredentialConsentRequested(
+        makeCredentialConsentRequest: MakeCredentialConsentRequest
+    ): Boolean {
+        val rpId = makeCredentialConsentRequest.rp?.id ?: "unknown"
+        logger.info("MakeCredential consent requested for RP: {} (auto-approving in {}ms)", rpId, APPROVAL_DELAY_MS)
+        delay(APPROVAL_DELAY_MS)
+        return true
+    }
+
+    override suspend fun onGetAssertionConsentRequested(
+        getAssertionConsentRequest: GetAssertionConsentRequest
+    ): Boolean {
+        val rpId = getAssertionConsentRequest.rpId ?: "unknown"
+        logger.info("GetAssertion consent requested for RP: {} (auto-approving in {}ms)", rpId, APPROVAL_DELAY_MS)
+        delay(APPROVAL_DELAY_MS)
+        return true
+    }
+}

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
@@ -1,0 +1,166 @@
+package com.webauthn4j.unifidokey.usbip
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.attestation.DemoAttestationConstants
+import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
+import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
+import com.webauthn4j.ctap.core.data.options.ClientPINOption
+import com.webauthn4j.ctap.core.data.options.PlatformOption
+import com.webauthn4j.ctap.core.data.options.ResidentKeyOption
+import com.webauthn4j.ctap.core.data.options.UserPresenceOption
+import com.webauthn4j.ctap.core.data.options.UserVerificationOption
+import com.webauthn4j.data.AttachmentHint
+import com.webauthn4j.data.AuthenticationAlgorithm
+import com.webauthn4j.data.AuthenticatorAttestationType
+import com.webauthn4j.data.KeyProtectionType
+import com.webauthn4j.data.MatcherProtectionType
+import com.webauthn4j.data.PinProtocolVersion
+import com.webauthn4j.data.PublicKeyRepresentationFormat
+import com.webauthn4j.data.UserVerificationMethod
+import com.webauthn4j.data.attestation.authenticator.AAGUID
+import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule
+import com.webauthn4j.metadata.data.statement.AuthenticatorGetInfo
+import com.webauthn4j.metadata.data.statement.AuthenticatorGetInfo.Options
+import com.webauthn4j.metadata.data.statement.MetadataStatement
+import com.webauthn4j.metadata.data.statement.VerificationMethodANDCombinations
+import com.webauthn4j.metadata.data.statement.VerificationMethodDescriptor
+import com.webauthn4j.metadata.data.statement.Version
+import com.webauthn4j.util.HexUtil
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import picocli.CommandLine.Command
+import picocli.CommandLine.Parameters
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationFeature
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.annotation.JsonSerialize
+import tools.jackson.databind.ser.std.StdSerializer
+import java.io.File
+
+@Command(name = "generate-metadata", mixinStandardHelpOptions = true,
+    description = ["Generate FIDO MetadataStatement JSON for Conformance Tools"])
+class GenerateMetadataStatement : Runnable {
+
+    private val logger = LoggerFactory.getLogger(GenerateMetadataStatement::class.java)
+
+    @Parameters(index = "0", description = ["Output file path for the metadata JSON"])
+    lateinit var outputFile: File
+
+    override fun run() {
+        val authenticator = CtapAuthenticator(
+            attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey(),
+            userVerificationHandler = ConsoleUserVerificationHandler()
+        )
+        val session = authenticator.createSession()
+        val getInfoResponse = runBlocking { session.getInfo() }
+        val getInfo = getInfoResponse.responseData!!
+
+        val metadataGetInfo = toMetadataGetInfo(getInfo)
+
+        val metadataStatement = MetadataStatement(
+            null, // legalHeader
+            null, // aaid
+            getInfo.aaguid,
+            null, // attestationCertificateKeyIdentifiers
+            "UniFIDOKey USB-IP Virtual FIDO2 Authenticator", // description
+            null, // alternativeDescriptions
+            2,    // authenticatorVersion
+            "fido2", // protocolFamily
+            3,    // schema
+            listOf(Version(1, 0)), // upv
+            listOf(AuthenticationAlgorithm.SECP256R1_ECDSA_SHA256_RAW), // authenticationAlgorithms
+            listOf(PublicKeyRepresentationFormat.COSE), // publicKeyAlgAndEncodings
+            listOf(AuthenticatorAttestationType.BASIC_FULL), // attestationTypes
+            listOf( // userVerificationDetails
+                VerificationMethodANDCombinations(listOf(
+                    VerificationMethodDescriptor(UserVerificationMethod.PRESENCE_INTERNAL, null, null, null),
+                )),
+                VerificationMethodANDCombinations(listOf(
+                    VerificationMethodDescriptor(UserVerificationMethod.PASSCODE_INTERNAL, null, null, null),
+                )),
+                VerificationMethodANDCombinations(listOf(
+                    VerificationMethodDescriptor(UserVerificationMethod.PASSCODE_EXTERNAL, null, null, null),
+                ))
+            ),
+            listOf(KeyProtectionType.SOFTWARE), // keyProtection
+            null, // isKeyRestricted
+            null, // isFreshUserVerificationRequired
+            listOf(MatcherProtectionType.ON_CHIP), // matcherProtection
+            null, // cryptoStrength
+            listOf(AttachmentHint.EXTERNAL, AttachmentHint.WIRED), // attachmentHint
+            emptyList(), // tcDisplay
+            null, // tcDisplayContentType
+            null, // tcDisplayPNGCharacteristics
+            listOf(DemoAttestationConstants.DEMO_ROOT_CA_CERTIFICATE), // attestationRootCertificates
+            null, // ecdaaTrustAnchors
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==", // icon (1x1 transparent PNG)
+            null, // supportedExtensions
+            metadataGetInfo
+        )
+
+        val objectConverter = ObjectConverter()
+        val mapper = objectConverter.jsonMapper.rebuild()
+            .addModule(WebAuthnMetadataJSONModule())
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .changeDefaultPropertyInclusion { JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL) }
+            .addMixIn(AuthenticatorGetInfo::class.java, AuthenticatorGetInfoHexAaguidMixIn::class.java)
+            .build()
+        outputFile.writeText(mapper.writeValueAsString(metadataStatement))
+        logger.info("Metadata written to {}", outputFile.absolutePath)
+    }
+
+    abstract class AuthenticatorGetInfoHexAaguidMixIn {
+        @get:JsonSerialize(using = HexAaguidSerializer::class)
+        abstract val aaguid: AAGUID
+    }
+
+    class HexAaguidSerializer : StdSerializer<AAGUID>(AAGUID::class.java) {
+        override fun serialize(value: AAGUID, gen: JsonGenerator, ctxt: SerializationContext) {
+            gen.writeString(HexUtil.encodeToString(value.bytes).lowercase())
+        }
+    }
+
+    companion object {
+        private fun toMetadataGetInfo(getInfo: AuthenticatorGetInfoResponseData): AuthenticatorGetInfo {
+            return AuthenticatorGetInfo(
+                getInfo.versions,
+                getInfo.extensions ?: emptyList(),
+                getInfo.aaguid,
+                getInfo.options?.let { toMetadataOptions(it) },
+                getInfo.maxMsgSize?.toInt(),
+                getInfo.pinProtocols?.map { PinProtocolVersion.create(it.value.toInt()) }
+            )
+        }
+
+        private fun toMetadataOptions(options: AuthenticatorGetInfoResponseData.Options): Options {
+            return Options(
+                when (options.plat) {
+                    PlatformOption.PLATFORM -> Options.PlatformOption.PLATFORM
+                    else -> Options.PlatformOption.CROSS_PLATFORM
+                },
+                when (options.rk) {
+                    ResidentKeyOption.SUPPORTED -> Options.ResidentKeyOption.SUPPORTED
+                    else -> Options.ResidentKeyOption.NOT_SUPPORTED
+                },
+                when (options.clientPin) {
+                    ClientPINOption.SET -> Options.ClientPINOption.SET
+                    ClientPINOption.NOT_SET -> Options.ClientPINOption.NOT_SET
+                    else -> null
+                },
+                when (options.up) {
+                    UserPresenceOption.SUPPORTED -> Options.UserPresenceOption.SUPPORTED
+                    else -> Options.UserPresenceOption.NOT_SUPPORTED
+                },
+                when (options.uv) {
+                    UserVerificationOption.READY -> Options.UserVerificationOption.READY
+                    UserVerificationOption.NOT_READY -> Options.UserVerificationOption.NOT_READY
+                    else -> null
+                },
+                null,
+                null
+            )
+        }
+    }
+}

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/TopCommand.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/TopCommand.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.unifidokey.usbip
+
+import io.quarkus.picocli.runtime.annotations.TopCommand
+import picocli.CommandLine.Command
+
+@TopCommand
+@Command(name = "unifidokey-usbip", mixinStandardHelpOptions = true,
+    subcommands = [UniFIDOKeyUSBIP::class, GenerateMetadataStatement::class])
+class TopCommand

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
@@ -1,0 +1,51 @@
+package com.webauthn4j.unifidokey.usbip
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDevice
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.jboss.logging.Logger
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+@Command(name = "serve", mixinStandardHelpOptions = true,
+    description = ["Start USB-IP server exposing a virtual FIDO2 security key"])
+class UniFIDOKeyUSBIP : Runnable {
+
+    @Option(names = ["-H", "--host"], description = ["Bind address (default: 0.0.0.0)"])
+    var host: String = "0.0.0.0"
+
+    @Option(names = ["-p", "--port"], description = ["TCP port (default: 3240)"])
+    var port: Int = 3240
+
+    private val logger = Logger.getLogger(UniFIDOKeyUSBIP::class.java)
+
+    override fun run() {
+        val config = USBIPDeviceConfig(host = host, port = port)
+        val authenticator = CtapAuthenticator(
+            attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey(),
+            userVerificationHandler = ConsoleUserVerificationHandler()
+        )
+        val device = USBIPDevice(authenticator, config)
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        Runtime.getRuntime().addShutdownHook(Thread {
+            runBlocking { device.stop() }
+        })
+
+        runBlocking {
+            device.start(scope)
+        }
+
+        logger.info("USB-IP Virtual FIDO2 Device is running")
+        logger.infof("  Server: %s:%d", config.host, config.port)
+        logger.infof("  Bus ID: %s", config.busId)
+
+        // Keep running until interrupted
+        Thread.currentThread().join()
+    }
+}

--- a/unifidokey-usbip/src/main/resources/application.properties
+++ b/unifidokey-usbip/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.package.jar.type=uber-jar
+quarkus.package.jar.add-runner-suffix=false
+quarkus.package.output-name=unifidokey-usbip
+quarkus.banner.enabled=false
+quarkus.log.console.stderr=true
+quarkus.log.category."com.webauthn4j".level=DEBUG

--- a/webauthn4j-ctap-authenticator-usbip/README.md
+++ b/webauthn4j-ctap-authenticator-usbip/README.md
@@ -1,0 +1,33 @@
+# webauthn4j-ctap-authenticator-usbip
+
+Library that exposes a `CtapAuthenticator` as a virtual USB HID FIDO2 device over USB/IP (TCP/IP).
+
+The primary use case is running **FIDO Conformance Tests on Windows** against the WebAuthn4J CTAP Authenticator. The `unifidokey-usbip` CLI application uses this module to serve the authenticator, and Windows-side tools connect via USB/IP as if it were a physical security key.
+
+## Requirements
+
+- Java 17+
+- USB/IP client on the connecting machine ([usbip-win2](https://github.com/vadimgrn/usbip-win2) for Windows, `usbip` for Linux)
+
+## Usage
+
+```kotlin
+val authenticator = CtapAuthenticator()
+val config = USBIPDeviceConfig(host = "0.0.0.0", port = 3240)
+val device = USBIPDevice(authenticator, config)
+val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+device.start(scope)
+// Clients can now attach via: usbip attach -r <server-ip> -b 1-1
+```
+
+## Key Classes
+
+| Class | Description |
+|---|---|
+| `USBIPDevice` | TCP accept loop and server lifecycle management |
+| `USBIPSession` | Per-connection protocol state machine using select-based event loop |
+| `USBIPDeviceConfig` | Server and device configuration |
+| `ControlEndpoint` | USB control endpoint (EP0) emulation |
+| `InterruptEndpoint` | HID interrupt endpoint bridge to HIDTransport |
+| `USBDescriptors` | USB/HID descriptor generation |

--- a/webauthn4j-ctap-authenticator-usbip/build.gradle.kts
+++ b/webauthn4j-ctap-authenticator-usbip/build.gradle.kts
@@ -1,0 +1,57 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+}
+
+description = "CTAP USB-IP server library for cross-platform virtual FIDO2 devices"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions{
+        jvmTarget = JvmTarget.JVM_17
+        javaParameters = true
+    }
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+    jacocoTestReport {
+        reports {
+            xml.required.set(true)
+        }
+    }
+}
+
+dependencies {
+
+    // Project dependencies
+    api(project(":webauthn4j-ctap-authenticator"))
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.ktor.network)
+    implementation(libs.slf4j.api)
+
+    // Test dependencies
+    testImplementation(platform(libs.junit.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.logback.classic)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.assertj.core)
+
+    testImplementation(libs.jackson.module.kotlin)
+    testImplementation(libs.jackson.dataformat.cbor)
+    testImplementation(project(":webauthn4j-ctap-client"))
+    testImplementation(libs.webauthn4j.test)
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/URBProcessor.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/URBProcessor.kt
@@ -1,0 +1,114 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip
+
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.SubmitRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.SubmitResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.TransferDirection
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.UnlinkRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.UnlinkResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.UrbRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.UrbStatus
+import com.webauthn4j.ctap.authenticator.transport.usbip.endpoint.ControlEndpoint
+import com.webauthn4j.ctap.authenticator.transport.usbip.endpoint.InterruptEndpoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import org.slf4j.LoggerFactory
+
+/**
+ * Processes URBs on an established [USBIPSession] using a select-based event loop.
+ *
+ * An IO coroutine reads URBs from the TCP stream and feeds them into a queue.
+ * The main loop uses [select] to monitor both the URB queue and the HID response
+ * channel simultaneously, ensuring Interrupt IN requests are fulfilled in FIFO
+ * order without blocking URB reading.
+ *
+ * UNLINK requests correctly remove pending Interrupt IN entries, preventing
+ * stale responses and ensuring accurate status reporting.
+ */
+class URBProcessor(private val session: USBIPSession) {
+
+    private val logger = LoggerFactory.getLogger(URBProcessor::class.java)
+
+    suspend fun process() {
+        coroutineScope {
+            val urbQueue = Channel<UrbRequest>(Channel.UNLIMITED)
+            launch(Dispatchers.IO) { readURBs(urbQueue) }
+            launch { processURBs(urbQueue) }
+        }
+    }
+
+    private suspend fun readURBs(urbQueue: Channel<UrbRequest>) {
+        try {
+            while (currentCoroutineContext().isActive) {
+                urbQueue.send(UrbRequest.parse(session.readChannel))
+            }
+        } finally {
+            urbQueue.close()
+        }
+    }
+
+    private suspend fun processURBs(urbQueue: Channel<UrbRequest>) {
+        val pendingIns = LinkedHashMap<Int, SubmitRequest>()
+
+        while (true) {
+            select {
+                urbQueue.onReceive { urb ->
+                    when (urb) {
+                        is SubmitRequest -> {
+                            if (urb.transferBufferLength > MAX_TRANSFER_BUFFER_LENGTH) {
+                                logger.warn("Transfer size too large: {}", urb.transferBufferLength)
+                                session.writeResponse(SubmitResponse.error(urb, UrbStatus.EINVAL).toBytes())
+                                return@onReceive
+                            }
+                            logger.debug("CMD_SUBMIT: ep={}, dir={}, len={}", urb.ep, urb.direction, urb.transferBufferLength)
+                            if (urb.direction == TransferDirection.IN && urb.ep == InterruptEndpoint.EP_NUMBER) {
+                                pendingIns[urb.seqnum] = urb
+                            } else {
+                                submitAndRespond(urb)
+                            }
+                        }
+                        is UnlinkRequest -> {
+                            logger.debug("CMD_UNLINK: seqnum={}, unlinkSeqnum={}", urb.seqnum, urb.unlinkSeqnum)
+                            val wasPending = pendingIns.remove(urb.unlinkSeqnum) != null
+                            val status = if (wasPending) UrbStatus.ECONNRESET else UrbStatus.SUCCESS
+                            session.writeResponse(UnlinkResponse(seqnum = urb.seqnum, status = status).toBytes())
+                        }
+                    }
+                }
+                if (pendingIns.isNotEmpty()) {
+                    session.interruptEndpoint.responses.onReceive { data ->
+                        val entry = pendingIns.entries.first()
+                        pendingIns.remove(entry.key)
+                        logger.debug("Interrupt IN: returning {} bytes (seqnum={})", data.size, entry.key)
+                        session.writeResponse(SubmitResponse.ok(entry.value, data).toBytes())
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun submitAndRespond(request: SubmitRequest) {
+        try {
+            val response = when (request.ep) {
+                ControlEndpoint.EP_NUMBER -> session.controlEndpoint.process(request)
+                InterruptEndpoint.EP_NUMBER -> session.interruptEndpoint.processOut(request)
+                else -> {
+                    logger.warn("Unknown endpoint: 0x{}", Integer.toHexString(request.ep))
+                    SubmitResponse.error(request, UrbStatus.EPIPE)
+                }
+            }
+            session.writeResponse(response.toBytes())
+        } catch (e: Exception) {
+            logger.error("Error processing submit request", e)
+            session.writeResponse(SubmitResponse.error(request, UrbStatus.EINVAL).toBytes())
+        }
+    }
+
+    companion object {
+        private const val MAX_TRANSFER_BUFFER_LENGTH = 4096
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/URBProcessor.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/URBProcessor.kt
@@ -19,19 +19,17 @@ import kotlinx.coroutines.selects.select
 import org.slf4j.LoggerFactory
 
 /**
- * Processes URBs on an established [USBIPSession] using a select-based event loop.
+ * Drives URB processing on an established [USBIPSession].
  *
- * An IO coroutine reads URBs from the TCP stream and feeds them into a queue.
- * The main loop uses [select] to monitor both the URB queue and the HID response
- * channel simultaneously, ensuring Interrupt IN requests are fulfilled in FIFO
- * order without blocking URB reading.
- *
- * UNLINK requests correctly remove pending Interrupt IN entries, preventing
- * stale responses and ensuring accurate status reporting.
+ * An IO coroutine reads URBs from the TCP stream into a queue. The main
+ * coroutine uses [select] to concurrently monitor that queue and the HID
+ * response channel, dispatching each URB to the appropriate endpoint and
+ * fulfilling pending Interrupt IN requests in FIFO order.
  */
 class URBProcessor(private val session: USBIPSession) {
 
     private val logger = LoggerFactory.getLogger(URBProcessor::class.java)
+    private val pendingIns = LinkedHashMap<Int, SubmitRequest>()
 
     suspend fun process() {
         coroutineScope {
@@ -52,60 +50,67 @@ class URBProcessor(private val session: USBIPSession) {
     }
 
     private suspend fun processURBs(urbQueue: Channel<UrbRequest>) {
-        val pendingIns = LinkedHashMap<Int, SubmitRequest>()
-
         while (true) {
             select {
                 urbQueue.onReceive { urb ->
                     when (urb) {
-                        is SubmitRequest -> {
-                            if (urb.transferBufferLength > MAX_TRANSFER_BUFFER_LENGTH) {
-                                logger.warn("Transfer size too large: {}", urb.transferBufferLength)
-                                session.writeResponse(SubmitResponse.error(urb, UrbStatus.EINVAL).toBytes())
-                                return@onReceive
-                            }
-                            logger.debug("CMD_SUBMIT: ep={}, dir={}, len={}", urb.ep, urb.direction, urb.transferBufferLength)
-                            if (urb.direction == TransferDirection.IN && urb.ep == InterruptEndpoint.EP_NUMBER) {
-                                pendingIns[urb.seqnum] = urb
-                            } else {
-                                submitAndRespond(urb)
-                            }
-                        }
-                        is UnlinkRequest -> {
-                            logger.debug("CMD_UNLINK: seqnum={}, unlinkSeqnum={}", urb.seqnum, urb.unlinkSeqnum)
-                            val wasPending = pendingIns.remove(urb.unlinkSeqnum) != null
-                            val status = if (wasPending) UrbStatus.ECONNRESET else UrbStatus.SUCCESS
-                            session.writeResponse(UnlinkResponse(seqnum = urb.seqnum, status = status).toBytes())
-                        }
+                        is SubmitRequest -> handleSubmit(urb)
+                        is UnlinkRequest -> handleUnlink(urb)
                     }
                 }
                 if (pendingIns.isNotEmpty()) {
                     session.interruptEndpoint.responses.onReceive { data ->
-                        val entry = pendingIns.entries.first()
-                        pendingIns.remove(entry.key)
-                        logger.debug("Interrupt IN: returning {} bytes (seqnum={})", data.size, entry.key)
-                        session.writeResponse(SubmitResponse.ok(entry.value, data).toBytes())
+                        completeInterruptIn(data)
                     }
                 }
             }
         }
     }
 
-    private suspend fun submitAndRespond(request: SubmitRequest) {
-        try {
-            val response = when (request.ep) {
-                ControlEndpoint.EP_NUMBER -> session.controlEndpoint.process(request)
-                InterruptEndpoint.EP_NUMBER -> session.interruptEndpoint.processOut(request)
-                else -> {
-                    logger.warn("Unknown endpoint: 0x{}", Integer.toHexString(request.ep))
-                    SubmitResponse.error(request, UrbStatus.EPIPE)
-                }
+    private suspend fun handleSubmit(request: SubmitRequest) {
+        if (request.transferBufferLength > MAX_TRANSFER_BUFFER_LENGTH) {
+            logger.warn("Transfer size too large: {}", request.transferBufferLength)
+            session.writeResponse(SubmitResponse.error(request, UrbStatus.EINVAL).toBytes())
+            return
+        }
+        logger.debug("CMD_SUBMIT: ep={}, dir={}, len={}", request.ep, request.direction, request.transferBufferLength)
+        if (request.direction == TransferDirection.IN && request.ep == InterruptEndpoint.EP_NUMBER) {
+            pendingIns[request.seqnum] = request
+        } else {
+            val response = try {
+                dispatchSubmit(request)
+            } catch (e: Exception) {
+                handleEndpointFailure(request, e)
             }
             session.writeResponse(response.toBytes())
-        } catch (e: Exception) {
-            logger.error("Error processing submit request", e)
-            session.writeResponse(SubmitResponse.error(request, UrbStatus.EINVAL).toBytes())
         }
+    }
+
+    private suspend fun handleUnlink(request: UnlinkRequest) {
+        logger.debug("CMD_UNLINK: seqnum={}, unlinkSeqnum={}", request.seqnum, request.unlinkSeqnum)
+        val wasPending = pendingIns.remove(request.unlinkSeqnum) != null
+        val status = if (wasPending) UrbStatus.ECONNRESET else UrbStatus.SUCCESS
+        session.writeResponse(UnlinkResponse(seqnum = request.seqnum, status = status).toBytes())
+    }
+
+    private suspend fun completeInterruptIn(data: ByteArray) {
+        val entry = pendingIns.entries.first()
+        pendingIns.remove(entry.key)
+        logger.debug("Interrupt IN: returning {} bytes (seqnum={})", data.size, entry.key)
+        session.writeResponse(SubmitResponse.ok(entry.value, data).toBytes())
+    }
+
+    private suspend fun dispatchSubmit(request: SubmitRequest): SubmitResponse {
+        return when (request.ep) {
+            ControlEndpoint.EP_NUMBER -> session.controlEndpoint.process(request)
+            InterruptEndpoint.EP_NUMBER -> session.interruptEndpoint.process(request)
+            else -> throw IllegalArgumentException("Unknown endpoint: 0x${Integer.toHexString(request.ep)}")
+        }
+    }
+
+    private fun handleEndpointFailure(request: SubmitRequest, e: Exception): SubmitResponse {
+        logger.error("Error processing submit request", e)
+        return SubmitResponse.error(request, UrbStatus.EINVAL)
     }
 
     companion object {

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
@@ -1,0 +1,109 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticator
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDTransport
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.DeviceInfo
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.USBSpeed
+import io.ktor.network.selector.SelectorManager
+import io.ktor.network.sockets.aSocket
+import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+
+/**
+ * Virtual USB FIDO2 security key exposed over USB/IP (TCP/IP).
+ *
+ * Wraps a [CtapAuthenticator] and serves it as a USB HID device that remote
+ * machines can attach via the USB/IP protocol.
+ */
+class USBIPDevice(
+    ctapAuthenticator: CtapAuthenticator,
+    private val config: USBIPDeviceConfig = USBIPDeviceConfig()
+) : AutoCloseable {
+
+    private val logger = LoggerFactory.getLogger(USBIPDevice::class.java)
+    private val hidTransport = HIDTransport(ctapAuthenticator)
+
+    private var serverJob: Job? = null
+    private var selectorManager: SelectorManager? = null
+
+    suspend fun start(scope: CoroutineScope) {
+        logger.info("Starting USB-IP server")
+        logger.info("Device: {}", config.deviceName)
+        logger.info("VID:PID = 0x{}:0x{}",
+            Integer.toHexString(config.vendorId),
+            Integer.toHexString(config.productId))
+        logger.info("Server address: {}:{}", config.host, config.port)
+        logger.info("Bus ID: {}", config.busId)
+
+        hidTransport.start(scope)
+
+        val deviceInfo = createDeviceInfo()
+        val sm = SelectorManager(Dispatchers.IO)
+        selectorManager = sm
+
+        serverJob = scope.launch(Dispatchers.IO) {
+            aSocket(sm).tcp().bind(config.host, config.port).use { serverSocket ->
+                logger.info("USB-IP server listening on {}:{}", config.host, config.port)
+
+                while (isActive) {
+                    val clientSocket = serverSocket.accept()
+                    logger.info("Client connected from {}", clientSocket.remoteAddress)
+
+                    launch {
+                        try {
+                            clientSocket.use { socket ->
+                                USBIPSession.create(socket, deviceInfo, config, hidTransport).use { session ->
+                                    URBProcessor(session).process()
+                                }
+                            }
+                        } catch (_: java.io.IOException) {
+                            logger.debug("Client disconnected: {}", clientSocket.remoteAddress)
+                        } catch (e: Exception) {
+                            logger.error("Session error", e)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun stop() {
+        logger.info("Stopping USB-IP server")
+        serverJob?.cancelAndJoin()
+        serverJob = null
+        selectorManager?.close()
+        selectorManager = null
+        hidTransport.close()
+        logger.info("USB-IP server stopped")
+    }
+
+    override fun close() {
+        runBlocking { stop() }
+    }
+
+    private fun createDeviceInfo(): DeviceInfo {
+        return DeviceInfo(
+            path = "/sys/devices/virtual/usbip/${config.busId}",
+            busid = config.busId,
+            busnum = config.busNum,
+            devnum = config.devNum,
+            speed = USBSpeed.FULL,
+            idVendor = config.vendorId,
+            idProduct = config.productId,
+            bcdDevice = config.version,
+            bDeviceClass = 0,
+            bDeviceSubClass = 0,
+            bDeviceProtocol = 0,
+            bConfigurationValue = 1,
+            bNumConfigurations = 1,
+            bNumInterfaces = 1,
+            interfaces = listOf(
+                DeviceInfo.InterfaceInfo(
+                    bInterfaceClass = 0x03,
+                    bInterfaceSubClass = 0x00,
+                    bInterfaceProtocol = 0x00
+                )
+            )
+        )
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
@@ -10,10 +10,11 @@ import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 
 /**
- * Virtual USB FIDO2 security key exposed over USB/IP (TCP/IP).
+ * Virtual USB FIDO2 security key exposed over USB/IP.
  *
- * Wraps a [CtapAuthenticator] and serves it as a USB HID device that remote
- * machines can attach via the USB/IP protocol.
+ * Listens for TCP connections and, for each client, creates a [USBIPSession]
+ * (which negotiates the handshake) and hands it to a [URBProcessor] that
+ * drives endpoint I/O until the connection closes.
  */
 class USBIPDevice(
     ctapAuthenticator: CtapAuthenticator,
@@ -56,8 +57,8 @@ class USBIPDevice(
                                     URBProcessor(session).process()
                                 }
                             }
-                        } catch (_: java.io.IOException) {
-                            logger.debug("Client disconnected: {}", clientSocket.remoteAddress)
+                        } catch (e: java.io.IOException) {
+                            logger.debug("Session ended: {} ({})", clientSocket.remoteAddress, e.message)
                         } catch (e: Exception) {
                             logger.error("Session error", e)
                         }

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDeviceConfig.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDeviceConfig.kt
@@ -1,0 +1,36 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip
+
+/**
+ * Configuration for USB-IP virtual device.
+ *
+ * @property deviceName Human-readable device name (manufacturer + product name)
+ * @property vendorId USB Vendor ID (0x0000-0xFFFF)
+ * @property productId USB Product ID (0x0000-0xFFFF)
+ * @property version Device version in BCD format (e.g., 0x0100 for v1.0)
+ * @property host Host address to bind the USB-IP server (0.0.0.0 for all interfaces)
+ * @property port TCP port for USB-IP protocol (standard is 3240)
+ * @property busId Bus ID string for USB-IP device identification (e.g., "1-1")
+ * @property busNum USB bus number
+ * @property devNum USB device number on the bus
+ */
+data class USBIPDeviceConfig(
+    val deviceName: String = "WebAuthn4J Virtual FIDO2 Key",
+    val vendorId: Int = 0x1234,
+    val productId: Int = 0xF1D0,
+    val version: Int = 0x0100,
+    val host: String = "0.0.0.0",
+    val port: Int = 3240,
+    val busId: String = "1-1",
+    val busNum: Int = 1,
+    val devNum: Int = 2
+) {
+    init {
+        require(vendorId in 0x0000..0xFFFF) { "Vendor ID must be 0x0000-0xFFFF" }
+        require(productId in 0x0000..0xFFFF) { "Product ID must be 0x0000-0xFFFF" }
+        require(version in 0x0000..0xFFFF) { "Version must be 0x0000-0xFFFF" }
+        require(port in 1..65535) { "Port must be 1-65535" }
+        require(busNum >= 0) { "Bus number must be non-negative" }
+        require(devNum >= 0) { "Device number must be non-negative" }
+        require(busId.isNotBlank()) { "Bus ID must not be blank" }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPSession.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPSession.kt
@@ -1,0 +1,86 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip
+
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDTransport
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.DeviceInfo
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.DeviceListRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.DeviceListResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.HandshakeRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.ImportRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake.ImportResponse
+import com.webauthn4j.ctap.authenticator.transport.usbip.endpoint.ControlEndpoint
+import com.webauthn4j.ctap.authenticator.transport.usbip.endpoint.InterruptEndpoint
+import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.openReadChannel
+import io.ktor.network.sockets.openWriteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.writeFully
+import org.slf4j.LoggerFactory
+
+/**
+ * Represents an established USB-IP client connection.
+ *
+ * Created via [create], which opens TCP channels and completes the USB-IP
+ * handshake (device list / import). Once created, the session is ready for
+ * URB processing via [URBProcessor].
+ *
+ * Each session owns its own [ControlEndpoint] and [InterruptEndpoint] instances.
+ */
+class USBIPSession private constructor(
+    val readChannel: ByteReadChannel,
+    val writeChannel: ByteWriteChannel,
+    val controlEndpoint: ControlEndpoint,
+    val interruptEndpoint: InterruptEndpoint
+) : AutoCloseable {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(USBIPSession::class.java)
+
+        suspend fun create(
+            socket: Socket,
+            deviceInfo: DeviceInfo,
+            config: USBIPDeviceConfig,
+            hidTransport: HIDTransport
+        ): USBIPSession {
+            val readChannel = socket.openReadChannel()
+            val writeChannel = socket.openWriteChannel(autoFlush = true)
+            val session = USBIPSession(
+                readChannel = readChannel,
+                writeChannel = writeChannel,
+                controlEndpoint = ControlEndpoint(config),
+                interruptEndpoint = InterruptEndpoint(hidTransport)
+            )
+            session.negotiateHandshake(deviceInfo)
+            return session
+        }
+
+        private suspend fun USBIPSession.negotiateHandshake(deviceInfo: DeviceInfo) {
+            while (true) {
+                when (val request = HandshakeRequest.parse(readChannel)) {
+                    is DeviceListRequest -> {
+                        logger.debug("Handling OP_REQ_DEVLIST")
+                        writeResponse(DeviceListResponse(devices = listOf(deviceInfo)).toBytes())
+                    }
+                    is ImportRequest -> {
+                        logger.debug("Handling OP_REQ_IMPORT: busid={}", request.busId)
+                        if (request.busId != deviceInfo.busid) {
+                            logger.warn("Import request for unknown busid: {}", request.busId)
+                            continue
+                        }
+                        writeResponse(ImportResponse(device = deviceInfo).toBytes())
+                        logger.info("Device attached to client")
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun writeResponse(data: ByteArray) {
+        writeChannel.writeFully(data, 0, data.size)
+    }
+
+    override fun close() {
+        interruptEndpoint.close()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPSession.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPSession.kt
@@ -18,13 +18,10 @@ import io.ktor.utils.io.writeFully
 import org.slf4j.LoggerFactory
 
 /**
- * Represents an established USB-IP client connection.
+ * An established USB-IP client connection with its per-session endpoints.
  *
- * Created via [create], which opens TCP channels and completes the USB-IP
- * handshake (device list / import). Once created, the session is ready for
- * URB processing via [URBProcessor].
- *
- * Each session owns its own [ControlEndpoint] and [InterruptEndpoint] instances.
+ * [create] opens TCP channels, negotiates the USB-IP handshake, and returns
+ * a ready-to-use session. [URBProcessor] then drives endpoint I/O on it.
  */
 class USBIPSession private constructor(
     val readChannel: ByteReadChannel,
@@ -33,9 +30,9 @@ class USBIPSession private constructor(
     val interruptEndpoint: InterruptEndpoint
 ) : AutoCloseable {
 
-    companion object {
-        private val logger = LoggerFactory.getLogger(USBIPSession::class.java)
+    private val logger = LoggerFactory.getLogger(USBIPSession::class.java)
 
+    companion object {
         suspend fun create(
             socket: Socket,
             deviceInfo: DeviceInfo,
@@ -53,24 +50,24 @@ class USBIPSession private constructor(
             session.negotiateHandshake(deviceInfo)
             return session
         }
+    }
 
-        private suspend fun USBIPSession.negotiateHandshake(deviceInfo: DeviceInfo) {
-            while (true) {
-                when (val request = HandshakeRequest.parse(readChannel)) {
-                    is DeviceListRequest -> {
-                        logger.debug("Handling OP_REQ_DEVLIST")
-                        writeResponse(DeviceListResponse(devices = listOf(deviceInfo)).toBytes())
+    private suspend fun negotiateHandshake(deviceInfo: DeviceInfo) {
+        while (true) {
+            when (val request = HandshakeRequest.parse(readChannel)) {
+                is DeviceListRequest -> {
+                    logger.debug("Handling OP_REQ_DEVLIST")
+                    writeResponse(DeviceListResponse(devices = listOf(deviceInfo)).toBytes())
+                }
+                is ImportRequest -> {
+                    logger.debug("Handling OP_REQ_IMPORT: busid={}", request.busId)
+                    if (request.busId != deviceInfo.busid) {
+                        logger.warn("Import request for unknown busid: {}", request.busId)
+                        continue
                     }
-                    is ImportRequest -> {
-                        logger.debug("Handling OP_REQ_IMPORT: busid={}", request.busId)
-                        if (request.busId != deviceInfo.busid) {
-                            logger.warn("Import request for unknown busid: {}", request.busId)
-                            continue
-                        }
-                        writeResponse(ImportResponse(device = deviceInfo).toBytes())
-                        logger.info("Device attached to client")
-                        return
-                    }
+                    writeResponse(ImportResponse(device = deviceInfo).toBytes())
+                    logger.info("Device attached to client")
+                    return
                 }
             }
         }

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/DeviceInfo.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/DeviceInfo.kt
@@ -1,0 +1,73 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+import java.nio.ByteBuffer
+
+/**
+ * Device information structure for USB-IP.
+ */
+data class DeviceInfo(
+    val path: String,  // 256 bytes
+    val busid: String, // 32 bytes
+    val busnum: Int,
+    val devnum: Int,
+    val speed: USBSpeed,
+    val idVendor: Int,
+    val idProduct: Int,
+    val bcdDevice: Int,
+    val bDeviceClass: Int,
+    val bDeviceSubClass: Int,
+    val bDeviceProtocol: Int,
+    val bConfigurationValue: Int,
+    val bNumConfigurations: Int,
+    val bNumInterfaces: Int,
+    val interfaces: List<InterfaceInfo> = emptyList()
+) {
+    data class InterfaceInfo(
+        val bInterfaceClass: Int,
+        val bInterfaceSubClass: Int,
+        val bInterfaceProtocol: Int
+    ) {
+        companion object {
+            const val SIZE = 4
+        }
+    }
+
+    companion object {
+        private const val PATH_FIELD_SIZE = 256
+        const val BUSID_FIELD_SIZE = 32
+        const val SIZE = PATH_FIELD_SIZE + BUSID_FIELD_SIZE + 4 * 3 + 2 * 3 + 6 // 312
+    }
+
+    fun writeTo(buffer: ByteBuffer, includeInterfaces: Boolean = false) {
+        writeString(buffer, path, PATH_FIELD_SIZE)
+        writeString(buffer, busid, BUSID_FIELD_SIZE)
+        buffer.putInt(busnum)
+        buffer.putInt(devnum)
+        buffer.putInt(speed.value)
+        buffer.putShort(idVendor.toShort())
+        buffer.putShort(idProduct.toShort())
+        buffer.putShort(bcdDevice.toShort())
+        buffer.put(bDeviceClass.toByte())
+        buffer.put(bDeviceSubClass.toByte())
+        buffer.put(bDeviceProtocol.toByte())
+        buffer.put(bConfigurationValue.toByte())
+        buffer.put(bNumConfigurations.toByte())
+        buffer.put(bNumInterfaces.toByte())
+
+        if (includeInterfaces) {
+            for (iface in interfaces) {
+                buffer.put(iface.bInterfaceClass.toByte())
+                buffer.put(iface.bInterfaceSubClass.toByte())
+                buffer.put(iface.bInterfaceProtocol.toByte())
+                buffer.put(0) // padding
+            }
+        }
+    }
+
+    private fun writeString(buffer: ByteBuffer, str: String, length: Int) {
+        val bytes = str.toByteArray(Charsets.US_ASCII)
+        val toCopy = minOf(bytes.size, length - 1)
+        buffer.put(bytes, 0, toCopy)
+        repeat(length - toCopy) { buffer.put(0) }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/DeviceListRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/DeviceListRequest.kt
@@ -1,0 +1,10 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+/** OP_REQ_DEVLIST — requests the server to list exported USB devices. */
+data class DeviceListRequest(
+    override val version: USBIPVersion
+) : HandshakeRequest() {
+    companion object {
+        const val OPCODE = 0x8005
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/DeviceListResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/DeviceListResponse.kt
@@ -1,0 +1,33 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/** OP_REP_DEVLIST — response containing exported USB devices. */
+data class DeviceListResponse(
+    val devices: List<DeviceInfo>
+) {
+    val version: USBIPVersion = USBIPVersion.V1_1_1
+    val status: HandshakeStatus = HandshakeStatus.OK
+
+    companion object {
+        const val OPCODE = 0x0005
+    }
+
+    fun toBytes(): ByteArray {
+        val headerSize = 2 + 2 + 4 + 4 // version + opcode + status + numDevices
+        val bufferSize = headerSize + devices.sumOf { DeviceInfo.SIZE + DeviceInfo.InterfaceInfo.SIZE * it.bNumInterfaces }
+        val buffer = ByteBuffer.allocate(bufferSize).order(ByteOrder.BIG_ENDIAN)
+
+        buffer.putShort(version.value.toShort())
+        buffer.putShort(OPCODE.toShort())
+        buffer.putInt(status.value)
+        buffer.putInt(devices.size)
+
+        for (device in devices) {
+            device.writeTo(buffer, includeInterfaces = true)
+        }
+
+        return buffer.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/HandshakeRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/HandshakeRequest.kt
@@ -1,0 +1,32 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readFully
+import io.ktor.utils.io.readInt
+import io.ktor.utils.io.readShort
+
+/** Base type for USB-IP handshake phase requests. */
+sealed class HandshakeRequest {
+    abstract val version: USBIPVersion
+
+    companion object {
+        suspend fun parse(channel: ByteReadChannel): HandshakeRequest {
+            val versionValue = channel.readShort().toInt() and 0xFFFF
+            val opcode = channel.readShort().toInt() and 0xFFFF
+            val status = channel.readInt()
+            val version = USBIPVersion.V1_1_1
+
+            return when (opcode) {
+                DeviceListRequest.OPCODE -> DeviceListRequest(version = version)
+                ImportRequest.OPCODE -> {
+                    val bytes = ByteArray(DeviceInfo.BUSID_FIELD_SIZE)
+                    channel.readFully(bytes, 0, bytes.size)
+                    val nullIndex = bytes.indexOf(0)
+                    val endIndex = if (nullIndex >= 0) nullIndex else bytes.size
+                    ImportRequest(version = version, busId = String(bytes, 0, endIndex, Charsets.US_ASCII))
+                }
+                else -> throw IllegalArgumentException("Unknown handshake opcode: 0x${Integer.toHexString(opcode)}")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/HandshakeStatus.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/HandshakeStatus.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+/** USB-IP handshake response status. */
+enum class HandshakeStatus(val value: Int) {
+    OK(0),
+    ERROR(1);
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/ImportRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/ImportRequest.kt
@@ -1,0 +1,11 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+/** OP_REQ_IMPORT — requests to attach a remote USB device by bus ID. */
+data class ImportRequest(
+    override val version: USBIPVersion,
+    val busId: String
+) : HandshakeRequest() {
+    companion object {
+        const val OPCODE = 0x8003
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/ImportResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/ImportResponse.kt
@@ -1,0 +1,29 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/** OP_REP_IMPORT — response confirming device attachment with device details. */
+data class ImportResponse(
+    val status: HandshakeStatus = HandshakeStatus.OK,
+    val device: DeviceInfo
+) {
+    val version: USBIPVersion = USBIPVersion.V1_1_1
+
+    companion object {
+        const val OPCODE = 0x0003
+    }
+
+    fun toBytes(): ByteArray {
+        val headerSize = 2 + 2 + 4 // version + opcode + status
+        val buffer = ByteBuffer.allocate(headerSize + DeviceInfo.SIZE).order(ByteOrder.BIG_ENDIAN)
+
+        buffer.putShort(version.value.toShort())
+        buffer.putShort(OPCODE.toShort())
+        buffer.putInt(status.value)
+
+        device.writeTo(buffer, includeInterfaces = false)
+
+        return buffer.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/USBIPVersion.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/USBIPVersion.kt
@@ -1,0 +1,6 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+/** USB-IP protocol version. */
+enum class USBIPVersion(val value: Int) {
+    V1_1_1(0x0111);
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/USBSpeed.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/handshake/USBSpeed.kt
@@ -1,0 +1,16 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.handshake
+
+/** USB device speed as reported in USB-IP device descriptors. */
+enum class USBSpeed(val value: Int) {
+    LOW(1),
+    FULL(2),
+    HIGH(3),
+    WIRELESS(4),
+    SUPER(5),
+    SUPER_PLUS(6);
+
+    companion object {
+        fun fromValue(value: Int): USBSpeed =
+            entries.first { it.value == value }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/SubmitRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/SubmitRequest.kt
@@ -1,0 +1,73 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.urb
+
+/** USBIP_CMD_SUBMIT — a USB Request Block submitted by the client. */
+class SubmitRequest(
+    override val seqnum: Int,
+    val devid: Int,
+    val direction: TransferDirection,
+    val ep: Int,
+    val transferFlags: Int,
+    val transferBufferLength: Int,
+    val startFrame: Int,
+    val numberOfPackets: Int,
+    val interval: Int,
+    val setup: Setup,
+    val transferBuffer: ByteArray
+) : UrbRequest() {
+    /** Parsed USB setup header (8 bytes) from a control transfer. */
+    data class Setup(
+        val bmRequestType: Int,
+        val bRequest: Int,
+        val wValue: Int,
+        val wIndex: Int,
+        val wLength: Int
+    ) {
+        companion object {
+            const val SIZE = 8
+
+            fun parse(bytes: ByteArray): Setup = Setup(
+                bmRequestType = bytes[0].toInt() and 0xFF,
+                bRequest = bytes[1].toInt() and 0xFF,
+                wValue = ((bytes[3].toInt() and 0xFF) shl 8) or (bytes[2].toInt() and 0xFF),
+                wIndex = ((bytes[5].toInt() and 0xFF) shl 8) or (bytes[4].toInt() and 0xFF),
+                wLength = ((bytes[7].toInt() and 0xFF) shl 8) or (bytes[6].toInt() and 0xFF)
+            )
+        }
+    }
+
+    companion object {
+        const val COMMAND = 0x00000001
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as SubmitRequest
+        return seqnum == other.seqnum && devid == other.devid && direction == other.direction &&
+                ep == other.ep && transferFlags == other.transferFlags &&
+                transferBufferLength == other.transferBufferLength &&
+                startFrame == other.startFrame && numberOfPackets == other.numberOfPackets &&
+                interval == other.interval && setup == other.setup &&
+                transferBuffer.contentEquals(other.transferBuffer)
+    }
+
+    override fun hashCode(): Int {
+        var result = seqnum
+        result = 31 * result + devid
+        result = 31 * result + direction.hashCode()
+        result = 31 * result + ep
+        result = 31 * result + transferFlags
+        result = 31 * result + transferBufferLength
+        result = 31 * result + startFrame
+        result = 31 * result + numberOfPackets
+        result = 31 * result + interval
+        result = 31 * result + setup.hashCode()
+        result = 31 * result + transferBuffer.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "SubmitRequest(seqnum=$seqnum, devid=$devid, direction=$direction, ep=$ep, " +
+                "transferBufferLength=$transferBufferLength)"
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/SubmitResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/SubmitResponse.kt
@@ -1,0 +1,84 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.urb
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/** USBIP_RET_SUBMIT — server response after processing a submitted URB. */
+class SubmitResponse(
+    val seqnum: Int,
+    val status: UrbStatus,
+    val actualLength: Int,
+    val startFrame: Int,
+    val numberOfPackets: Int,
+    val errorCount: Int,
+    val transferBuffer: ByteArray
+) {
+    val devid: Int = 0
+    val direction: TransferDirection = TransferDirection.OUT
+    val ep: Int = 0
+
+    companion object {
+        const val COMMAND = 0x00000003
+        // command(4) + seqnum(4) + devid(4) + direction(4) + ep(4) + status(4) + actualLength(4) + startFrame(4) + numberOfPackets(4) + errorCount(4) + setup(8) = 48
+        private const val HEADER_SIZE = 48
+
+        fun ok(request: SubmitRequest, transferBuffer: ByteArray, actualLength: Int = transferBuffer.size): SubmitResponse = SubmitResponse(
+            seqnum = request.seqnum,
+            status = UrbStatus.SUCCESS, actualLength = actualLength,
+            startFrame = 0, numberOfPackets = 0, errorCount = 0, transferBuffer = transferBuffer
+        )
+
+        fun error(request: SubmitRequest, status: UrbStatus): SubmitResponse = SubmitResponse(
+            seqnum = request.seqnum,
+            status = status, actualLength = 0,
+            startFrame = 0, numberOfPackets = 0, errorCount = 0, transferBuffer = ByteArray(0)
+        )
+    }
+
+    fun toBytes(): ByteArray {
+        val buffer = ByteBuffer.allocate(HEADER_SIZE + transferBuffer.size).order(ByteOrder.BIG_ENDIAN)
+
+        buffer.putInt(COMMAND)
+        buffer.putInt(seqnum)
+        buffer.putInt(devid)
+        buffer.putInt(direction.value)
+        buffer.putInt(ep)
+        buffer.putInt(status.value)
+        buffer.putInt(actualLength)
+        buffer.putInt(startFrame)
+        buffer.putInt(numberOfPackets)
+        buffer.putInt(errorCount)
+        buffer.putLong(0) // setup padding
+        buffer.put(transferBuffer)
+
+        return buffer.array()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as SubmitResponse
+        return seqnum == other.seqnum && devid == other.devid && direction == other.direction &&
+                ep == other.ep && status == other.status && actualLength == other.actualLength &&
+                startFrame == other.startFrame && numberOfPackets == other.numberOfPackets &&
+                errorCount == other.errorCount && transferBuffer.contentEquals(other.transferBuffer)
+    }
+
+    override fun hashCode(): Int {
+        var result = seqnum
+        result = 31 * result + devid
+        result = 31 * result + direction.hashCode()
+        result = 31 * result + ep
+        result = 31 * result + status.hashCode()
+        result = 31 * result + actualLength
+        result = 31 * result + startFrame
+        result = 31 * result + numberOfPackets
+        result = 31 * result + errorCount
+        result = 31 * result + transferBuffer.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "SubmitResponse(seqnum=$seqnum, devid=$devid, direction=$direction, ep=$ep, status=$status, actualLength=$actualLength, transferBufferSize=${transferBuffer.size})"
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/TransferDirection.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/TransferDirection.kt
@@ -1,0 +1,12 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.urb
+
+/** USB transfer direction: OUT (host→device) or IN (device→host). */
+enum class TransferDirection(val value: Int) {
+    OUT(0x00),
+    IN(0x01);
+
+    companion object {
+        fun fromValue(value: Int): TransferDirection =
+            entries.first { it.value == value }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UnlinkRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UnlinkRequest.kt
@@ -1,0 +1,11 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.urb
+
+/** USBIP_CMD_UNLINK — request to cancel a previously submitted URB. */
+data class UnlinkRequest(
+    override val seqnum: Int,
+    val unlinkSeqnum: Int
+) : UrbRequest() {
+    companion object {
+        const val COMMAND = 0x00000002
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UnlinkResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UnlinkResponse.kt
@@ -1,0 +1,35 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.urb
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/** USBIP_RET_UNLINK — server response to an unlink request. */
+data class UnlinkResponse(
+    val seqnum: Int,
+    val status: UrbStatus
+) {
+    val devid: Int = 0
+    val direction: TransferDirection = TransferDirection.OUT
+    val ep: Int = 0
+
+    companion object {
+        const val COMMAND = 0x00000004
+        // command(4) + seqnum(4) + devid(4) + direction(4) + ep(4) + status(4) + padding(24) = 48
+        private const val SIZE = 48
+    }
+
+    fun toBytes(): ByteArray {
+        val buffer = ByteBuffer.allocate(SIZE).order(ByteOrder.BIG_ENDIAN)
+
+        buffer.putInt(COMMAND)
+        buffer.putInt(seqnum)
+        buffer.putInt(devid)
+        buffer.putInt(direction.value)
+        buffer.putInt(ep)
+
+        buffer.putInt(status.value)
+        repeat(6) { buffer.putInt(0) } // padding
+
+        return buffer.array()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UrbRequest.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UrbRequest.kt
@@ -1,0 +1,56 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.urb
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readFully
+import io.ktor.utils.io.readInt
+
+/** Base type for USB-IP URB phase requests. */
+sealed class UrbRequest {
+    abstract val seqnum: Int
+
+    companion object {
+        suspend fun parse(channel: ByteReadChannel): UrbRequest {
+            val command = channel.readInt()
+            val seqnum = channel.readInt()
+            val devid = channel.readInt()
+            val directionValue = channel.readInt()
+            val ep = channel.readInt()
+
+            return when (command) {
+                SubmitRequest.COMMAND -> {
+                    val direction = TransferDirection.fromValue(directionValue)
+                    val transferFlags = channel.readInt()
+                    val transferBufferLength = channel.readInt()
+                    val startFrame = channel.readInt()
+                    val numberOfPackets = channel.readInt()
+                    val interval = channel.readInt()
+                    val setupBytes = ByteArray(SubmitRequest.Setup.SIZE)
+                    channel.readFully(setupBytes, 0, setupBytes.size)
+
+                    val transferBuffer = if (direction == TransferDirection.OUT && transferBufferLength > 0) {
+                        val bytes = ByteArray(transferBufferLength)
+                        channel.readFully(bytes, 0, transferBufferLength)
+                        bytes
+                    } else {
+                        ByteArray(0)
+                    }
+
+                    SubmitRequest(
+                        seqnum = seqnum, devid = devid, direction = direction, ep = ep,
+                        transferFlags = transferFlags, transferBufferLength = transferBufferLength,
+                        startFrame = startFrame, numberOfPackets = numberOfPackets, interval = interval,
+                        setup = SubmitRequest.Setup.parse(setupBytes), transferBuffer = transferBuffer
+                    )
+                }
+                UnlinkRequest.COMMAND -> {
+                    val unlinkSeqnum = channel.readInt()
+                    // skip remaining 24 bytes of padding
+                    val padding = ByteArray(24)
+                    channel.readFully(padding, 0, padding.size)
+                    UnlinkRequest(seqnum = seqnum, unlinkSeqnum = unlinkSeqnum)
+                }
+                else -> throw IllegalArgumentException("Unknown URB command: 0x${Integer.toHexString(command)}")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UrbStatus.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/UrbStatus.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.data.urb
+
+/** URB completion status codes (Linux errno values). */
+enum class UrbStatus(val value: Int) {
+    SUCCESS(0),
+    EINVAL(-22),
+    EPIPE(-32),
+    ECONNRESET(-104);
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/ControlEndpoint.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/ControlEndpoint.kt
@@ -21,12 +21,6 @@ class ControlEndpoint(
         private const val USB_REQ_GET_DESCRIPTOR = 0x06
         private const val USB_REQ_SET_CONFIGURATION = 0x09
         private const val USB_REQ_SET_IDLE = 0x0A
-
-        private const val USB_DT_DEVICE = 0x01
-        private const val USB_DT_CONFIG = 0x02
-        private const val USB_DT_STRING = 0x03
-        private const val USB_DT_HID = 0x21
-        private const val USB_DT_REPORT = 0x22
     }
 
     fun process(request: SubmitRequest): SubmitResponse {
@@ -58,11 +52,11 @@ class ControlEndpoint(
             Integer.toHexString(descriptorType), descriptorIndex, setup.wLength)
 
         val descriptorData = when (descriptorType) {
-            USB_DT_DEVICE -> USBDescriptors.generateDeviceDescriptor(config)
-            USB_DT_CONFIG -> USBDescriptors.generateConfigurationDescriptor()
-            USB_DT_STRING -> USBDescriptors.generateStringDescriptor(descriptorIndex, config.deviceName)
-            USB_DT_REPORT -> USBDescriptors.getReportDescriptor()
-            USB_DT_HID -> USBDescriptors.getHIDDescriptor()
+            USBDescriptors.USB_DT_DEVICE -> USBDescriptors.generateDeviceDescriptor(config)
+            USBDescriptors.USB_DT_CONFIG -> USBDescriptors.generateConfigurationDescriptor()
+            USBDescriptors.USB_DT_STRING -> USBDescriptors.generateStringDescriptor(descriptorIndex, config.deviceName)
+            USBDescriptors.USB_DT_REPORT -> USBDescriptors.getReportDescriptor()
+            USBDescriptors.USB_DT_HID -> USBDescriptors.getHIDDescriptor()
             else -> {
                 logger.warn("Unknown descriptor type: 0x{}", Integer.toHexString(descriptorType))
                 return SubmitResponse.error(request, UrbStatus.EPIPE)

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/ControlEndpoint.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/ControlEndpoint.kt
@@ -1,0 +1,86 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.endpoint
+
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.SubmitRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.UrbStatus
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.SubmitResponse
+import org.slf4j.LoggerFactory
+
+/**
+ * USB control endpoint (EP0) emulation.
+ * Responds to standard USB requests: GET_DESCRIPTOR, SET_CONFIGURATION, SET_IDLE.
+ */
+class ControlEndpoint(
+    private val config: USBIPDeviceConfig
+) {
+    private val logger = LoggerFactory.getLogger(ControlEndpoint::class.java)
+
+    companion object {
+        const val EP_NUMBER = 0x00
+
+        private const val USB_REQ_GET_DESCRIPTOR = 0x06
+        private const val USB_REQ_SET_CONFIGURATION = 0x09
+        private const val USB_REQ_SET_IDLE = 0x0A
+
+        private const val USB_DT_DEVICE = 0x01
+        private const val USB_DT_CONFIG = 0x02
+        private const val USB_DT_STRING = 0x03
+        private const val USB_DT_HID = 0x21
+        private const val USB_DT_REPORT = 0x22
+    }
+
+    fun process(request: SubmitRequest): SubmitResponse {
+        val setup = request.setup
+
+        logger.debug("Control request: type=0x{}, req=0x{}, value=0x{}, index=0x{}, length={}",
+            Integer.toHexString(setup.bmRequestType),
+            Integer.toHexString(setup.bRequest),
+            Integer.toHexString(setup.wValue),
+            Integer.toHexString(setup.wIndex),
+            setup.wLength)
+
+        return when (setup.bRequest) {
+            USB_REQ_GET_DESCRIPTOR -> processGetDescriptor(request, setup)
+            USB_REQ_SET_CONFIGURATION -> processSetConfiguration(request, setup.wValue)
+            USB_REQ_SET_IDLE -> processSetIdle(request)
+            else -> {
+                logger.warn("Unsupported control request: 0x{}", Integer.toHexString(setup.bRequest))
+                SubmitResponse.error(request, UrbStatus.EPIPE)
+            }
+        }
+    }
+
+    private fun processGetDescriptor(request: SubmitRequest, setup: SubmitRequest.Setup): SubmitResponse {
+        val descriptorType = (setup.wValue shr 8) and 0xFF
+        val descriptorIndex = setup.wValue and 0xFF
+
+        logger.debug("GET_DESCRIPTOR: type=0x{}, index={}, length={}",
+            Integer.toHexString(descriptorType), descriptorIndex, setup.wLength)
+
+        val descriptorData = when (descriptorType) {
+            USB_DT_DEVICE -> USBDescriptors.generateDeviceDescriptor(config)
+            USB_DT_CONFIG -> USBDescriptors.generateConfigurationDescriptor()
+            USB_DT_STRING -> USBDescriptors.generateStringDescriptor(descriptorIndex, config.deviceName)
+            USB_DT_REPORT -> USBDescriptors.getReportDescriptor()
+            USB_DT_HID -> USBDescriptors.getHIDDescriptor()
+            else -> {
+                logger.warn("Unknown descriptor type: 0x{}", Integer.toHexString(descriptorType))
+                return SubmitResponse.error(request, UrbStatus.EPIPE)
+            }
+        }
+
+        val responseData = descriptorData.copyOf(minOf(descriptorData.size, setup.wLength))
+        logger.debug("Returning {} bytes of descriptor data", responseData.size)
+        return SubmitResponse.ok(request, responseData)
+    }
+
+    private fun processSetConfiguration(request: SubmitRequest, value: Int): SubmitResponse {
+        logger.debug("SET_CONFIGURATION: value={}", value)
+        return SubmitResponse.ok(request, ByteArray(0))
+    }
+
+    private fun processSetIdle(request: SubmitRequest): SubmitResponse {
+        logger.debug("SET_IDLE request")
+        return SubmitResponse.ok(request, ByteArray(0))
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/InterruptEndpoint.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/InterruptEndpoint.kt
@@ -1,0 +1,49 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.endpoint
+
+import com.webauthn4j.ctap.authenticator.transport.hid.HIDTransport
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.SubmitRequest
+import com.webauthn4j.ctap.authenticator.transport.usbip.data.urb.SubmitResponse
+import kotlinx.coroutines.channels.Channel
+import org.slf4j.LoggerFactory
+
+/**
+ * Bridges USB HID interrupt endpoint transfers to [HIDTransport].
+ *
+ * OUT transfers pass HID data to [HIDTransport.onHIDDataReceived], which
+ * queues it for async processing. Resulting HID responses are delivered
+ * to [responses] for the session to pick up and return to pending IN requests.
+ *
+ * Each instance is scoped to a single session. When the session ends,
+ * [close] should be called to discard stale responses.
+ */
+class InterruptEndpoint(
+    private val hidTransport: HIDTransport
+) {
+    private val logger = LoggerFactory.getLogger(InterruptEndpoint::class.java)
+
+    val responses = Channel<ByteArray>(Channel.UNLIMITED)
+
+    companion object {
+        const val EP_NUMBER = 1
+    }
+
+    fun processOut(request: SubmitRequest): SubmitResponse {
+        logger.debug("Interrupt OUT: {} bytes", request.transferBuffer.size)
+
+        if (request.transferBuffer.isEmpty()) {
+            logger.warn("Interrupt OUT with no data")
+            return SubmitResponse.ok(request, ByteArray(0))
+        }
+
+        hidTransport.onHIDDataReceived(request.transferBuffer) { responseBytes ->
+            responses.trySend(responseBytes)
+            logger.debug("Queued response: {} bytes", responseBytes.size)
+        }
+
+        return SubmitResponse.ok(request, ByteArray(0))
+    }
+
+    fun close() {
+        responses.close()
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/InterruptEndpoint.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/InterruptEndpoint.kt
@@ -7,14 +7,11 @@ import kotlinx.coroutines.channels.Channel
 import org.slf4j.LoggerFactory
 
 /**
- * Bridges USB HID interrupt endpoint transfers to [HIDTransport].
+ * Bridges USB HID interrupt transfers to [HIDTransport].
  *
- * OUT transfers pass HID data to [HIDTransport.onHIDDataReceived], which
- * queues it for async processing. Resulting HID responses are delivered
- * to [responses] for the session to pick up and return to pending IN requests.
- *
- * Each instance is scoped to a single session. When the session ends,
- * [close] should be called to discard stale responses.
+ * OUT transfers forward HID data to [HIDTransport]; resulting responses
+ * are queued in [responses] for [URBProcessor] to pair with pending
+ * Interrupt IN requests. Each instance is scoped to a single session.
  */
 class InterruptEndpoint(
     private val hidTransport: HIDTransport
@@ -27,7 +24,7 @@ class InterruptEndpoint(
         const val EP_NUMBER = 1
     }
 
-    fun processOut(request: SubmitRequest): SubmitResponse {
+    fun process(request: SubmitRequest): SubmitResponse {
         logger.debug("Interrupt OUT: {} bytes", request.transferBuffer.size)
 
         if (request.transferBuffer.isEmpty()) {

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/USBDescriptors.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/USBDescriptors.kt
@@ -1,0 +1,170 @@
+package com.webauthn4j.ctap.authenticator.transport.usbip.endpoint
+
+import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
+
+/**
+ * USB descriptor generator for a FIDO HID device.
+ * Produces device, configuration, HID, report, and string descriptors
+ * used by [ControlEndpoint] to respond to GET_DESCRIPTOR requests.
+ */
+object USBDescriptors {
+
+    /**
+     * Standard FIDO HID report descriptor (34 bytes).
+     * Defines 64-byte input and output reports for FIDO Alliance Usage Page (0xF1D0).
+     */
+    private val FIDO_HID_REPORT_DESCRIPTOR = byteArrayOf(
+        0x06, 0xD0.toByte(), 0xF1.toByte(),   // Usage Page (FIDO Alliance = 0xF1D0)
+        0x09, 0x01,                             // Usage (U2F HID Authenticator Device)
+        0xA1.toByte(), 0x01,                    // Collection (Application)
+        0x09, 0x20,                             //   Usage (Input Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x81.toByte(), 0x02,                    //   Input (Data, Var, Abs)
+        0x09, 0x21,                             //   Usage (Output Report Data)
+        0x15, 0x00,                             //   Logical Minimum (0)
+        0x26, 0xFF.toByte(), 0x00,              //   Logical Maximum (255)
+        0x75, 0x08,                             //   Report Size (8)
+        0x95.toByte(), 0x40,                    //   Report Count (64)
+        0x91.toByte(), 0x02,                    //   Output (Data, Var, Abs)
+        0xC0.toByte()                           // End Collection
+    )
+
+    /**
+     * Generates USB device descriptor (18 bytes).
+     * Describes basic device properties like VID/PID and USB version.
+     */
+    fun generateDeviceDescriptor(config: USBIPDeviceConfig): ByteArray {
+        return byteArrayOf(
+            0x12,                                // bLength (18 bytes)
+            0x01,                                // bDescriptorType (Device)
+            0x00, 0x02,                          // bcdUSB (USB 2.0)
+            0x00,                                // bDeviceClass (defined in interface)
+            0x00,                                // bDeviceSubClass
+            0x00,                                // bDeviceProtocol
+            0x40,                                // bMaxPacketSize0 (64 bytes)
+            (config.vendorId and 0xFF).toByte(),
+            ((config.vendorId shr 8) and 0xFF).toByte(),
+            (config.productId and 0xFF).toByte(),
+            ((config.productId shr 8) and 0xFF).toByte(),
+            (config.version and 0xFF).toByte(),
+            ((config.version shr 8) and 0xFF).toByte(),
+            0x01,                                // iManufacturer (string index 1)
+            0x02,                                // iProduct (string index 2)
+            0x00,                                // iSerialNumber (none)
+            0x01                                 // bNumConfigurations
+        )
+    }
+
+    /**
+     * Generates complete configuration descriptor tree (41 bytes).
+     * Includes: Configuration + Interface + HID + 2 Endpoints (IN + OUT).
+     */
+    fun generateConfigurationDescriptor(): ByteArray {
+        val totalLength = 9 + 9 + 9 + 7 + 7  // Config + Interface + HID + EP_IN + EP_OUT = 41
+
+        return byteArrayOf(
+            // Configuration Descriptor (9 bytes)
+            0x09,                                // bLength
+            0x02,                                // bDescriptorType (Configuration)
+            (totalLength and 0xFF).toByte(),
+            ((totalLength shr 8) and 0xFF).toByte(),  // wTotalLength
+            0x01,                                // bNumInterfaces
+            0x01,                                // bConfigurationValue
+            0x00,                                // iConfiguration
+            0xA0.toByte(),                       // bmAttributes (Bus powered, Remote wakeup)
+            0x32,                                // bMaxPower (100mA)
+
+            // Interface Descriptor (9 bytes)
+            0x09,                                // bLength
+            0x04,                                // bDescriptorType (Interface)
+            0x00,                                // bInterfaceNumber
+            0x00,                                // bAlternateSetting
+            0x02,                                // bNumEndpoints (IN + OUT)
+            0x03,                                // bInterfaceClass (HID)
+            0x00,                                // bInterfaceSubClass
+            0x00,                                // bInterfaceProtocol
+            0x00,                                // iInterface
+
+            // HID Descriptor (9 bytes)
+            0x09,                                // bLength
+            0x21,                                // bDescriptorType (HID)
+            0x11, 0x01,                          // bcdHID (HID 1.11)
+            0x00,                                // bCountryCode
+            0x01,                                // bNumDescriptors
+            0x22,                                // bDescriptorType (Report)
+            (FIDO_HID_REPORT_DESCRIPTOR.size and 0xFF).toByte(),
+            ((FIDO_HID_REPORT_DESCRIPTOR.size shr 8) and 0xFF).toByte(),
+
+            // Endpoint Descriptor - Interrupt IN (7 bytes)
+            0x07,                                // bLength
+            0x05,                                // bDescriptorType (Endpoint)
+            0x81.toByte(),                       // bEndpointAddress (IN, EP1)
+            0x03,                                // bmAttributes (Interrupt)
+            0x40, 0x00,                          // wMaxPacketSize (64 bytes)
+            0x05,                                // bInterval (5ms)
+
+            // Endpoint Descriptor - Interrupt OUT (7 bytes)
+            0x07,                                // bLength
+            0x05,                                // bDescriptorType (Endpoint)
+            0x01,                                // bEndpointAddress (OUT, EP1)
+            0x03,                                // bmAttributes (Interrupt)
+            0x40, 0x00,                          // wMaxPacketSize (64 bytes)
+            0x05                                 // bInterval (5ms)
+        )
+    }
+
+    /**
+     * Returns the FIDO HID report descriptor.
+     */
+    fun getReportDescriptor(): ByteArray {
+        return FIDO_HID_REPORT_DESCRIPTOR
+    }
+
+    /**
+     * Returns the 9-byte HID class descriptor.
+     */
+    fun getHIDDescriptor(): ByteArray {
+        return byteArrayOf(
+            0x09,                                // bLength
+            0x21,                                // bDescriptorType (HID)
+            0x11, 0x01,                          // bcdHID (HID 1.11)
+            0x00,                                // bCountryCode
+            0x01,                                // bNumDescriptors
+            0x22,                                // bDescriptorType (Report)
+            (FIDO_HID_REPORT_DESCRIPTOR.size and 0xFF).toByte(),
+            ((FIDO_HID_REPORT_DESCRIPTOR.size shr 8) and 0xFF).toByte()
+        )
+    }
+
+    /**
+     * Generates USB string descriptor.
+     * @param index String descriptor index (0 = language IDs, 1 = manufacturer, 2 = product)
+     * @param value String value (used for product name from config)
+     */
+    fun generateStringDescriptor(index: Int, value: String = ""): ByteArray {
+        return when (index) {
+            0 -> byteArrayOf(
+                0x04,                            // bLength
+                0x03,                            // bDescriptorType (String)
+                0x09, 0x04                       // Language ID: English (US) = 0x0409
+            )
+            1 -> encodeStringDescriptor("WebAuthn4J")
+            2 -> encodeStringDescriptor(value)
+            else -> byteArrayOf(0x02, 0x03)      // Empty string
+        }
+    }
+
+    /**
+     * Encodes a string as UTF-16LE for USB string descriptor.
+     */
+    private fun encodeStringDescriptor(str: String): ByteArray {
+        val utf16 = str.toByteArray(Charsets.UTF_16LE)
+        return byteArrayOf(
+            (utf16.size + 2).toByte(),           // bLength
+            0x03                                  // bDescriptorType (String)
+        ) + utf16
+    }
+}

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/USBDescriptors.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/endpoint/USBDescriptors.kt
@@ -2,17 +2,15 @@ package com.webauthn4j.ctap.authenticator.transport.usbip.endpoint
 
 import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
 
-/**
- * USB descriptor generator for a FIDO HID device.
- * Produces device, configuration, HID, report, and string descriptors
- * used by [ControlEndpoint] to respond to GET_DESCRIPTOR requests.
- */
+/** USB descriptor constants and generators for a FIDO HID device. */
 object USBDescriptors {
 
-    /**
-     * Standard FIDO HID report descriptor (34 bytes).
-     * Defines 64-byte input and output reports for FIDO Alliance Usage Page (0xF1D0).
-     */
+    const val USB_DT_DEVICE = 0x01
+    const val USB_DT_CONFIG = 0x02
+    const val USB_DT_STRING = 0x03
+    const val USB_DT_HID = 0x21
+    const val USB_DT_REPORT = 0x22
+
     private val FIDO_HID_REPORT_DESCRIPTOR = byteArrayOf(
         0x06, 0xD0.toByte(), 0xF1.toByte(),   // Usage Page (FIDO Alliance = 0xF1D0)
         0x09, 0x01,                             // Usage (U2F HID Authenticator Device)
@@ -32,10 +30,6 @@ object USBDescriptors {
         0xC0.toByte()                           // End Collection
     )
 
-    /**
-     * Generates USB device descriptor (18 bytes).
-     * Describes basic device properties like VID/PID and USB version.
-     */
     fun generateDeviceDescriptor(config: USBIPDeviceConfig): ByteArray {
         return byteArrayOf(
             0x12,                                // bLength (18 bytes)
@@ -58,12 +52,19 @@ object USBDescriptors {
         )
     }
 
-    /**
-     * Generates complete configuration descriptor tree (41 bytes).
-     * Includes: Configuration + Interface + HID + 2 Endpoints (IN + OUT).
-     */
+    private val HID_DESCRIPTOR = byteArrayOf(
+        0x09,                                // bLength
+        0x21,                                // bDescriptorType (HID)
+        0x11, 0x01,                          // bcdHID (HID 1.11)
+        0x00,                                // bCountryCode
+        0x01,                                // bNumDescriptors
+        0x22,                                // bDescriptorType (Report)
+        (FIDO_HID_REPORT_DESCRIPTOR.size and 0xFF).toByte(),
+        ((FIDO_HID_REPORT_DESCRIPTOR.size shr 8) and 0xFF).toByte()
+    )
+
     fun generateConfigurationDescriptor(): ByteArray {
-        val totalLength = 9 + 9 + 9 + 7 + 7  // Config + Interface + HID + EP_IN + EP_OUT = 41
+        val totalLength = 9 + 9 + HID_DESCRIPTOR.size + 7 + 7
 
         return byteArrayOf(
             // Configuration Descriptor (9 bytes)
@@ -86,18 +87,8 @@ object USBDescriptors {
             0x03,                                // bInterfaceClass (HID)
             0x00,                                // bInterfaceSubClass
             0x00,                                // bInterfaceProtocol
-            0x00,                                // iInterface
-
-            // HID Descriptor (9 bytes)
-            0x09,                                // bLength
-            0x21,                                // bDescriptorType (HID)
-            0x11, 0x01,                          // bcdHID (HID 1.11)
-            0x00,                                // bCountryCode
-            0x01,                                // bNumDescriptors
-            0x22,                                // bDescriptorType (Report)
-            (FIDO_HID_REPORT_DESCRIPTOR.size and 0xFF).toByte(),
-            ((FIDO_HID_REPORT_DESCRIPTOR.size shr 8) and 0xFF).toByte(),
-
+            0x00                                 // iInterface
+        ) + HID_DESCRIPTOR + byteArrayOf(
             // Endpoint Descriptor - Interrupt IN (7 bytes)
             0x07,                                // bLength
             0x05,                                // bDescriptorType (Endpoint)
@@ -116,34 +107,14 @@ object USBDescriptors {
         )
     }
 
-    /**
-     * Returns the FIDO HID report descriptor.
-     */
     fun getReportDescriptor(): ByteArray {
         return FIDO_HID_REPORT_DESCRIPTOR
     }
 
-    /**
-     * Returns the 9-byte HID class descriptor.
-     */
     fun getHIDDescriptor(): ByteArray {
-        return byteArrayOf(
-            0x09,                                // bLength
-            0x21,                                // bDescriptorType (HID)
-            0x11, 0x01,                          // bcdHID (HID 1.11)
-            0x00,                                // bCountryCode
-            0x01,                                // bNumDescriptors
-            0x22,                                // bDescriptorType (Report)
-            (FIDO_HID_REPORT_DESCRIPTOR.size and 0xFF).toByte(),
-            ((FIDO_HID_REPORT_DESCRIPTOR.size shr 8) and 0xFF).toByte()
-        )
+        return HID_DESCRIPTOR
     }
 
-    /**
-     * Generates USB string descriptor.
-     * @param index String descriptor index (0 = language IDs, 1 = manufacturer, 2 = product)
-     * @param value String value (used for product name from config)
-     */
     fun generateStringDescriptor(index: Int, value: String = ""): ByteArray {
         return when (index) {
             0 -> byteArrayOf(
@@ -157,9 +128,6 @@ object USBDescriptors {
         }
     }
 
-    /**
-     * Encodes a string as UTF-16LE for USB string descriptor.
-     */
     private fun encodeStringDescriptor(str: String): ByteArray {
         val utf16 = str.toByteArray(Charsets.UTF_16LE)
         return byteArrayOf(


### PR DESCRIPTION
## Summary
- USB-IP protocol implementation for exposing a virtual FIDO2 authenticator over TCP/IP
- Select-based event loop (URBProcessor) for concurrent URB and HID response handling
- USB control/interrupt endpoint emulation with proper descriptor support

## Test plan
- [ ] `./gradlew build` passes
- [ ] USB-IP server starts and accepts connections
- [ ] FIDO2 Conformance Tools pass with USB-IP transport