### PR TITLE
Represent power cycle as session recreation instead of state mutation

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/ClientPINService.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/ClientPINService.kt
@@ -51,12 +51,6 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         SecureRandom().nextBytes(pinToken)
     }
 
-    fun regenerateKeys() {
-        authenticatorKeyAgreementKey = ECUtil.createKeyPair()
-        SecureRandom().nextBytes(pinToken)
-        volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
-    }
-
     //spec| 5.5.3 Getting Retries from Authenticator
     //spec| Retries count is the number of attempts remaining before lockout.
     //spec| Authenticator responds back with retries.
@@ -303,10 +297,6 @@ class ClientPINService(private val authenticatorPropertyStore: AuthenticatorProp
         if (!Arrays.equals(calculatedPinAuth, pinAuth)) {
             throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-    }
-
-    fun resetVolatilePinRetryCounter() {
-        volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
     }
 
     val isClientPINReady: Boolean

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -175,10 +175,6 @@ class CtapAuthenticatorSession internal constructor(
         onGoingGetAssertionSession = null
     }
 
-    fun resetVolatileState() {
-        clientPINService.regenerateKeys()
-    }
-
     internal fun publishEvent(event: Event) {
         eventListeners.forEach { it.onEvent(event) }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ResetExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ResetExecution.kt
@@ -34,7 +34,6 @@ class ResetExecution internal constructor(
         return when (ctapAuthenticatorSession.resetProtection) {
             ResetProtectionSetting.ENABLED -> AuthenticatorResetResponse(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
             else -> {
-                ctapAuthenticatorSession.clientPINService.resetVolatilePinRetryCounter()
                 authenticatorPropertyStore.clear()
                 ctapAuthenticatorSession.publishEvent(ResetEvent(Instant.now()))
                 AuthenticatorResetResponse(CtapStatusCode.CTAP2_OK)

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
@@ -18,7 +18,7 @@ import java.security.SecureRandom
 
 // @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-discovery">8.1. USB Human Interface Device (USB HID)</a>
 class HIDTransport(
-    ctapAuthenticator: CtapAuthenticator,
+    private val ctapAuthenticator: CtapAuthenticator,
     private val packetSize: Int = DEFAULT_PACKET_SIZE
 ) : Transport, AutoCloseable {
 
@@ -31,9 +31,9 @@ class HIDTransport(
 
     private val logger = LoggerFactory.getLogger(HIDTransport::class.java)
 
-    private var ctapAuthenticatorSession: CtapAuthenticatorSession = ctapAuthenticator.createSession() //TODO: revisit
+    private var ctapAuthenticatorSession: CtapAuthenticatorSession = ctapAuthenticator.createSession()
 
-    private val u2fAPDUProcessor = U2FAPDUProcessor().also { it.onConnect(ctapAuthenticatorSession) }
+    private var u2fAPDUProcessor = createU2FAPDUProcessor()
 
     private val hidPacketConverter = HIDPacketConverter()
     private val hidChannels: MutableMap<HIDChannelId, HIDChannel> = HashMap()
@@ -74,8 +74,8 @@ class HIDTransport(
         }
     })
     private val pingHandler = HIDPingCommandHandler()
-    private val cancelHandler = HIDCancelCommandHandler(ctapAuthenticatorSession)
-    private val winkHandler = HIDWinkCommandHandler(ctapAuthenticatorSession)
+    private var cancelHandler = HIDCancelCommandHandler(ctapAuthenticatorSession)
+    private var winkHandler = HIDWinkCommandHandler(ctapAuthenticatorSession)
     private val lockHandler = HIDLockCommandHandler(lockState)
 
     fun start(scope: CoroutineScope) {
@@ -95,7 +95,16 @@ class HIDTransport(
     }
 
     fun onDeviceAttached() {
-        ctapAuthenticatorSession.resetVolatileState()
+        ctapAuthenticatorSession = ctapAuthenticator.createSession()
+        u2fAPDUProcessor = createU2FAPDUProcessor()
+        cancelHandler = HIDCancelCommandHandler(ctapAuthenticatorSession)
+        winkHandler = HIDWinkCommandHandler(ctapAuthenticatorSession)
+        hidChannels.values.forEach { it.close() }
+        hidChannels.clear()
+    }
+
+    private fun createU2FAPDUProcessor(): U2FAPDUProcessor {
+        return U2FAPDUProcessor().also { it.onConnect(ctapAuthenticatorSession) }
     }
 
     fun onHIDDataReceived(bytes: ByteArray, hidPacketHandler: HIDPacketHandler) {


### PR DESCRIPTION
- Replace resetVolatileState() with CtapAuthenticatorSession recreation in HIDTransport.onDeviceAttached()
- All volatile state (PIN protocol keys, pinUvAuthToken, retry counter) is fresh by construction rather than by procedural reset
- Remove regenerateKeys() and resetVolatilePinRetryCounter() from ClientPINService
- Session-dependent handlers (cancelHandler, winkHandler, u2fAPDUProcessor) are recreated alongside the session