### PR TITLE
Add PIN/UV Auth Protocol v2 support

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/ClientPINService.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/ClientPINService.kt
@@ -5,81 +5,68 @@ import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINResponseData
 import com.webauthn4j.ctap.core.data.CtapStatusCode
+import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.core.util.internal.ArrayUtil
-import com.webauthn4j.ctap.core.util.internal.CipherUtil
-import com.webauthn4j.ctap.core.util.internal.KeyAgreementUtil
 import com.webauthn4j.data.attestation.authenticator.COSEKey
-import com.webauthn4j.data.attestation.authenticator.EC2COSEKey
-import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
-import com.webauthn4j.util.ECUtil
-import com.webauthn4j.util.MACUtil
 import com.webauthn4j.util.MessageDigestUtil
 import java.nio.ByteBuffer
-import java.security.SecureRandom
-import java.security.interfaces.ECPrivateKey
-import java.security.interfaces.ECPublicKey
 import java.util.Arrays
-import javax.crypto.SecretKey
-import javax.crypto.spec.SecretKeySpec
 
-// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorClientPIN">5.5. authenticatorClientPIN</a>
-class ClientPINService(private val authenticatorPropertyStore: AuthenticatorPropertyStore) {
+/**
+ * Service handling authenticatorClientPIN command operations.
+ *
+ * Supports multiple PIN/UV Auth Protocol versions by delegating cryptographic operations
+ * to [PinUvAuthProtocol] instances.
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorClientPIN">6.5. authenticatorClientPIN</a>
+ */
+class ClientPINService(
+    private val authenticatorPropertyStore: AuthenticatorPropertyStore,
+    private val protocols: List<PinUvAuthProtocol> = listOf(PinUvAuthProtocolV1())
+) {
 
     companion object {
         const val MAX_PIN_RETRIES: UInt = 8u
         const val MAX_VOLATILE_PIN_RETRIES = 3
-        private val ZERO_IV = byteArrayOf(
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-        )
-        private val ECDH_ES_HKDF_256 = COSEAlgorithmIdentifier.create(-25)
     }
-
-    //spec| 5.5.2 Authenticator Configuration Operations Upon Power Up
-    //spec| Generate "authenticatorKeyAgreementKey":
-    //spec| Generate an ECDH P-256 key pair called "authenticatorKeyAgreementKey"
-    //spec| denoted by (a, aG) where "a" denotes the private key and "aG" denotes the public key.
-    var authenticatorKeyAgreementKey = ECUtil.createKeyPair()
-
-    //spec| Generate "pinToken":
-    //spec| Generate a random integer of length which is multiple of 16 bytes (AES block length).
-    val pinToken = ByteArray(16)
 
     private var volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
 
-    init {
-        SecureRandom().nextBytes(pinToken)
+    private val protocolMap: Map<PinProtocolVersion, PinUvAuthProtocol> = protocols.associateBy { it.version }
+
+    fun getProtocol(pinProtocol: PinProtocolVersion): PinUvAuthProtocol {
+        return protocolMap[pinProtocol]
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
     }
 
-    //spec| 5.5.3 Getting Retries from Authenticator
-    //spec| Retries count is the number of attempts remaining before lockout.
-    //spec| Authenticator responds back with retries.
+    //spec| 6.5.5.2 Platform getting PIN retries from Authenticator
+    //spec| Authenticator responds back with pinRetries and, optionally, powerCycleState.
     fun getPinRetries(): AuthenticatorClientPINResponse {
         val pinRetries = authenticatorPropertyStore.loadPINRetries()
         val responseData = AuthenticatorClientPINResponseData(null, null, pinRetries)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
-    //spec| 5.5.4 Getting sharedSecret from Authenticator
-    //spec| Authenticator responds back with public key of authenticatorKeyAgreementKey, "aG".
-    fun getKeyAgreement(): AuthenticatorClientPINResponse {
-        val keyAgreement = EC2COSEKey.create(
-            (authenticatorKeyAgreementKey.public as ECPublicKey),
-            ECDH_ES_HKDF_256
-        )
+    //spec| 6.5.5.4 Obtaining the Shared Secret
+    //spec| Otherwise the authenticator sends a response with the following parameters:
+    //spec| keyAgreement: the result of calling getPublicKey for the selected pinUvAuthProtocol.
+    fun getKeyAgreement(pinProtocol: PinProtocolVersion): AuthenticatorClientPINResponse {
+        val protocol = getProtocol(pinProtocol)
+        val keyAgreement = protocol.getPublicKey()
         val responseData = AuthenticatorClientPINResponseData(keyAgreement, null, null)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
-    //spec| 5.5.5 Setting a New PIN
+    //spec| 6.5.5.5 Setting a New PIN
     //spec| Authenticator performs following operations upon receiving the request:
     fun setPIN(
+        pinProtocol: PinProtocolVersion,
         platformKeyAgreementKey: COSEKey?,
         pinAuth: ByteArray?,
         newPinEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
 
-        //spec| If Authenticator does not receive mandatory parameters for this command,
+        //spec| If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinAuth == null || newPinEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
@@ -88,37 +75,37 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         if (isClientPINReady) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of
-        //spec| authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
-        val sharedSecret = generateSharedSecret(platformKeyAgreementKey)
 
-        //spec| Authenticator verifies pinAuth by generating LEFT(HMAC-SHA-256(sharedSecret, newPinEnc), 16)
-        //spec| and matching against input pinAuth parameter.
-        //spec| If pinAuth verification fails, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
-        val mac = MACUtil.calculateHmacSHA256(newPinEnc, sharedSecret, 16)
-        if (!Arrays.equals(mac, pinAuth)) {
+        val protocol = getProtocol(pinProtocol)
+
+        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+        val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
+
+        //spec| The authenticator calls verify(shared secret, newPinEnc, pinUvAuthParam)
+        //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
+        if (!protocol.verify(sharedSecret, newPinEnc, pinAuth)) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| Authenticator decrypts newPinEnc using above "sharedSecret" producing newPin and
-        //spec| checks newPin length against minimum PIN length of 4 bytes.
-        //spec| The decrypted padded newPin should be of at least 64 bytes length and authenticator
-        //spec| determines actual PIN length by looking for first 0x00 byte which terminates the PIN.
-        //spec| If minimum PIN length check fails, authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION error.
-        val secretKey: SecretKey = SecretKeySpec(sharedSecret, "AES")
-        val newPIN = CipherUtil.decryptWithAESCBCNoPadding(newPinEnc, secretKey, ZERO_IV)
+        //spec| The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
+        //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
+        val newPIN = protocol.decrypt(sharedSecret, newPinEnc)
+        //spec| The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
         val sentinelPos = newPIN.indexOf(0x00)
         val trimmedNewPIN: ByteArray = when {
             (sentinelPos < 0) -> newPIN
             else -> newPIN.copyOf(sentinelPos)
         }
+        //spec| The authenticator checks the length of newPin against the current minimum PIN length,
+        //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
         if (trimmedNewPIN.size < 4) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        //spec| Authenticator stores LEFT(SHA-256(newPin), 16) on the device,
-        //spec| sets the retries counter to 8, and returns CTAP2_OK.
+        //spec| The authenticator stores LEFT(SHA-256(newPin), 16) internally as CurrentStoredPIN,
+        //spec| sets the pinRetries counter to maximum count, and returns CTAP2_OK.
         authenticatorPropertyStore.saveClientPIN(
             Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
         )
@@ -126,56 +113,56 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
-    //spec| 5.5.6 Changing existing PIN
+    //spec| 6.5.5.6 Changing existing PIN
     //spec| Authenticator performs following operations upon receiving the request:
     fun changePIN(
+        pinProtocol: PinProtocolVersion,
         platformKeyAgreementKey: COSEKey?,
         pinAuth: ByteArray?,
         newPinEnc: ByteArray?,
         pinHashEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
-        //spec| If Authenticator does not receive mandatory parameters for this command,
+        //spec| If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinAuth == null || newPinEnc == null || pinHashEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
         if (authenticatorPropertyStore.loadPINRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
         }
-        //spec| Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of
-        //spec| authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
-        val sharedSecret = generateSharedSecret(platformKeyAgreementKey)
-        //spec| Authenticator verifies pinAuth by generating LEFT(HMAC-SHA-256(sharedSecret, newPinEnc || pinHashEnc), 16)
-        //spec| and matching against input pinAuth parameter.
-        //spec| If pinAuth verification fails, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
+
+        val protocol = getProtocol(pinProtocol)
+
+        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+        val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
+        //spec| The authenticator calls verify(shared secret, newPinEnc || pinHashEnc, pinUvAuthParam)
+        //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
         val joined =
             ByteBuffer.allocate(newPinEnc.size + pinHashEnc.size).put(newPinEnc).put(pinHashEnc)
                 .array()
-        val mac = MACUtil.calculateHmacSHA256(joined, sharedSecret, 16)
-        if (!Arrays.equals(mac, pinAuth)) {
+        if (!protocol.verify(sharedSecret, joined, pinAuth)) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| Authenticator decrements the retries counter by 1.
+        //spec| The authenticator decrements the pinRetries counter by 1.
         authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
 
-        //spec| Authenticator decrypts pinHashEnc and verifies against its internal stored LEFT(SHA-256(curPin), 16).
-        val secretKey: SecretKey = SecretKeySpec(sharedSecret, "AES")
-        val pinHash = CipherUtil.decryptWithAESCBCNoPadding(pinHashEnc, secretKey, ZERO_IV)
+        //spec| The authenticator decrypts pinHashEnc using decrypt(shared secret, pinHashEnc)
+        //spec| and verifies against its internal stored LEFT(SHA-256(curPin), 16).
+        val pinHash = protocol.decrypt(sharedSecret, pinHashEnc)
         val storedPinHash =
             authenticatorPropertyStore.loadClientPIN() ?: return AuthenticatorClientPINResponse(
                 CtapStatusCode.CTAP2_ERR_PIN_NOT_SET
             )
 
         if (!Arrays.equals(pinHash, storedPinHash)) {
-            //spec| If a mismatch is detected, the authenticator performs the following operations:
-            //spec| Authenticator generates a new "authenticatorKeyAgreementKey".
-            //spec| Generate a new ECDH P-256 key pair called "authenticatorKeyAgreementKey" denoted by
-            //spec| (a, aG), where "a" denotes the private key and "aG" denotes the public key.
-            authenticatorKeyAgreementKey = ECUtil.createKeyPair()
+            //spec| If an error results, or a mismatch is detected, the authenticator performs the following operations:
+            //spec| Calls regenerate for the selected pinUvAuthProtocol.
+            protocol.regenerate()
             volatilePinRetryCounter--
-            //spec| Authenticator returns errors according to following conditions:
-            //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+            //spec| The authenticator returns errors according to following conditions:
+            //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
             //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
             //spec| indicating that power cycling is needed for further operations. This is done so that malware
             //spec| running on the platform should not be able to block the device without user interaction.
@@ -189,15 +176,15 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
                     AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
             }
         }
-        //spec| Authenticator sets the retries counter to 8.
+        //spec| The authenticator sets the pinRetries counter to maximum value.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
-        //spec| Authenticator decrypts newPinEnc using above "sharedSecret" producing newPin and
-        //spec| checks newPin length against minimum PIN length of 4 bytes.
-        //spec| The decrypted padded newPin should be of at least 64 bytes length and authenticator
-        //spec| determines actual PIN length by looking for first 0x00 byte which terminates the PIN.
-        //spec| If minimum PIN length check fails, authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION error.
-        val newPIN = CipherUtil.decryptWithAESCBCNoPadding(newPinEnc, secretKey, ZERO_IV)
+        //spec| The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
+        //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
+        //spec| The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
+        //spec| The authenticator checks the length of newPin against the current minimum PIN length,
+        //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
+        val newPIN = protocol.decrypt(sharedSecret, newPinEnc)
         val sentinelPos = ArrayUtil.indexOf(newPIN, 0x00.toByte())
         if (sentinelPos < 0) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
@@ -209,53 +196,56 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        //spec| Authenticator stores LEFT(SHA-256(newPin), 16) on the device and returns CTAP2_OK.
+        //spec| The authenticator stores LEFT(SHA-256(newPin), 16) internally as the new value of CurrentStoredPIN.
+        //spec| The authenticator returns CTAP2_OK.
         authenticatorPropertyStore.saveClientPIN(
             Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
         )
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
-    //spec| 5.5.7 Getting pinToken from the Authenticator
+    //spec| 6.5.5.7.1 Getting pinUvAuthToken using getPinToken (superseded)
     //spec| Authenticator performs following operations upon receiving the request:
     fun getPinToken(
+        pinProtocol: PinProtocolVersion,
         platformKeyAgreementKey: COSEKey?,
         pinHashEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
-        //spec| If Authenticator does not receive mandatory parameters for this command,
+        //spec| If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinHashEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
         if (authenticatorPropertyStore.loadPINRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
         }
         if (volatilePinRetryCounter <= 0) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
         }
-        //spec| Authenticator generates "sharedSecret": SHA-256((abG).x) using private key of
-        //spec| authenticatorKeyAgreementKey, "a" and public key of platformKeyAgreementKey, "bG".
-        val sharedSecret = generateSharedSecret(platformKeyAgreementKey)
-        //spec| Authenticator decrements the retries counter by 1.
+
+        val protocol = getProtocol(pinProtocol)
+
+        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+        val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
+        //spec| The authenticator decrements the pinRetries counter by 1.
         authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
 
-        //spec| Authenticator decrypts pinHashEnc and verifies against its internal stored LEFT(SHA-256(curPin), 16).
-        val secretKey: SecretKey = SecretKeySpec(sharedSecret, "AES")
-        val pinHash = CipherUtil.decryptWithAESCBCNoPadding(pinHashEnc, secretKey, ZERO_IV)
+        //spec| The authenticator decrypts pinHashEnc using decrypt and verifies against its
+        //spec| internally stored CurrentStoredPIN.
+        val pinHash = protocol.decrypt(sharedSecret, pinHashEnc)
         val storedPinHash =
             authenticatorPropertyStore.loadClientPIN() ?: return AuthenticatorClientPINResponse(
                 CtapStatusCode.CTAP2_ERR_PIN_NOT_SET
             )
         if (!Arrays.equals(pinHash, storedPinHash)) {
-            //spec| If a mismatch is detected, the authenticator performs the following operations:
-            //spec| Authenticator generates a new "authenticatorKeyAgreementKey".
-            //spec| Generate a new ECDH P-256 key pair called "authenticatorKeyAgreementKey" denoted by
-            //spec| (a, aG), where "a" denotes the private key and "aG" denotes the public key.
-            authenticatorKeyAgreementKey = ECUtil.createKeyPair()
+            //spec| If an error results, or a mismatch is detected, the authenticator performs the following operations:
+            //spec| Calls regenerate for the selected pinUvAuthProtocol.
+            protocol.regenerate()
             volatilePinRetryCounter--
-            //spec| Authenticator returns errors according to following conditions:
-            //spec| If the retries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+            //spec| The authenticator returns errors according to following conditions:
+            //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
             //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
             //spec| indicating that power cycling is needed for further operations. This is done so that malware
             //spec| running on the platform should not be able to block the device without user interaction.
@@ -269,34 +259,33 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
                     AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
             }
         }
-        //spec| Authenticator sets the retries counter to 8.
+        //spec| The authenticator sets the pinRetries counter to maximum value.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
-        //spec| Authenticator returns encrypted pinToken using "sharedSecret": AES256-CBC(sharedSecret, IV=0, pinToken).
-        //spec| pinToken should be a multiple of 16 bytes (AES block length) without any padding or IV.
-        //spec| There is no PKCS #7 padding used in this scheme.
-        val pinTokenEnc = CipherUtil.encryptWithAESCBCNoPadding(pinToken, secretKey, ZERO_IV)
+        //spec| The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
+        //spec| i.e. encrypt(shared secret, pinUvAuthToken).
+        val pinTokenEnc = protocol.encrypt(sharedSecret, protocol.pinUvAuthToken)
         val responseData =
             AuthenticatorClientPINResponseData(null, pinTokenEnc, null)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
-    fun generateSharedSecret(platformKeyAgreementKey: COSEKey): ByteArray {
-        return MessageDigestUtil.createSHA256().digest(
-            KeyAgreementUtil.generateSecret(
-                authenticatorKeyAgreementKey.private as ECPrivateKey,
-                platformKeyAgreementKey.publicKey as ECPublicKey?
-            )
-        )
-    }
-
-    //spec| verify it by matching it against first 16 bytes of HMAC-SHA-256 of clientDataHash parameter
-    //spec| using pinToken: HMAC-SHA-256(pinToken, clientDataHash).
-    fun validatePINAuth(pinAuth: ByteArray?, clientDataHash: ByteArray?) {
-        val calculatedPinAuth = MACUtil.calculateHmacSHA256(clientDataHash, pinToken, 16)
-        if (!Arrays.equals(calculatedPinAuth, pinAuth)) {
+    //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+    //spec| If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
+    fun verifyPinUvAuthParam(pinAuth: ByteArray?, clientDataHash: ByteArray?) {
+        if (pinAuth == null || clientDataHash == null) {
             throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
+        // Try verification against all protocols' pinUvAuthTokens
+        for (protocol in protocols) {
+            val calculatedPinAuth = protocol.authenticate(
+                protocol.pinUvAuthToken, clientDataHash
+            )
+            if (Arrays.equals(calculatedPinAuth, pinAuth)) {
+                return
+            }
+        }
+        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
     }
 
     val isClientPINReady: Boolean

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -34,6 +34,7 @@ class CtapAuthenticator(
     var attestationStatementProvider: AttestationStatementProvider = NoneAttestationStatementProvider(),
     var fidoU2FBasicAttestationStatementGenerator: FIDOU2FAttestationStatementProvider = FIDOU2FBasicAttestationStatementProvider.createWithDemoAttestationKey(),
     transports: Set<AuthenticatorTransport> = setOf(),
+    pinProtocols: Set<PinProtocolVersion> = setOf(PinProtocolVersion.VERSION_2, PinProtocolVersion.VERSION_1),
     val extensionProcessors: List<ExtensionProcessor> = listOf(),
     // Handlers
     var authenticatorPropertyStore: AuthenticatorPropertyStore = InMemoryAuthenticatorPropertyStore(),
@@ -62,8 +63,6 @@ class CtapAuthenticator(
         @JvmField
         val VERSIONS = listOf(VERSION_U2F_V2, VERSION_FIDO_2_0)
 
-        @JvmField
-        val PIN_PROTOCOLS = listOf(PinProtocolVersion.VERSION_1)
         private fun createObjectConverter(): ObjectConverter {
             val jsonMapper = JsonMapper()
             val cborMapper = CBORMapper.builder()
@@ -94,6 +93,7 @@ class CtapAuthenticator(
     }
 
     val transports: MutableSet<AuthenticatorTransport> = transports.toMutableSet()
+    val pinProtocols: Set<PinProtocolVersion> = pinProtocols
     internal val eventListeners: MutableList<EventListener> = mutableListOf()
     internal val exceptionReporters: MutableList<ExceptionReporter> = mutableListOf()
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -4,6 +4,7 @@ import com.webauthn4j.converter.AuthenticatorDataConverter
 import com.webauthn4j.ctap.authenticator.attestation.AttestationStatementProvider
 import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FAttestationStatementProvider
 import com.webauthn4j.ctap.authenticator.data.event.Event
+import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.authenticator.data.settings.*
 import com.webauthn4j.ctap.authenticator.execution.ClientPINExecution
 import com.webauthn4j.ctap.authenticator.execution.GetAssertionExecution
@@ -51,7 +52,19 @@ class CtapAuthenticatorSession internal constructor(
 
     val objectConverter = ctapAuthenticator.objectConverter
     val authenticatorDataConverter: AuthenticatorDataConverter = AuthenticatorDataConverter(ctapAuthenticator.objectConverter)
-    val clientPINService: ClientPINService = ClientPINService(authenticatorPropertyStore)
+    val pinProtocols: List<PinProtocolVersion> = ctapAuthenticator.pinProtocols
+        .sortedByDescending { it.value }
+
+    val clientPINService: ClientPINService = ClientPINService(
+        authenticatorPropertyStore,
+        pinProtocols.map { version ->
+            when (version) {
+                PinProtocolVersion.VERSION_1 -> PinUvAuthProtocolV1()
+                PinProtocolVersion.VERSION_2 -> PinUvAuthProtocolV2()
+                else -> throw IllegalArgumentException("Unsupported PIN protocol version: $version")
+            }
+        }
+    )
 
     // Authenticator characteristics
     val platform: AttachmentSetting = ctapAuthenticator.platform

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocol.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocol.kt
@@ -1,0 +1,55 @@
+package com.webauthn4j.ctap.authenticator
+
+import com.webauthn4j.data.PinProtocolVersion
+import com.webauthn4j.data.attestation.authenticator.COSEKey
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authnrClientPin-puaprot-abstract-dfn">6.5.4. PIN/UV Auth Protocol Abstract Definition</a>
+//spec| A specific PIN/UV auth protocol defines an implementation of two interfaces to cryptographic services:
+//spec| one for the authenticator, and one for the platform.
+//spec| The authenticator interface is:
+interface PinUvAuthProtocol {
+
+    val version: PinProtocolVersion
+
+    //spec| initialize()
+    //spec|   This process is run by the authenticator at power-on.
+    fun initialize()
+
+    //spec| regenerate()
+    //spec|   Generates a fresh public key.
+    fun regenerate()
+
+    //spec| resetPinUvAuthToken()
+    //spec|   Generates a fresh pinUvAuthToken.
+    fun resetPinUvAuthToken()
+
+    //spec| getPublicKey() → coseKey
+    //spec|   Returns the authenticator's public key as a COSE_Key structure.
+    fun getPublicKey(): COSEKey
+
+    //spec| decapsulate(peerCoseKey) → sharedSecret | error
+    //spec|   Processes the output of encapsulate from the peer and produces a shared secret,
+    //spec|   known to both the platform and the authenticator.
+    fun decapsulate(peerCoseKey: COSEKey): ByteArray
+
+    //spec| encrypt(key, demPlaintext) → ciphertext
+    //spec|   Encrypts a plaintext to produce a ciphertext, which may be longer than the plaintext.
+    //spec|   The plaintext is restricted to being a multiple of the AES block size (16 bytes) in length.
+    fun encrypt(key: ByteArray, plaintext: ByteArray): ByteArray
+
+    //spec| decrypt(sharedSecret, ciphertext) → plaintext | error
+    //spec|   Decrypts a ciphertext, using sharedSecret as a key, and returns the plaintext.
+    fun decrypt(key: ByteArray, ciphertext: ByteArray): ByteArray
+
+    //spec| authenticate(key, message) → signature
+    //spec|   Computes a MAC of the given message.
+    fun authenticate(key: ByteArray, message: ByteArray): ByteArray
+
+    //spec| verify(key, message, signature) → success | error
+    //spec|   Verifies that the signature is a valid MAC for the given message.
+    //spec|   If the key parameter value is the current pinUvAuthToken, it also checks whether
+    //spec|   the pinUvAuthToken is in use or not.
+    fun verify(key: ByteArray, message: ByteArray, signature: ByteArray): Boolean
+
+    val pinUvAuthToken: ByteArray
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV1.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV1.kt
@@ -1,0 +1,113 @@
+package com.webauthn4j.ctap.authenticator
+
+import com.webauthn4j.data.PinProtocolVersion
+import com.webauthn4j.ctap.core.util.internal.CipherUtil
+import com.webauthn4j.ctap.core.util.internal.KeyAgreementUtil
+import com.webauthn4j.data.attestation.authenticator.COSEKey
+import com.webauthn4j.data.attestation.authenticator.EC2COSEKey
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.util.ECUtil
+import com.webauthn4j.util.MACUtil
+import com.webauthn4j.util.MessageDigestUtil
+import java.security.KeyPair
+import java.security.SecureRandom
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
+import java.util.Arrays
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * PIN/UV Auth Protocol version 1 implementation.
+ *
+ * Uses AES-256-CBC with a zero IV and HMAC-SHA-256 truncated to 16 bytes.
+ * The shared secret is derived as SHA-256 of the raw ECDH shared secret.
+ * The pinUvAuthToken is 16 bytes.
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#pinProto1">6.5.6. PIN/UV Auth Protocol One</a>
+ */
+class PinUvAuthProtocolV1 : PinUvAuthProtocol {
+
+    companion object {
+        private val ZERO_IV = byteArrayOf(
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        )
+        private val ECDH_ES_HKDF_256 = COSEAlgorithmIdentifier.create(-25)
+        private const val PIN_UV_AUTH_TOKEN_LENGTH = 16
+        private const val HMAC_OUTPUT_LENGTH = 16
+    }
+
+    override val version: PinProtocolVersion = PinProtocolVersion.VERSION_1
+
+    private var keyAgreementKeyPair: KeyPair = ECUtil.createKeyPair()
+    private var _pinUvAuthToken: ByteArray = ByteArray(PIN_UV_AUTH_TOKEN_LENGTH)
+
+    override val pinUvAuthToken: ByteArray
+        get() = _pinUvAuthToken.copyOf()
+
+    init {
+        SecureRandom().nextBytes(_pinUvAuthToken)
+    }
+
+    override fun initialize() {
+        keyAgreementKeyPair = ECUtil.createKeyPair()
+        resetPinUvAuthToken()
+    }
+
+    override fun regenerate() {
+        keyAgreementKeyPair = ECUtil.createKeyPair()
+    }
+
+    override fun resetPinUvAuthToken() {
+        _pinUvAuthToken = ByteArray(PIN_UV_AUTH_TOKEN_LENGTH)
+        SecureRandom().nextBytes(_pinUvAuthToken)
+    }
+
+    override fun getPublicKey(): COSEKey {
+        return EC2COSEKey.create(
+            keyAgreementKeyPair.public as ECPublicKey,
+            ECDH_ES_HKDF_256
+        )
+    }
+
+    //spec| kdf(Z) → sharedSecret
+    //spec|   Return SHA-256(Z)
+    override fun decapsulate(peerCoseKey: COSEKey): ByteArray {
+        val ecdhSecret = KeyAgreementUtil.generateSecret(
+            keyAgreementKeyPair.private as ECPrivateKey,
+            peerCoseKey.publicKey as ECPublicKey?
+        )
+        return MessageDigestUtil.createSHA256().digest(ecdhSecret)
+    }
+
+    //spec| encrypt(key, demPlaintext) → ciphertext
+    //spec|   Return the AES-256-CBC encryption of demPlaintext using an all-zero IV.
+    //spec|   (No padding is performed as the size of demPlaintext is required to be a multiple of the AES block length.)
+    override fun encrypt(key: ByteArray, plaintext: ByteArray): ByteArray {
+        val secretKey = SecretKeySpec(key, "AES")
+        return CipherUtil.encryptWithAESCBCNoPadding(plaintext, secretKey, ZERO_IV)
+    }
+
+    //spec| decrypt(key, demCiphertext) → plaintext | error
+    //spec|   If the size of demCiphertext is not a multiple of the AES block length, return error.
+    //spec|   Otherwise return the AES-256-CBC decryption of demCiphertext using an all-zero IV.
+    override fun decrypt(key: ByteArray, ciphertext: ByteArray): ByteArray {
+        val secretKey = SecretKeySpec(key, "AES")
+        return CipherUtil.decryptWithAESCBCNoPadding(ciphertext, secretKey, ZERO_IV)
+    }
+
+    //spec| authenticate(key, message) → signature
+    //spec|   Return the first 16 bytes of the result of computing HMAC-SHA-256 with the given key and message.
+    override fun authenticate(key: ByteArray, message: ByteArray): ByteArray {
+        return MACUtil.calculateHmacSHA256(message, key, HMAC_OUTPUT_LENGTH)
+    }
+
+    //spec| verify(key, message, signature) → success | error
+    //spec|   If the key parameter value is the current pinUvAuthToken and it is not in use, then return error.
+    //spec|   Compute HMAC-SHA-256 with the given key and message.
+    //spec|   Return success if signature is 16 bytes and is equal to the first 16 bytes of the result, otherwise return error.
+    override fun verify(key: ByteArray, message: ByteArray, signature: ByteArray): Boolean {
+        val expected = authenticate(key, message)
+        return Arrays.equals(expected, signature)
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV2.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV2.kt
@@ -1,0 +1,163 @@
+package com.webauthn4j.ctap.authenticator
+
+import com.webauthn4j.data.PinProtocolVersion
+import com.webauthn4j.ctap.core.util.internal.CipherUtil
+import com.webauthn4j.ctap.core.util.internal.KeyAgreementUtil
+import com.webauthn4j.data.attestation.authenticator.COSEKey
+import com.webauthn4j.data.attestation.authenticator.EC2COSEKey
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.util.ECUtil
+import java.security.KeyPair
+import java.security.SecureRandom
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
+import java.util.Arrays
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * PIN/UV Auth Protocol version 2 implementation.
+ *
+ * Key differences from v1:
+ * - KDF uses HKDF-SHA-256 to derive separate HMAC key and AES key (64 bytes total)
+ * - Encryption uses a random IV prepended to the ciphertext
+ * - HMAC-SHA-256 output is not truncated (full 32 bytes)
+ * - pinUvAuthToken is 32 bytes
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#pinProto2">6.5.7. PIN/UV Auth Protocol Two</a>
+ */
+class PinUvAuthProtocolV2 : PinUvAuthProtocol {
+
+    companion object {
+        private val ECDH_ES_HKDF_256 = COSEAlgorithmIdentifier.create(-25)
+        private const val PIN_UV_AUTH_TOKEN_LENGTH = 32
+        private const val HMAC_KEY_LENGTH = 32
+        private const val AES_KEY_LENGTH = 32
+        private const val IV_LENGTH = 16
+        private val HKDF_SALT = ByteArray(32) // 32 zero bytes
+        private val HMAC_KEY_INFO = "CTAP2 HMAC key".toByteArray(Charsets.UTF_8)
+        private val AES_KEY_INFO = "CTAP2 AES key".toByteArray(Charsets.UTF_8)
+    }
+
+    override val version: PinProtocolVersion = PinProtocolVersion.VERSION_2
+
+    private var keyAgreementKeyPair: KeyPair = ECUtil.createKeyPair()
+    private var _pinUvAuthToken: ByteArray = ByteArray(PIN_UV_AUTH_TOKEN_LENGTH)
+
+    override val pinUvAuthToken: ByteArray
+        get() = _pinUvAuthToken.copyOf()
+
+    init {
+        SecureRandom().nextBytes(_pinUvAuthToken)
+    }
+
+    override fun initialize() {
+        keyAgreementKeyPair = ECUtil.createKeyPair()
+        resetPinUvAuthToken()
+    }
+
+    override fun regenerate() {
+        keyAgreementKeyPair = ECUtil.createKeyPair()
+    }
+
+    override fun resetPinUvAuthToken() {
+        _pinUvAuthToken = ByteArray(PIN_UV_AUTH_TOKEN_LENGTH)
+        SecureRandom().nextBytes(_pinUvAuthToken)
+    }
+
+    override fun getPublicKey(): COSEKey {
+        return EC2COSEKey.create(
+            keyAgreementKeyPair.public as ECPublicKey,
+            ECDH_ES_HKDF_256
+        )
+    }
+
+    //spec| kdf(Z) → sharedSecret
+    //spec|   Return
+    //spec|   HKDF-SHA-256(salt = 32 zero bytes, IKM = Z, L = 32, info = "CTAP2 HMAC key") ||
+    //spec|   HKDF-SHA-256(salt = 32 zero bytes, IKM = Z, L = 32, info = "CTAP2 AES key")
+    override fun decapsulate(peerCoseKey: COSEKey): ByteArray {
+        val ecdhSecret = KeyAgreementUtil.generateSecret(
+            keyAgreementKeyPair.private as ECPrivateKey,
+            peerCoseKey.publicKey as ECPublicKey?
+        )
+        val hmacKey = hkdfSha256(HKDF_SALT, ecdhSecret, HMAC_KEY_INFO, HMAC_KEY_LENGTH)
+        val aesKey = hkdfSha256(HKDF_SALT, ecdhSecret, AES_KEY_INFO, AES_KEY_LENGTH)
+        return hmacKey + aesKey
+    }
+
+    //spec| encrypt(key, demPlaintext) → ciphertext
+    //spec|   Discard the first 32 bytes of key. (This selects the AES-key portion of the shared secret.)
+    //spec|   Let iv be a 16-byte, random bytestring.
+    //spec|   Let ct be the AES-256-CBC encryption of demPlaintext using key and iv.
+    //spec|   (No padding is performed as the size of demPlaintext is required to be a multiple of the AES block length.)
+    //spec|   Return iv || ct.
+    override fun encrypt(key: ByteArray, plaintext: ByteArray): ByteArray {
+        val aesKey = key.copyOfRange(HMAC_KEY_LENGTH, HMAC_KEY_LENGTH + AES_KEY_LENGTH)
+        val iv = ByteArray(IV_LENGTH)
+        SecureRandom().nextBytes(iv)
+        val secretKey = SecretKeySpec(aesKey, "AES")
+        val ciphertext = CipherUtil.encryptWithAESCBCNoPadding(plaintext, secretKey, iv)
+        return iv + ciphertext
+    }
+
+    //spec| decrypt(key, demCiphertext) → plaintext | error
+    //spec|   Discard the first 32 bytes of key. (This selects the AES-key portion of the shared secret.)
+    //spec|   If demPlaintext is less than 16 bytes in length, return an error
+    //spec|   Split demPlaintext after the 16th byte to produce two subspans, iv and ct.
+    //spec|   Return the AES-256-CBC decryption of ct using key and iv.
+    override fun decrypt(key: ByteArray, ciphertext: ByteArray): ByteArray {
+        val aesKey = key.copyOfRange(HMAC_KEY_LENGTH, HMAC_KEY_LENGTH + AES_KEY_LENGTH)
+        val iv = ciphertext.copyOfRange(0, IV_LENGTH)
+        val ct = ciphertext.copyOfRange(IV_LENGTH, ciphertext.size)
+        val secretKey = SecretKeySpec(aesKey, "AES")
+        return CipherUtil.decryptWithAESCBCNoPadding(ct, secretKey, iv)
+    }
+
+    //spec| authenticate(key, message) → signature
+    //spec|   If key is longer than 32 bytes, discard the excess.
+    //spec|   (This selects the HMAC-key portion of the shared secret.
+    //spec|   When key is the pinUvAuthToken, it is exactly 32 bytes long and thus this step has no effect.)
+    //spec|   Return the result of computing HMAC-SHA-256 on key and message.
+    override fun authenticate(key: ByteArray, message: ByteArray): ByteArray {
+        val hmacKey = key.copyOfRange(0, HMAC_KEY_LENGTH)
+        return hmacSha256(hmacKey, message)
+    }
+
+    //spec| verify(key, message, signature) → success | error
+    //spec|   If the key parameter value is the current pinUvAuthToken and it is not in use, then return error.
+    //spec|   If key is longer than 32 bytes, discard the excess.
+    //spec|   (This selects the HMAC-key portion of the shared secret.
+    //spec|   When key is the pinUvAuthToken, it is exactly 32 bytes long and thus this step has no effect.)
+    //spec|   Compute HMAC-SHA-256 with the given key and message.
+    //spec|   Return success if the signature is equal to the result, otherwise return an error.
+    override fun verify(key: ByteArray, message: ByteArray, signature: ByteArray): Boolean {
+        val expected = authenticate(key, message)
+        return Arrays.equals(expected, signature)
+    }
+
+    /**
+     * HKDF-SHA-256 implementation.
+     * HKDF-Extract: PRK = HMAC-SHA-256(salt, IKM)
+     * HKDF-Expand: OKM = HMAC-SHA-256(PRK, info || 0x01) truncated to L bytes
+     * Since L=32 equals the hash output length, only one iteration is needed.
+     */
+    private fun hkdfSha256(salt: ByteArray, ikm: ByteArray, info: ByteArray, length: Int): ByteArray {
+        // HKDF-Extract
+        val prk = hmacSha256(salt, ikm)
+        // HKDF-Expand (single iteration since L <= HashLen)
+        val expandInput = info + byteArrayOf(0x01)
+        val okm = hmacSha256(prk, expandInput)
+        return okm.copyOf(length)
+    }
+
+    /**
+     * Compute HMAC-SHA-256.
+     */
+    private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        val secretKeySpec = SecretKeySpec(key, "HmacSHA256")
+        mac.init(secretKeySpec)
+        return mac.doFinal(data)
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
@@ -28,6 +28,7 @@ internal class ClientPINExecution(
 
     override suspend fun doExecute(): AuthenticatorClientPINResponse {
         val clientPINService = ctapAuthenticatorSession.clientPINService
+        val pinProtocol = authenticatorClientPINRequest.pinProtocol
         val platformKeyAgreementKey = authenticatorClientPINRequest.keyAgreement
         val pinAuth = authenticatorClientPINRequest.pinAuth
         val newPinEnc = authenticatorClientPINRequest.newPinEnc
@@ -38,20 +39,20 @@ internal class ClientPINExecution(
                 clientPINService.getPinRetries()
             }
             PinSubCommand.GET_KEY_AGREEMENT -> {
-                logger.debug("Processing clientPIN getKeyAgreement sub-command")
-                clientPINService.getKeyAgreement()
+                logger.debug("Processing clientPIN getKeyAgreement sub-command (protocol={})", pinProtocol)
+                clientPINService.getKeyAgreement(pinProtocol)
             }
             PinSubCommand.SET_PIN -> {
-                logger.debug("Processing clientPIN setPIN sub-command")
-                clientPINService.setPIN(platformKeyAgreementKey, pinAuth, newPinEnc)
+                logger.debug("Processing clientPIN setPIN sub-command (protocol={})", pinProtocol)
+                clientPINService.setPIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc)
             }
             PinSubCommand.CHANGE_PIN -> {
-                logger.debug("Processing clientPIN changePIN sub-command")
-                clientPINService.changePIN(platformKeyAgreementKey, pinAuth, newPinEnc, pinHashEnc)
+                logger.debug("Processing clientPIN changePIN sub-command (protocol={})", pinProtocol)
+                clientPINService.changePIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc, pinHashEnc)
             }
             PinSubCommand.GET_PIN_TOKEN -> {
-                logger.debug("Processing clientPIN getPINToken sub-command")
-                clientPINService.getPinToken(platformKeyAgreementKey, pinHashEnc)
+                logger.debug("Processing clientPIN getPINToken sub-command (protocol={})", pinProtocol)
+                clientPINService.getPinToken(pinProtocol, platformKeyAgreementKey, pinHashEnc)
             }
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -174,7 +174,7 @@ internal class GetAssertionExecution :
         if (pinAuth != null && pinProtocol == PinProtocolVersion.VERSION_1) {
             val clientDataHash = clientDataHash
             val pinAuth = pinAuth
-            ctapAuthenticatorSession.clientPINService.validatePINAuth(pinAuth, clientDataHash)
+            ctapAuthenticatorSession.clientPINService.verifyPinUvAuthParam(pinAuth, clientDataHash)
             userVerificationResult = true
             return
         }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -88,7 +88,7 @@ internal class GetInfoExecution(
                 ctapAuthenticatorSession.aaguid,   // aaguid (0x03): Required
                 AuthenticatorGetInfoResponseData.Options(plat, rk, clientPin, up, uv), // options (0x04): Optional
                 2048u,                             // maxMsgSize (0x05): Optional
-                CtapAuthenticator.PIN_PROTOCOLS,   // pinProtocols (0x06): Optional
+                ctapAuthenticatorSession.pinProtocols,   // pinProtocols (0x06): Optional
                 null,
                 null,
                 ctapAuthenticatorSession.transports

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -276,7 +276,7 @@ internal class MakeCredentialExecution :
                         throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
                     }
                 } else {
-                    ctapAuthenticatorSession.clientPINService.validatePINAuth(it, clientDataHash)
+                    ctapAuthenticatorSession.clientPINService.verifyPinUvAuthParam(it, clientDataHash)
                     userPresenceResult = true
                     userVerificationResult = true
                 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/HMACSecretExtensionProcessor.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/HMACSecretExtensionProcessor.kt
@@ -6,12 +6,10 @@ import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.ctap.authenticator.UserCredentialBuilder
 import com.webauthn4j.ctap.authenticator.execution.CtapCommandExecutionException
 import com.webauthn4j.ctap.core.data.CtapStatusCode
-import com.webauthn4j.ctap.core.util.internal.CipherUtil
+import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.data.extension.authenticator.*
 import com.webauthn4j.util.MACUtil
 import java.security.SecureRandom
-import javax.crypto.SecretKey
-import javax.crypto.spec.SecretKeySpec
 
 class HMACSecretExtensionProcessor : RegistrationExtensionProcessor,
     AuthenticationExtensionProcessor {
@@ -19,7 +17,6 @@ class HMACSecretExtensionProcessor : RegistrationExtensionProcessor,
     companion object {
         private const val DETAILS_ID_HMAC_SECRET_EXTENSION =
             "unifidokey.hmac-secret-extension.secret"
-        private val IV_ZERO = ByteArray(16)
         private val jsonConverter = ObjectConverter().jsonConverter
         private val secureRandom = SecureRandom()
     }
@@ -78,58 +75,57 @@ class HMACSecretExtensionProcessor : RegistrationExtensionProcessor,
         val saltEnc = hmacGetSecretAuthenticatorInput.saltEnc
         val saltAuth = hmacGetSecretAuthenticatorInput.saltAuth
 
-        //spec| The authenticator waits for user consent.
+        //spec| If pinUvAuthProtocol is absent and a pinUvAuthProtocol value of 1 is supported by the authenticator,
+        //spec| let the value of pinUvAuthProtocol be 1
+        //spec| If pinUvAuthProtocol is absent and a pinUvAuthProtocol value of 1 is not supported by the authenticator,
+        //spec| then return CTAP2_ERR_PIN_AUTH_INVALID.
+        val pinProtocol = hmacGetSecretAuthenticatorInput.pinUvAuthProtocol
+            ?: PinProtocolVersion.VERSION_1
+        val protocol = context.ctapAuthenticatorSession.clientPINService.getProtocol(pinProtocol)
 
-        //done in MakeCredentialExecution
+        //spec| The authenticator calls decapsulate on the provided platform key-agreement key to obtain a shared secret.
+        val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
 
-        //spec| If request asks for user verification, authenticator waits for user verification.
-        //spec| - If user verification is requested via Client PIN mechanism, verify the user by verifying the Client PIN parameters in the request as mentioned in the authenticatorGetAssertion steps.
-        //spec| - If user verification is requested via built in "uv" method, verify the user by built-in user verification method as mentioned in the authenticatorGetAssertion steps.
-
-        //done in MakeCredentialExecution
-
-        //spec| The authenticator generates "sharedSecret": SHA-256((abG).x) using the private key of authenticatorKeyAgreementKey, "a" and the public key of platformKeyAgreementKey, "bG".
-        //spec| - SHA-256 is done over only the "x" curve point of "abG".
-        //spec| - See [RFC6090] Section 4.1 and Appendix (C.2) of [SP800-56A] for more ECDH key agreement protocol details and key representation information.
-        val sharedSecret =
-            context.ctapAuthenticatorSession.clientPINService.generateSharedSecret(platformKeyAgreementKey)
-
-        //spec| The authenticator verifies saltEnc by generating LEFT(HMAC-SHA-256(sharedSecret, saltEnc), 16) and matching against the input saltAuth parameter.
-        val mac = MACUtil.calculateHmacSHA256(saltEnc, sharedSecret, 16)
-        if (!mac.contentEquals(saltAuth)) {
-            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+        //spec| The authenticator calls verify(shared secret, saltEnc, saltAuth)
+        //spec|   If the verification fails, return CTAP2_ERR_PIN_AUTH_INVALID.
+        if (!protocol.verify(sharedSecret, saltEnc, saltAuth)) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
 
-        //spec| The authenticator chooses which CredRandom to use for next step based on whether user verification was done or not in above steps.
-        //spec| - If uv bit is set to 1 in the response, let CredRandom be CredRandomWithUV.
-        //spec| - If uv bit is set to 0 in the response, let CredRandom be CredRandomWithoutUV.
+        //spec| The authenticator obtains salt1 and salt2 by calling decrypt(shared secret, saltEnc).
+        //spec| If the decryption fails, or if the result is not 32 or 64 bytes long, return CTAP1_ERR_INVALID_PARAMETER.
+        val salt = protocol.decrypt(sharedSecret, saltEnc)
+
+        //spec| The authenticator chooses which CredRandom to use for next step
+        //spec| based on whether user verification was done or not in above steps.
+        //spec|   If uv bit is set to 1 in the response, let CredRandom be CredRandomWithUV.
+        //spec|   If uv bit is set to 0 in the response, let CredRandom be CredRandomWithoutUV.
         val credRandom = when (context.userVerificationPlan) {
             true -> hmacSecretUserDetails.credRandomWithUV
             false -> hmacSecretUserDetails.credRandomWithoutUV
         }
 
-        //spec| The authenticator generates one or two HMAC-SHA-256 values, depending upon whether it received one salt (32 bytes) or two salts (64 bytes):
-        //spec| - output1: HMAC-SHA-256(CredRandom, salt1)
-        //spec| - output2: HMAC-SHA-256(CredRandom, salt2)
-        //spec| The authenticator returns output1 and, when there were two salts, output2 encrypted to the platform using sharedSecret as part of "extensions" parameter:
-        //spec| - One salt case: "hmac-secret": AES256-CBC(sharedSecret, IV=0, output1 (32 bytes))
-        //spec| - Two salt case: "hmac-secret": AES256-CBC(sharedSecret, IV=0, output1 (32 bytes) || output2 (32 bytes))
-        val secretKey: SecretKey = SecretKeySpec(sharedSecret, "AES")
-        val salt = CipherUtil.decryptWithAESCBCNoPadding(saltEnc, secretKey, IV_ZERO)
+        //spec| The authenticator generates one or two HMAC-SHA-256 values,
+        //spec| depending upon whether it received one salt (32 bytes) or two salts (64 bytes):
+        //spec|   output1: HMAC-SHA-256(CredRandom, salt1)
+        //spec|   output2: HMAC-SHA-256(CredRandom, salt2)
+        //spec| The authenticator returns output1 and (when there were two salts) output2, encrypted to the platform using
+        //spec| the shared secret, as part of "extensions" parameter:
+        //spec|   One salt case: "hmac-secret": encrypt(shared secret, output1)
+        //spec|   Two salt case: "hmac-secret": encrypt(shared secret, output1 || output2)
         val hmacGetSecret = when (salt.size) {
             32 -> {
                 val output1 = MACUtil.calculateHmacSHA256(salt, credRandom)
-                CipherUtil.encryptWithAESCBCNoPadding(output1, secretKey, IV_ZERO)
+                protocol.encrypt(sharedSecret, output1)
             }
             64 -> {
                 val salt1 = salt.copyOfRange(0, 32)
                 val salt2 = salt.copyOfRange(32, 64)
                 val output1 = MACUtil.calculateHmacSHA256(salt1, credRandom)
                 val output2 = MACUtil.calculateHmacSHA256(salt2, credRandom)
-                val output = output1.plus(output2)
-                CipherUtil.encryptWithAESCBCNoPadding(output, secretKey, IV_ZERO)
+                protocol.encrypt(sharedSecret, output1.plus(output2))
             }
-            else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_CBOR) //TODO: validation should be done at appropriate place
+            else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
         }
 
         outputsBuilder.setHMACGetSecret(hmacGetSecret)

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
@@ -28,7 +28,7 @@ internal class CtapClientTest {
         Assertions.assertThat(response.responseData!!.versions)
             .isEqualTo(CtapAuthenticator.VERSIONS)
         Assertions.assertThat(response.responseData!!.pinProtocols)
-            .isEqualTo(CtapAuthenticator.PIN_PROTOCOLS)
+            .isEqualTo(listOf(PinProtocolVersion.VERSION_2, PinProtocolVersion.VERSION_1))
         Assertions.assertThat(response.responseData!!.options).isNotNull
         Assertions.assertThat(response.responseData!!.options!!.plat)
             .isEqualTo(PlatformOption.CROSS_PLATFORM)

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorClientPINRequestValidator.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorClientPINRequestValidator.kt
@@ -7,7 +7,16 @@ import com.webauthn4j.ctap.core.data.PinSubCommand
 class AuthenticatorClientPINRequestValidator {
 
     fun validate(value: AuthenticatorClientPINRequest) {
-        require(value.pinProtocol == PinProtocolVersion.VERSION_1) { "Only PIN Protocol version 1 is supported" }
+        val pinProtocol = value.pinProtocol
+        require(pinProtocol == PinProtocolVersion.VERSION_1 || pinProtocol == PinProtocolVersion.VERSION_2) {
+            "PIN Protocol version ${pinProtocol.value} is not supported"
+        }
+        // Expected pinAuth length: 16 bytes for v1, 32 bytes for v2
+        val expectedPinAuthLength = when (pinProtocol) {
+            PinProtocolVersion.VERSION_1 -> 16
+            PinProtocolVersion.VERSION_2 -> 32
+            else -> throw IllegalArgumentException("Unsupported PIN protocol version: ${pinProtocol.value}")
+        }
         when (value.subCommand) {
             PinSubCommand.GET_PIN_RETRIES -> {
                 // nop
@@ -20,7 +29,9 @@ class AuthenticatorClientPINRequestValidator {
                 requireNotNull(value.newPinEnc)
                 val pinAuth = value.pinAuth
                 requireNotNull(pinAuth)
-                require(pinAuth.size == 16) { "pinAuth must be 16 bytes length" }
+                require(pinAuth.size == expectedPinAuthLength) {
+                    "pinAuth must be $expectedPinAuthLength bytes length for PIN protocol ${pinProtocol.value}"
+                }
             }
             PinSubCommand.CHANGE_PIN -> {
                 requireNotNull(value.keyAgreement)
@@ -28,7 +39,9 @@ class AuthenticatorClientPINRequestValidator {
                 requireNotNull(value.newPinEnc)
                 val pinAuth = value.pinAuth
                 requireNotNull(pinAuth)
-                require(pinAuth.size == 16) { "pinAuth must be 16 bytes length" }
+                require(pinAuth.size == expectedPinAuthLength) {
+                    "pinAuth must be $expectedPinAuthLength bytes length for PIN protocol ${pinProtocol.value}"
+                }
             }
             PinSubCommand.GET_PIN_TOKEN -> {
                 requireNotNull(value.keyAgreement)

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
@@ -98,12 +98,12 @@ abstract class IntegrationTestCaseBase {
             }.depends(clientPINParameter, algorithmsParameter)
         internal val ctapAuthenticatorParameter = TestParameter {
             val ctapAuthenticator = CtapAuthenticator(
-                objectConverter,
-                attestationStatementGenerator,
-                fidoU2FAttestationStatementGenerator,
-                emptySet(),
-                emptyList(),
-                authenticatorPropertyStore,
+                objectConverter = objectConverter,
+                attestationStatementProvider = attestationStatementGenerator,
+                fidoU2FBasicAttestationStatementGenerator = fidoU2FAttestationStatementGenerator,
+                transports = emptySet(),
+                extensionProcessors = emptyList(),
+                authenticatorPropertyStore = authenticatorPropertyStore,
                 credentialSelectionHandler = credentialSelectionHandler
             )
             ctapAuthenticator.aaguid = aaguid


### PR DESCRIPTION
- Introduce PinUvAuthProtocol interface matching CTAP 2.3 §6.5.4 abstract definition, with v1 and v2 implementations
- Protocol v2: HKDF-SHA-256 key derivation (64-byte shared secret), random IV encryption, full 32-byte HMAC signatures
- Refactor ClientPINService to delegate crypto operations to protocol instances
- GetInfo reports pinUvAuthProtocols as [2, 1] (v2 preferred)
- All existing PIN v1 tests pass unchanged