### PR TITLE
Fix Discoverable Credentials and ClientPIN conformance test failures

### DIFF
--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
@@ -2,6 +2,7 @@ package com.webauthn4j.unifidokey.usbip
 
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
+import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDevice
 import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
 import kotlinx.coroutines.CoroutineScope
@@ -29,7 +30,9 @@ class UniFIDOKeyUSBIP : Runnable {
         val authenticator = CtapAuthenticator(
             attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey(),
             userVerificationHandler = ConsoleUserVerificationHandler()
-        )
+        ).apply {
+            credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
+        }
         val device = USBIPDevice(authenticator, config)
         val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/USBIPDevice.kt
@@ -50,15 +50,17 @@ class USBIPDevice(
                     val clientSocket = serverSocket.accept()
                     logger.info("Client connected from {}", clientSocket.remoteAddress)
 
+                    val remoteAddress = clientSocket.remoteAddress
                     launch {
                         try {
                             clientSocket.use { socket ->
                                 USBIPSession.create(socket, deviceInfo, config, hidTransport).use { session ->
+                                    hidTransport.onDeviceAttached()
                                     URBProcessor(session).process()
                                 }
                             }
                         } catch (e: java.io.IOException) {
-                            logger.debug("Session ended: {} ({})", clientSocket.remoteAddress, e.message)
+                            logger.debug("Session ended: {} ({})", remoteAddress, e.message)
                         } catch (e: Exception) {
                             logger.error("Session error", e)
                         }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -176,7 +176,7 @@ class CtapAuthenticatorSession internal constructor(
     }
 
     fun resetVolatileState() {
-        clientPINService.resetVolatilePinRetryCounter()
+        clientPINService.regenerateKeys()
     }
 
     internal fun publishEvent(event: Event) {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
@@ -94,6 +94,10 @@ class HIDTransport(
         hidChannels.clear()
     }
 
+    fun onDeviceAttached() {
+        ctapAuthenticatorSession.resetVolatileState()
+    }
+
     fun onHIDDataReceived(bytes: ByteArray, hidPacketHandler: HIDPacketHandler) {
         val commandStartTime = currentCommandStartTimeMs
         if (commandStartTime > 0) {
@@ -129,7 +133,6 @@ class HIDTransport(
                         logger.debug("Cancelling ongoing CBOR on channel {} before processing broadcast INIT", activeChannel)
                         hidChannels[activeChannel]?.cancelAndAwaitCbor()
                     }
-                    ctapAuthenticatorSession.resetVolatileState()
                     val tempChannel = createChannel(channelId)
                     tempChannel.handlePacket(hidPacket) { responsePacket ->
                         logger.debug(CTAP_RESPONSE_HID_PACKET_LOGGING_TEMPLATE, responsePacket.toString())


### PR DESCRIPTION
- Set `credentialSelector` to `CLIENT_PLATFORM` for the display-less virtual authenticator so GetAssertion returns all credentials via GetNextAssertion (fixes `numberOfCredentials` always being 1)
- Remove volatile PIN retry counter reset from broadcast INIT — per CTAP2 spec §5.5.2, it should only reset on power cycle, not on HID channel initialization
- Add `onDeviceAttached()` to HIDTransport, called after USB-IP IMPORT handshake to simulate power cycle (regenerate keys, pinToken, and reset volatile counter)
- Fix `ClosedChannelException` when logging disconnection by capturing `remoteAddress` before socket close