### PR TITLE
Add pinUvAuthToken with permissions support

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -55,7 +55,7 @@ class CtapAuthenticatorSession internal constructor(
     val pinProtocols: List<PinProtocolVersion> = ctapAuthenticator.pinProtocols
         .sortedByDescending { it.value }
 
-    val pinUvAuthService: PinUvAuthService = PinUvAuthService(
+    val pinUvAuthManager: PinUvAuthManager = PinUvAuthManager(
         authenticatorPropertyStore,
         pinProtocols.map { version ->
             when (version) {
@@ -65,6 +65,9 @@ class CtapAuthenticatorSession internal constructor(
             }
         }
     )
+
+    val isClientPINReady: Boolean
+        get() = authenticatorPropertyStore.loadClientPIN() != null
 
     // Authenticator characteristics
     val platform: AttachmentSetting = ctapAuthenticator.platform

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthManager.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthManager.kt
@@ -15,16 +15,21 @@ import java.nio.ByteBuffer
 import java.util.Arrays
 
 /**
- * Service handling authenticatorClientPIN command operations.
+ * Implementation of the authenticatorClientPIN (0x06) command subcommands
+ * defined in CTAP 2.3 §6.5.5.
  *
- * Supports multiple PIN/UV Auth Protocol versions by delegating cryptographic operations
- * to [PinUvAuthProtocol] instances.
+ * Each public method corresponds to a subcommand (getPINRetries, getKeyAgreement,
+ * setPIN, changePIN, getPinToken, getPinUvAuthTokenUsingPinWithPermissions,
+ * getPinUvAuthTokenUsingUvWithPermissions, getUVRetries).
+ *
+ * Holds volatile state (e.g. PIN retry counters) that resets on power cycle,
+ * as required by the spec.
  *
  * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorClientPIN">6.5. authenticatorClientPIN</a>
  */
-class PinUvAuthService(
+class PinUvAuthManager(
     private val authenticatorPropertyStore: AuthenticatorPropertyStore,
-    private val protocols: List<PinUvAuthProtocol> = listOf(PinUvAuthProtocolV1())
+    val pinUvAuthProtocols: List<PinUvAuthProtocol> = listOf(PinUvAuthProtocolV1())
 ) {
 
     companion object {
@@ -34,13 +39,6 @@ class PinUvAuthService(
     }
 
     private var volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
-
-    private val protocolMap: Map<PinProtocolVersion, PinUvAuthProtocol> = protocols.associateBy { it.version }
-
-    fun getProtocol(pinProtocol: PinProtocolVersion): PinUvAuthProtocol {
-        return protocolMap[pinProtocol]
-            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
-    }
 
     //spec| 6.5.5.2. Platform getting PIN retries from Authenticator
     //spec| PIN retries count is the number of PIN attempts remaining before PIN is disabled on the device.
@@ -54,6 +52,7 @@ class PinUvAuthService(
     //spec|      powerCycleState.
     // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#gettingPINRetries">§6.5.5.2</a>
     fun getPinRetries(): AuthenticatorClientPINResponse {
+        //spec| Step 2: Authenticator responds back with pinRetries and, optionally, powerCycleState.
         val pinRetries = authenticatorPropertyStore.loadPINRetries()
         val powerCycleState = if (volatilePinRetryCounter <= 0) true else null
         val responseData = AuthenticatorClientPINResponseData(null, null, pinRetries, powerCycleState, null)
@@ -84,7 +83,14 @@ class PinUvAuthService(
     //spec|      the platform key-agreement key and the shared secret.
     // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#gettingSharedSecret">§6.5.5.4</a>
     fun getKeyAgreement(pinProtocol: PinProtocolVersion): AuthenticatorClientPINResponse {
+        //spec| Step 3: If the authenticator does not receive mandatory parameters for this subcommand,
+        //spec| end the operation by returning CTAP2_ERR_MISSING_PARAMETER.
+        // (pinProtocol is non-null by Kotlin type system; validated at deserialization layer)
+        //spec| Step 4: If the authenticator does not support the selected pinUvAuthProtocol,
+        //spec| it returns CTAP1_ERR_INVALID_PARAMETER.
         val protocol = getProtocol(pinProtocol)
+        //spec| Step 5: Otherwise the authenticator sends a response with the following parameters:
+        //spec| keyAgreement: the result of calling getPublicKey for the selected pinUvAuthProtocol.
         val keyAgreement = protocol.getPublicKey()
         val responseData = AuthenticatorClientPINResponseData(keyAgreement, null, null)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
@@ -124,56 +130,60 @@ class PinUvAuthService(
         newPinEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
 
-        //spec| If the authenticator does not receive mandatory parameters for this command,
+        //spec| Step 1: If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinAuth == null || newPinEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| If a PIN has already been set, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
-        if (isClientPINReady) {
+        //spec| Step 2: If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+        val protocol = getProtocol(pinProtocol)
+        //spec| Step 3: If a PIN has already been set, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
+        if (authenticatorPropertyStore.loadClientPIN() != null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
 
-        val protocol = getProtocol(pinProtocol)
-
-        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| Step 4: The authenticator calls decapsulate on the provided platform key-agreement key
         //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
         val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
 
-        //spec| The authenticator calls verify(shared secret, newPinEnc, pinUvAuthParam)
+        //spec| Step 5: The authenticator calls verify(shared secret, newPinEnc, pinUvAuthParam)
         //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
         if (!protocol.verify(sharedSecret, newPinEnc, pinAuth)) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
+        //spec| Step 6: The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
         //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
         val newPIN = protocol.decrypt(sharedSecret, newPinEnc)
+        //spec| Step 7: If paddedNewPin is NOT 64 bytes long, it returns CTAP1_ERR_INVALID_PARAMETER.
         if (newPIN.size != 64) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
         }
-        //spec| The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
+        //spec| Step 8: The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
         val sentinelPos = newPIN.indexOf(0x00)
         val trimmedNewPIN: ByteArray = when {
             (sentinelPos < 0) -> newPIN
             else -> newPIN.copyOf(sentinelPos)
         }
-        //spec| The authenticator checks the length of newPin against the current minimum PIN length,
+        //spec| Step 9: The authenticator checks the length of newPin against the current minimum PIN length,
         //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
         if (trimmedNewPIN.size < 4) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
+        //spec| Step 10: An authenticator MAY impose arbitrary, additional constraints on PINs. If newPin fails to
+        //spec| satisfy such additional constraints, the authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        //spec| The authenticator stores LEFT(SHA-256(newPin), 16) internally as CurrentStoredPIN,
+        // TODO: Step 11: remember newPin length as PINCodePointLength (needed when authenticatorConfig setMinPINLength is implemented)
+        //spec| Step 12: The authenticator stores LEFT(SHA-256(newPin), 16) internally as CurrentStoredPIN,
         //spec| sets the pinRetries counter to maximum count, and returns CTAP2_OK.
         authenticatorPropertyStore.saveClientPIN(
             Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
         )
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
-        //spec| The authenticator calls resetPinUvAuthToken() for all pinUvAuthProtocols supported by this authenticator.
-        protocols.forEach { it.resetPinUvAuthToken() }
+        // Reset all pinUvAuthTokens (not a spec step in §6.5.5.5, but necessary for security)
+        pinUvAuthProtocols.forEach { it.resetPinUvAuthToken() }
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
@@ -233,22 +243,22 @@ class PinUvAuthService(
         newPinEnc: ByteArray?,
         pinHashEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
-        //spec| If the authenticator does not receive mandatory parameters for this command,
+        //spec| Step 1: If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinAuth == null || newPinEnc == null || pinHashEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        //spec| Step 2: If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+        val protocol = getProtocol(pinProtocol)
+        //spec| Step 3: If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
         if (authenticatorPropertyStore.loadPINRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
         }
 
-        val protocol = getProtocol(pinProtocol)
-
-        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| Step 4: The authenticator calls decapsulate on the provided platform key-agreement key
         //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
         val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
-        //spec| The authenticator calls verify(shared secret, newPinEnc || pinHashEnc, pinUvAuthParam)
+        //spec| Step 5: The authenticator calls verify(shared secret, newPinEnc || pinHashEnc, pinUvAuthParam)
         //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
         val joined =
             ByteBuffer.allocate(newPinEnc.size + pinHashEnc.size).put(newPinEnc).put(pinHashEnc)
@@ -256,10 +266,10 @@ class PinUvAuthService(
         if (!protocol.verify(sharedSecret, joined, pinAuth)) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
-        //spec| The authenticator decrements the pinRetries counter by 1.
+        //spec| Step 6: The authenticator decrements the pinRetries counter by 1.
         authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
 
-        //spec| The authenticator decrypts pinHashEnc using decrypt(shared secret, pinHashEnc)
+        //spec| Step 7: The authenticator decrypts pinHashEnc using decrypt(shared secret, pinHashEnc)
         //spec| and verifies against its internal stored LEFT(SHA-256(curPin), 16).
         val pinHash = protocol.decrypt(sharedSecret, pinHashEnc)
         val storedPinHash =
@@ -268,11 +278,11 @@ class PinUvAuthService(
             )
 
         if (!Arrays.equals(pinHash, storedPinHash)) {
-            //spec| If an error results, or a mismatch is detected, the authenticator performs the following operations:
-            //spec| Calls regenerate for the selected pinUvAuthProtocol.
+            //spec| Step 7.1: If an error results, or a mismatch is detected, the authenticator performs the following operations:
+            //spec| Step 7.1.1: Calls regenerate for the selected pinUvAuthProtocol.
             protocol.regenerate()
             volatilePinRetryCounter--
-            //spec| The authenticator returns errors according to following conditions:
+            //spec| Step 7.1.2: The authenticator returns errors according to following conditions:
             //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
             //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
             //spec| indicating that power cycling is needed for further operations. This is done so that malware
@@ -287,41 +297,46 @@ class PinUvAuthService(
                     AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
             }
         }
-        //spec| The authenticator sets the pinRetries counter to maximum value.
+        //spec| Step 8: The authenticator sets the pinRetries counter to maximum value.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
-        //spec| The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
+        //spec| Step 9: The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
         //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
-        //spec| The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
-        //spec| The authenticator checks the length of newPin against the current minimum PIN length,
-        //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
         val newPIN = protocol.decrypt(sharedSecret, newPinEnc)
+        //spec| Step 10: If paddedNewPin is NOT 64 bytes long, it returns CTAP1_ERR_INVALID_PARAMETER.
         if (newPIN.size != 64) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
         }
+        //spec| Step 11: The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
         val sentinelPos = ArrayUtil.indexOf(newPIN, 0x00.toByte())
         if (sentinelPos < 0) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
         val trimmedNewPIN = newPIN.copyOf(sentinelPos)
+        //spec| Step 12: The authenticator checks the length of newPin against the current minimum PIN length,
+        //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
         if (trimmedNewPIN.size < 4) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
+        // TODO: Step 13: forcePINChange check (needed when authenticatorConfig setMinPINLength is implemented)
+        //spec| Step 14: An authenticator MAY impose arbitrary, additional constraints on PINs. If newPin fails to
+        //spec| satisfy such additional constraints, the authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        // forcePINChange is not currently supported (always false). When authenticatorConfig
-        // setMinPINLength is implemented, this flag may be set to true.
-        //spec| The authenticator stores LEFT(SHA-256(newPin), 16) internally as the new value of CurrentStoredPIN.
+        // TODO: Step 15: remember newPin length as PINCodePointLength (needed when authenticatorConfig setMinPINLength is implemented)
+        // TODO: Step 16: set forcePINChange to false (needed when authenticatorConfig setMinPINLength is implemented)
+        //spec| Step 17: The authenticator stores LEFT(SHA-256(newPin), 16) internally as the new value of CurrentStoredPIN.
         authenticatorPropertyStore.saveClientPIN(
             Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
         )
-        //spec| The authenticator calls resetPinUvAuthToken() for all pinUvAuthProtocols supported by this authenticator.
-        protocols.forEach { it.resetPinUvAuthToken() }
-        // persistentPinUvAuthToken is not yet implemented. When authenticatorCredentialManagement
-        // is added, pcmr permission handling and resetPersistentPinUvAuthToken() will be needed.
-        //spec| The authenticator returns CTAP2_OK.
+        //spec| Step 18: The authenticator sets the pinRetries counter to maximum count.
+        // (already done at Step 8)
+        //spec| Step 19: The authenticator calls resetPinUvAuthToken() for all pinUvAuthProtocols supported by this authenticator.
+        pinUvAuthProtocols.forEach { it.resetPinUvAuthToken() }
+        // TODO: Step 20: resetPersistentPinUvAuthToken (needed when authenticatorCredentialManagement is implemented)
+        //spec| Step 21: The authenticator returns CTAP2_OK.
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
@@ -369,28 +384,34 @@ class PinUvAuthService(
         platformKeyAgreementKey: COSEKey?,
         pinHashEnc: ByteArray?
     ): AuthenticatorClientPINResponse {
-        //spec| If the authenticator does not receive mandatory parameters for this command,
+        //spec| Step 1: If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinHashEnc == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
-        //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        //spec| Step 2: If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+        val protocol = getProtocol(pinProtocol)
+        // TODO: Step 3: If authenticatorClientPIN's permissions parameter is present in the getPinToken (0x05)
+        // subcommand, return CTAP1_ERR_INVALID_PARAMETER.
+        // TODO: Step 4: If authenticatorClientPIN's rpId parameter is present in the getPinToken (0x05)
+        // subcommand, return CTAP1_ERR_INVALID_PARAMETER.
+        //spec| Step 5: If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
         if (authenticatorPropertyStore.loadPINRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
         }
+        // Guard for PIN_AUTH_BLOCKED state (enforces Step 9.1.2 across calls; resets on power cycle)
         if (volatilePinRetryCounter <= 0) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
         }
 
-        val protocol = getProtocol(pinProtocol)
-
-        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| Step 6: The authenticator calls decapsulate on the provided platform key-agreement key
         //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
         val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
-        //spec| The authenticator decrements the pinRetries counter by 1.
+        // TODO: Step 7: request user consent if the authenticator has a display
+        //spec| Step 8: The authenticator decrements the pinRetries counter by 1.
         authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
 
-        //spec| The authenticator decrypts pinHashEnc using decrypt and verifies against its
+        //spec| Step 9: The authenticator decrypts pinHashEnc using decrypt and verifies against its
         //spec| internally stored CurrentStoredPIN.
         val pinHash = protocol.decrypt(sharedSecret, pinHashEnc)
         val storedPinHash =
@@ -398,11 +419,11 @@ class PinUvAuthService(
                 CtapStatusCode.CTAP2_ERR_PIN_NOT_SET
             )
         if (!Arrays.equals(pinHash, storedPinHash)) {
-            //spec| If an error results, or a mismatch is detected, the authenticator performs the following operations:
-            //spec| Calls regenerate for the selected pinUvAuthProtocol.
+            //spec| Step 9.1: If an error results, or a mismatch is detected, the authenticator performs the following operations:
+            //spec| Step 9.1.1: Calls regenerate for the selected pinUvAuthProtocol.
             protocol.regenerate()
             volatilePinRetryCounter--
-            //spec| The authenticator returns errors according to following conditions:
+            //spec| Step 9.1.2: The authenticator returns errors according to following conditions:
             //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
             //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
             //spec| indicating that power cycling is needed for further operations. This is done so that malware
@@ -417,19 +438,21 @@ class PinUvAuthService(
                     AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
             }
         }
-        //spec| The authenticator sets the pinRetries counter to maximum value.
+        //spec| Step 10: The authenticator sets the pinRetries counter to maximum value.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
-        //spec| Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all pinUvAuthProtocols
+        // TODO: Step 11: forcePINChange check (needed when authenticatorConfig setMinPINLength is implemented)
+        //spec| Step 12: Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all pinUvAuthProtocols
         //spec| supported by this authenticator.
-        protocols.forEach { it.resetPinUvAuthToken() }
-        // forcePINChange is not currently supported (always false). When authenticatorConfig
-        // setMinPINLength is implemented, this flag may be set to true.
+        pinUvAuthProtocols.forEach { it.resetPinUvAuthToken() }
+        //spec| Step 13: Call beginUsingPinUvAuthToken(userIsPresent: false).
         protocol.tokenState.beginUsingPinUvAuthToken(false)
+        //spec| Step 14: If the noMcGaPermissionsWithClientPin option ID is present and set to false, or absent,
+        //spec| then assign the pinUvAuthToken the default permissions.
         // noMcGaPermissionsWithClientPin option is absent, so default permissions (mc|ga) are granted.
         protocol.tokenState.permissions = PinUvAuthTokenPermissions(PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA)
-        //spec| The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
+        //spec| Step 15: The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
         //spec| i.e. encrypt(shared secret, pinUvAuthToken).
         val pinTokenEnc = protocol.encrypt(sharedSecret, protocol.pinUvAuthToken)
         val responseData =
@@ -499,19 +522,21 @@ class PinUvAuthService(
         permissions: PinUvAuthTokenPermissions?,
         rpId: String?
     ): AuthenticatorClientPINResponse {
-        //spec| If the authenticator does not receive mandatory parameters for this command,
+        //spec| Step 1: If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || pinHashEnc == null || permissions == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
 
-        //spec| If the authenticator receives a permissions parameter with value 0,
+        //spec| Step 2: If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+        val protocol = getProtocol(pinProtocol)
+        //spec| Step 3: If the authenticator receives a permissions parameter with value 0,
         //spec| return CTAP1_ERR_INVALID_PARAMETER.
         if (permissions.isEmpty()) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
         }
 
-        // Validate requested permissions against authenticator capabilities
+        //spec| Step 4: Validate requested permissions against authenticator capabilities.
         for (permission in permissions) {
             when (permission) {
                 PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA -> {
@@ -536,24 +561,24 @@ class PinUvAuthService(
             }
         }
 
-        //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        //spec| Step 5: If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
         if (authenticatorPropertyStore.loadPINRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
         }
+        // Guard for PIN_AUTH_BLOCKED state (enforces Step 9.1.2 across calls; resets on power cycle)
         if (volatilePinRetryCounter <= 0) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
         }
 
-        val protocol = getProtocol(pinProtocol)
-
-        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| Step 6: The authenticator calls decapsulate on the provided platform key-agreement key
         //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
         val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
+        // TODO: Step 7: request user consent if the authenticator has a display
 
-        //spec| The authenticator decrements the pinRetries counter by 1.
+        //spec| Step 8: The authenticator decrements the pinRetries counter by 1.
         authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
 
-        //spec| The authenticator decrypts pinHashEnc and verifies against its internally stored
+        //spec| Step 9: The authenticator decrypts pinHashEnc and verifies against its internally stored
         //spec| CurrentStoredPIN.
         val pinHash = protocol.decrypt(sharedSecret, pinHashEnc)
         val storedPinHash =
@@ -561,11 +586,11 @@ class PinUvAuthService(
                 CtapStatusCode.CTAP2_ERR_PIN_NOT_SET
             )
         if (!Arrays.equals(pinHash, storedPinHash)) {
-            //spec| If an error results, or a mismatch is detected, the authenticator performs the following operations:
-            //spec| Calls regenerate for the selected pinUvAuthProtocol.
+            //spec| Step 9.1: If an error results, or a mismatch is detected, the authenticator performs the following operations:
+            //spec| Step 9.1.1: Calls regenerate for the selected pinUvAuthProtocol.
             protocol.regenerate()
             volatilePinRetryCounter--
-            //spec| The authenticator returns errors according to following conditions:
+            //spec| Step 9.1.2: The authenticator returns errors according to following conditions:
             //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
             //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
             //spec| indicating that power cycling is needed for further operations. This is done so that malware
@@ -581,34 +606,32 @@ class PinUvAuthService(
             }
         }
 
-        //spec| The authenticator sets the pinRetries counter to maximum value.
+        //spec| Step 10: The authenticator sets the pinRetries counter to maximum value.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
 
-        // forcePINChange is not currently supported (always false). When authenticatorConfig
-        // setMinPINLength is implemented, this flag may be set to true.
-        // persistentPinUvAuthToken is not yet implemented. When authenticatorCredentialManagement
-        // is added, pcmr permission handling and resetPersistentPinUvAuthToken() will be needed.
+        // TODO: Step 11: forcePINChange check (needed when authenticatorConfig setMinPINLength is implemented)
+        // TODO: Step 12: pcmr permission handling (needed when authenticatorCredentialManagement is implemented)
 
-        //spec| Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
+        //spec| Step 13: Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
         //spec| pinUvAuthProtocols supported by this authenticator.
-        for (p in protocols) {
+        for (p in pinUvAuthProtocols) {
             p.resetPinUvAuthToken()
         }
 
-        //spec| Call beginUsingPinUvAuthToken(userIsPresent: false).
+        //spec| Step 14: Call beginUsingPinUvAuthToken(userIsPresent: false).
         protocol.tokenState.beginUsingPinUvAuthToken(false)
 
-        //spec| Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
+        //spec| Step 15: Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
         protocol.tokenState.permissions = permissions
 
-        //spec| If the rpId parameter is present, associate the permissions RP ID with the pinUvAuthToken.
+        //spec| Step 16: If the rpId parameter is present, associate the permissions RP ID with the pinUvAuthToken.
         if (rpId != null) {
             protocol.tokenState.permissionsRpId = rpId
         }
 
-        //spec| The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
+        //spec| Step 17: The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
         //spec| i.e. encrypt(shared secret, pinUvAuthToken).
         val pinTokenEnc = protocol.encrypt(sharedSecret, protocol.pinUvAuthToken)
         val responseData = AuthenticatorClientPINResponseData(null, pinTokenEnc, null)
@@ -674,19 +697,21 @@ class PinUvAuthService(
         permissions: PinUvAuthTokenPermissions?,
         rpId: String?
     ): AuthenticatorClientPINResponse {
-        //spec| If the authenticator does not receive mandatory parameters for this command,
+        //spec| Step 1: If the authenticator does not receive mandatory parameters for this command,
         //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
         if (platformKeyAgreementKey == null || permissions == null) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
         }
 
-        //spec| If the authenticator receives a permissions parameter with value 0,
+        //spec| Step 2: If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+        val protocol = getProtocol(pinProtocol)
+        //spec| Step 3: If the authenticator receives a permissions parameter with value 0,
         //spec| return CTAP1_ERR_INVALID_PARAMETER.
         if (permissions.isEmpty()) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
         }
 
-        // Validate requested permissions against authenticator capabilities
+        //spec| Step 4: Validate requested permissions against authenticator capabilities.
         for (permission in permissions) {
             when (permission) {
                 PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA -> {
@@ -710,54 +735,54 @@ class PinUvAuthService(
                 }
             }
         }
-        // Our virtual authenticator always supports and has configured built-in UV.
-        // A real authenticator would check the uv option ID in authenticatorGetInfo.
+        // TODO: Step 5: check if built-in UV is configured, return CTAP2_ERR_NOT_ALLOWED if not
+        // TODO: Step 6: determine internalRetry based on preferredPlatformUvAttempts
 
-        //spec| If the uvRetries counter is 0, return CTAP2_ERR_UV_BLOCKED error.
+        //spec| Step 7: If the uvRetries counter is 0, return CTAP2_ERR_UV_BLOCKED error.
         if (authenticatorPropertyStore.loadUVRetries() == 0u) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UV_BLOCKED)
         }
 
-        val protocol = getProtocol(pinProtocol)
-
-        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
-        //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+        // Decapsulate the platform key-agreement key to obtain the shared secret
+        // (implicit in the spec — needed for encrypt at Step 16)
         val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
+        // TODO: Step 8: request user consent if the authenticator has a display
 
+        //spec| Step 9: Let uvState be the result of calling performBuiltInUv(internalRetry)
+        //spec| Step 10: If uvState is error: return appropriate error.
         // Our virtual authenticator's built-in UV always succeeds.
         // A real authenticator would call performBuiltInUv(internalRetry) here,
         // decrement uvRetries on failure, and return appropriate errors
         // (CTAP2_ERR_UV_INVALID, CTAP2_ERR_UV_BLOCKED, CTAP2_ERR_USER_ACTION_TIMEOUT).
 
-        //spec| Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
+        // TODO: Step 11: pcmr permission handling (needed when authenticatorCredentialManagement is implemented)
+
+        //spec| Step 12: Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
         //spec| pinUvAuthProtocols supported by this authenticator.
-        for (p in protocols) {
+        for (p in pinUvAuthProtocols) {
             p.resetPinUvAuthToken()
         }
 
-        //spec| If the employed built-in user verification method supplied evidence of user interaction,
+        //spec| Step 13: If the employed built-in user verification method supplied evidence of user interaction,
         //spec| then call beginUsingPinUvAuthToken(userIsPresent: true).
         //spec| Otherwise (implying that user presence was not collected),
         //spec| call beginUsingPinUvAuthToken(userIsPresent: false).
         // Our virtual authenticator's UV always implies user interaction
         protocol.tokenState.beginUsingPinUvAuthToken(true)
 
-        // persistentPinUvAuthToken is not yet implemented. When authenticatorCredentialManagement
-        // is added, pcmr permission handling and resetPersistentPinUvAuthToken() will be needed.
-
-        //spec| Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
+        //spec| Step 14: Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
         protocol.tokenState.permissions = permissions
 
-        //spec| If the rpId parameter is present, use its value as the permissions RP ID and associate it with the pinUvAuthToken.
+        //spec| Step 15: If the rpId parameter is present, use its value as the permissions RP ID and associate it with the pinUvAuthToken.
         if (rpId != null) {
             protocol.tokenState.permissionsRpId = rpId
         }
 
-        //spec| The authenticator sets the pinRetries counter to maximum count.
+        // Reset retries counters after successful UV verification
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
 
-        //spec| The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
+        //spec| Step 16: The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
         //spec| i.e. encrypt(shared secret, pinUvAuthToken).
         val pinTokenEnc = protocol.encrypt(sharedSecret, protocol.pinUvAuthToken)
         val responseData = AuthenticatorClientPINResponseData(null, pinTokenEnc, null)
@@ -775,50 +800,15 @@ class PinUvAuthService(
     //spec|   2. Authenticator responds back with uvRetries.
     // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#gettingUVRetries">§6.5.5.3</a>
     fun getUVRetries(): AuthenticatorClientPINResponse {
+        //spec| Step 2: Authenticator responds back with uvRetries.
         val uvRetries = authenticatorPropertyStore.loadUVRetries()
         val responseData = AuthenticatorClientPINResponseData(null, null, null, null, uvRetries)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
-    //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
-    //spec| If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
-    fun verifyPinUvAuthParam(
-        pinAuth: ByteArray?,
-        clientDataHash: ByteArray?,
-        requiredPermission: PinUvAuthTokenPermission? = null,
-        rpId: String? = null
-    ) {
-        if (pinAuth == null || clientDataHash == null) {
-            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-        }
-        // Try verification against all protocols' pinUvAuthTokens
-        for (protocol in protocols) {
-            val calculatedPinAuth = protocol.authenticate(
-                protocol.pinUvAuthToken, clientDataHash
-            )
-            if (Arrays.equals(calculatedPinAuth, pinAuth)) {
-                if (protocol.tokenState.isInUse()) {
-                    if (requiredPermission != null && !protocol.tokenState.hasPermission(requiredPermission)) {
-                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-                    }
-
-                    val tokenRpId = protocol.tokenState.permissionsRpId
-                    if (tokenRpId != null && rpId != null && tokenRpId != rpId) {
-                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-                    }
-
-                    protocol.tokenState.recordPlatformUsage()
-                }
-
-                return
-            }
-        }
-        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+    private fun getProtocol(pinProtocol: PinProtocolVersion): PinUvAuthProtocol {
+        return pinUvAuthProtocols.firstOrNull { it.version == pinProtocol }
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
     }
-
-    val isClientPINReady: Boolean
-        get() = authenticatorPropertyStore.loadClientPIN() != null
-    val clientPIN: ByteArray?
-        get() = authenticatorPropertyStore.loadClientPIN()
 
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocol.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocol.kt
@@ -52,4 +52,7 @@ interface PinUvAuthProtocol {
     fun verify(key: ByteArray, message: ByteArray, signature: ByteArray): Boolean
 
     val pinUvAuthToken: ByteArray
+
+    //spec| A pinUvAuthToken has the following associated state variables.
+    val tokenState: PinUvAuthTokenState
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV1.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV1.kt
@@ -45,6 +45,8 @@ class PinUvAuthProtocolV1 : PinUvAuthProtocol {
     override val pinUvAuthToken: ByteArray
         get() = _pinUvAuthToken.copyOf()
 
+    override val tokenState: PinUvAuthTokenState = PinUvAuthTokenState()
+
     init {
         SecureRandom().nextBytes(_pinUvAuthToken)
     }
@@ -61,6 +63,7 @@ class PinUvAuthProtocolV1 : PinUvAuthProtocol {
     override fun resetPinUvAuthToken() {
         _pinUvAuthToken = ByteArray(PIN_UV_AUTH_TOKEN_LENGTH)
         SecureRandom().nextBytes(_pinUvAuthToken)
+        tokenState.stopUsingPinUvAuthToken()
     }
 
     override fun getPublicKey(): COSEKey {
@@ -107,6 +110,10 @@ class PinUvAuthProtocolV1 : PinUvAuthProtocol {
     //spec|   Compute HMAC-SHA-256 with the given key and message.
     //spec|   Return success if signature is 16 bytes and is equal to the first 16 bytes of the result, otherwise return error.
     override fun verify(key: ByteArray, message: ByteArray, signature: ByteArray): Boolean {
+        // If the key is the current pinUvAuthToken and it is not in use, return error
+        if (key.contentEquals(_pinUvAuthToken) && !tokenState.isInUse()) {
+            return false
+        }
         val expected = authenticate(key, message)
         return Arrays.equals(expected, signature)
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV2.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthProtocolV2.kt
@@ -47,6 +47,8 @@ class PinUvAuthProtocolV2 : PinUvAuthProtocol {
     override val pinUvAuthToken: ByteArray
         get() = _pinUvAuthToken.copyOf()
 
+    override val tokenState: PinUvAuthTokenState = PinUvAuthTokenState()
+
     init {
         SecureRandom().nextBytes(_pinUvAuthToken)
     }
@@ -63,6 +65,7 @@ class PinUvAuthProtocolV2 : PinUvAuthProtocol {
     override fun resetPinUvAuthToken() {
         _pinUvAuthToken = ByteArray(PIN_UV_AUTH_TOKEN_LENGTH)
         SecureRandom().nextBytes(_pinUvAuthToken)
+        tokenState.stopUsingPinUvAuthToken()
     }
 
     override fun getPublicKey(): COSEKey {
@@ -132,6 +135,10 @@ class PinUvAuthProtocolV2 : PinUvAuthProtocol {
     //spec|   Compute HMAC-SHA-256 with the given key and message.
     //spec|   Return success if the signature is equal to the result, otherwise return an error.
     override fun verify(key: ByteArray, message: ByteArray, signature: ByteArray): Boolean {
+        // If the key is the current pinUvAuthToken and it is not in use, return error
+        if (key.contentEquals(_pinUvAuthToken) && !tokenState.isInUse()) {
+            return false
+        }
         val expected = authenticate(key, message)
         return Arrays.equals(expected, signature)
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthService.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthService.kt
@@ -1,4 +1,6 @@
 package com.webauthn4j.ctap.authenticator
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
 
 import com.webauthn4j.ctap.authenticator.execution.CtapCommandExecutionException
 import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
@@ -28,6 +30,7 @@ class PinUvAuthService(
     companion object {
         const val MAX_PIN_RETRIES: UInt = 8u
         const val MAX_VOLATILE_PIN_RETRIES = 3
+        const val MAX_UV_RETRIES: UInt = 3u
     }
 
     private var volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
@@ -39,17 +42,47 @@ class PinUvAuthService(
             ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
     }
 
-    //spec| 6.5.5.2 Platform getting PIN retries from Authenticator
-    //spec| Authenticator responds back with pinRetries and, optionally, powerCycleState.
+    //spec| 6.5.5.2. Platform getting PIN retries from Authenticator
+    //spec| PIN retries count is the number of PIN attempts remaining before PIN is disabled on the device.
+    //spec| When the PIN retries count nears zero,
+    //spec| the platform can optionally warn the user to be careful while entering the PIN.
+    //spec| Platform performs the following operations to get pinRetries:
+    //spec|   1. Platform sends authenticatorClientPIN command
+    //spec|      with following parameters to the authenticator:
+    //spec|        subCommand: getPINRetries(0x01)
+    //spec|   2. Authenticator responds back with pinRetries and, optionally,
+    //spec|      powerCycleState.
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#gettingPINRetries">§6.5.5.2</a>
     fun getPinRetries(): AuthenticatorClientPINResponse {
         val pinRetries = authenticatorPropertyStore.loadPINRetries()
-        val responseData = AuthenticatorClientPINResponseData(null, null, pinRetries)
+        val powerCycleState = if (volatilePinRetryCounter <= 0) true else null
+        val responseData = AuthenticatorClientPINResponseData(null, null, pinRetries, powerCycleState, null)
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
-    //spec| 6.5.5.4 Obtaining the Shared Secret
-    //spec| Otherwise the authenticator sends a response with the following parameters:
-    //spec| keyAgreement: the result of calling getPublicKey for the selected pinUvAuthProtocol.
+    //spec| 6.5.5.4. Obtaining the Shared Secret
+    //spec| subCommand: getKeyAgreement (0x02)
+    //spec| Platforms obtain a shared secret for each transaction. The authenticator does not have to keep a list of
+    //spec| sharedSecrets for all active sessions. If there are subsequent authenticatorClientPIN transactions, a new
+    //spec| sharedSecret is generated every time.
+    //spec| Platform performs the following operations to arrive at the sharedSecret:
+    //spec|   1. The platform selects a mutually supported PIN/UV auth protocol by considering the list of protocols
+    //spec|      supported by the authenticator, as reported in the pinUvAuthProtocols member of the authenticatorGetInfo
+    //spec|      response. If there are multiple mutually supported protocols, and the platform has no preference, it SHOULD
+    //spec|      select the one listed first in pinUvAuthProtocols.
+    //spec|   2. The platform sends authenticatorClientPIN command
+    //spec|      with following parameters to the authenticator:
+    //spec|      - pinUvAuthProtocol: as chosen above
+    //spec|      - subCommand: getKeyAgreement(0x02)
+    //spec|   3. If the authenticator does not receive mandatory parameters for this subcommand, end the operation by
+    //spec|      returning CTAP2_ERR_MISSING_PARAMETER.
+    //spec|   4. If the authenticator does not support the selected pinUvAuthProtocol, it returns
+    //spec|      CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   5. Otherwise the authenticator sends a response with the following parameters:
+    //spec|      - keyAgreement: the result of calling getPublicKey for the selected pinUvAuthProtocol.
+    //spec|   6. The platform calls encapsulate with the public key that the authenticator returned in order to generate
+    //spec|      the platform key-agreement key and the shared secret.
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#gettingSharedSecret">§6.5.5.4</a>
     fun getKeyAgreement(pinProtocol: PinProtocolVersion): AuthenticatorClientPINResponse {
         val protocol = getProtocol(pinProtocol)
         val keyAgreement = protocol.getPublicKey()
@@ -57,8 +90,33 @@ class PinUvAuthService(
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
-    //spec| 6.5.5.5 Setting a New PIN
+    //spec| 6.5.5.5. Setting a New PIN
+    //spec| subCommand: setPIN (0x03)
+    //spec| The following operations are performed to set up a new PIN:
+    //spec| The platform collects the new PIN (newPinUnicode) from the user as Unicode characters in Normalization
+    //spec| Form C. The platform obtains the shared secret from the authenticator and sends the authenticatorClientPIN
+    //spec| command with setPIN(0x03) subCommand.
     //spec| Authenticator performs following operations upon receiving the request:
+    //spec|   1. If the authenticator does not receive mandatory parameters for this command,
+    //spec|      it returns CTAP2_ERR_MISSING_PARAMETER error.
+    //spec|   2. If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   3. If a PIN has already been set, authenticator returns CTAP2_ERR_PIN_AUTH_INVALID error.
+    //spec|   4. The authenticator calls decapsulate on the provided platform key-agreement key to obtain the shared
+    //spec|      secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   5. The authenticator calls verify(shared secret, newPinEnc, pinUvAuthParam)
+    //spec|      5.1. If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|   6. The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin. If an error results,
+    //spec|      it returns CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|   7. If paddedNewPin is NOT 64 bytes long, it returns CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   8. The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
+    //spec|   9. The authenticator checks the length of newPin against the current minimum PIN length, returning
+    //spec|      CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
+    //spec|   10. An authenticator MAY impose arbitrary, additional constraints on PINs. If newPin fails to satisfy such
+    //spec|       additional constraints, the authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
+    //spec|   11. The authenticator remembers newPin length internally as PINCodePointLength.
+    //spec|   12. The authenticator stores LEFT(SHA-256(newPin), 16) internally as CurrentStoredPIN,
+    //spec|       sets the pinRetries counter to maximum count, and returns CTAP2_OK.
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#settingNewPin">§6.5.5.5</a>
     fun setPIN(
         pinProtocol: PinProtocolVersion,
         platformKeyAgreementKey: COSEKey?,
@@ -90,6 +148,9 @@ class PinUvAuthService(
         //spec| The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
         //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
         val newPIN = protocol.decrypt(sharedSecret, newPinEnc)
+        if (newPIN.size != 64) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+        }
         //spec| The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
         val sentinelPos = newPIN.indexOf(0x00)
         val trimmedNewPIN: ByteArray = when {
@@ -110,11 +171,61 @@ class PinUvAuthService(
             Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
         )
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
+        authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
+        //spec| The authenticator calls resetPinUvAuthToken() for all pinUvAuthProtocols supported by this authenticator.
+        protocols.forEach { it.resetPinUvAuthToken() }
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
-    //spec| 6.5.5.6 Changing existing PIN
+    //spec| 6.5.5.6. Changing existing PIN
+    //spec| subCommand: changePIN (0x04)
+    //spec| The following operations are performed to change an existing PIN:
+    //spec| The Platform collects the current PIN (curPinUnicode) and new PIN (newPinUnicode) from the user as
+    //spec| Unicode characters in Normalization Form C. Platform obtains the shared secret from the authenticator
+    //spec| and sends the authenticatorClientPIN command with changePIN(0x04) subCommand.
     //spec| Authenticator performs following operations upon receiving the request:
+    //spec|   1. If the authenticator does not receive mandatory parameters for this command,
+    //spec|      it returns CTAP2_ERR_MISSING_PARAMETER error.
+    //spec|   2. If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   3. If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+    //spec|   4. The authenticator calls decapsulate on the provided platform key-agreement key to obtain the shared
+    //spec|      secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   5. The authenticator calls verify(shared secret, newPinEnc || pinHashEnc, pinUvAuthParam)
+    //spec|      5.1. If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|   6. The authenticator decrements the pinRetries counter by 1.
+    //spec|   7. The authenticator decrypts pinHashEnc using decrypt(shared secret, pinHashEnc) and verifies against its
+    //spec|      internal stored LEFT(SHA-256(curPin), 16).
+    //spec|      7.1. If an error results, or a mismatch is detected, the authenticator performs the following operations:
+    //spec|           7.1.1. Calls regenerate for the selected pinUvAuthProtocol.
+    //spec|           7.1.2. The authenticator returns errors according to following conditions:
+    //spec|                  - If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+    //spec|                  - If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
+    //spec|                    indicating that power cycling is needed for further operations. This is done so that malware
+    //spec|                    running on the platform should not be able to block the device without user interaction.
+    //spec|                  - Else return CTAP2_ERR_PIN_INVALID error.
+    //spec|   8. The authenticator sets the pinRetries counter to maximum value.
+    //spec|   9. The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin. If an error results,
+    //spec|      it returns CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|   10. If paddedNewPin is NOT 64 bytes long, it returns CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   11. The authenticator drops all trailing 0x00 bytes from paddedNewPin to produce newPin.
+    //spec|   12. The authenticator checks the length of newPin against the current minimum PIN length, returning
+    //spec|       CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
+    //spec|   13. If the forcePINChange member of the authenticatorGetInfo response is true and LEFT(SHA-256(newPin), 16)
+    //spec|       is equal to its internal stored LEFT(SHA-256(curPin), 16) then authenticator returns
+    //spec|       CTAP2_ERR_PIN_POLICY_VIOLATION.
+    //spec|   14. An authenticator MAY impose arbitrary, additional constraints on PINs. If newPin fails to satisfy such
+    //spec|       additional constraints, the authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
+    //spec|   15. The authenticator remembers newPin length internally as PINCodePointLength.
+    //spec|   16. The authenticator sets the value of the forcePINChange member of the authenticatorGetInfo response to
+    //spec|       false,
+    //spec|   17. The authenticator stores LEFT(SHA-256(newPin), 16) internally as the new value of CurrentStoredPIN.
+    //spec|   18. The authenticator sets the pinRetries counter to maximum count.
+    //spec|   19. The authenticator calls resetPinUvAuthToken() for all pinUvAuthProtocols supported by this
+    //spec|       authenticator. (I.e. all existing pinUvAuthTokens are invalidated.)
+    //spec|   20. The authenticator calls resetPersistentPinUvAuthToken() (all persistent permissions are cleared on pin
+    //spec|       change).
+    //spec|   21. The authenticator returns CTAP2_OK.
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#changingExistingPin">§6.5.5.6</a>
     fun changePIN(
         pinProtocol: PinProtocolVersion,
         platformKeyAgreementKey: COSEKey?,
@@ -178,6 +289,7 @@ class PinUvAuthService(
         }
         //spec| The authenticator sets the pinRetries counter to maximum value.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
+        authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
         //spec| The authenticator calls decrypt(shared secret, newPinEnc) to produce paddedNewPin.
         //spec| If an error results, it returns CTAP2_ERR_PIN_AUTH_INVALID.
@@ -185,6 +297,9 @@ class PinUvAuthService(
         //spec| The authenticator checks the length of newPin against the current minimum PIN length,
         //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
         val newPIN = protocol.decrypt(sharedSecret, newPinEnc)
+        if (newPIN.size != 64) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+        }
         val sentinelPos = ArrayUtil.indexOf(newPIN, 0x00.toByte())
         if (sentinelPos < 0) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
@@ -196,16 +311,59 @@ class PinUvAuthService(
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
+        // forcePINChange is not currently supported (always false). When authenticatorConfig
+        // setMinPINLength is implemented, this flag may be set to true.
         //spec| The authenticator stores LEFT(SHA-256(newPin), 16) internally as the new value of CurrentStoredPIN.
-        //spec| The authenticator returns CTAP2_OK.
         authenticatorPropertyStore.saveClientPIN(
             Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
         )
+        //spec| The authenticator calls resetPinUvAuthToken() for all pinUvAuthProtocols supported by this authenticator.
+        protocols.forEach { it.resetPinUvAuthToken() }
+        // persistentPinUvAuthToken is not yet implemented. When authenticatorCredentialManagement
+        // is added, pcmr permission handling and resetPersistentPinUvAuthToken() will be needed.
+        //spec| The authenticator returns CTAP2_OK.
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK)
     }
 
-    //spec| 6.5.5.7.1 Getting pinUvAuthToken using getPinToken (superseded)
+    //spec| 6.5.5.7.1. Getting pinUvAuthToken using getPinToken (superseded)
+    //spec| subCommand: getPinToken (0x05)
+    //spec| Platform collects PIN from the user. Platform obtains the shared secret from the authenticator and sends
+    //spec| the authenticatorClientPIN command with getPinToken(0x05) subCommand.
     //spec| Authenticator performs following operations upon receiving the request:
+    //spec|   1. If the authenticator does not receive mandatory parameters for this command,
+    //spec|      it returns CTAP2_ERR_MISSING_PARAMETER error.
+    //spec|   2. If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   3. If authenticatorClientPIN's permissions parameter is present in the getPinToken (0x05) subcommand,
+    //spec|      return CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   4. If authenticatorClientPIN's rpId parameter is present in the getPinToken (0x05) subcommand,
+    //spec|      return CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   5. If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+    //spec|   6. The authenticator calls decapsulate on the provided platform key-agreement key to obtain the shared
+    //spec|      secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   7. If the authenticator has a display, request user consent for the default permissions. If this is not
+    //spec|      approved, return CTAP2_ERR_OPERATION_DENIED.
+    //spec|   8. The authenticator decrements the pinRetries counter by 1.
+    //spec|   9. The authenticator decrypts pinHashEnc using decrypt and verifies against its internally stored
+    //spec|      CurrentStoredPIN.
+    //spec|      9.1. If an error results, or a mismatch is detected, the authenticator performs the following operations:
+    //spec|           9.1.1. Calls regenerate for the selected pinUvAuthProtocol.
+    //spec|           9.1.2. The authenticator returns errors according to following conditions:
+    //spec|                  - If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+    //spec|                  - If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
+    //spec|                    indicating that power cycling is needed for further operations. This is done so that malware
+    //spec|                    running on the platform should not be able to block the device without user interaction.
+    //spec|                  - Else return CTAP2_ERR_PIN_INVALID error.
+    //spec|   10. The authenticator sets the pinRetries counter to maximum value.
+    //spec|   11. If the value of the forcePINChange member of the authenticatorGetInfo response is true,
+    //spec|       authenticator returns CTAP2_ERR_PIN_INVALID error.
+    //spec|   12. Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all pinUvAuthProtocols supported by
+    //spec|       this authenticator. (I.e. all existing pinUvAuthTokens are invalidated.)
+    //spec|   13. Call beginUsingPinUvAuthToken(userIsPresent: false).
+    //spec|   14. If the noMcGaPermissionsWithClientPin option ID is present and set to false, or absent, then assign
+    //spec|       the pinUvAuthToken the default permissions.
+    //spec|   15. The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol, i.e.
+    //spec|       encrypt(shared secret, pinUvAuthToken).
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#getPinToken">§6.5.5.7.1</a>
     fun getPinToken(
         pinProtocol: PinProtocolVersion,
         platformKeyAgreementKey: COSEKey?,
@@ -261,7 +419,16 @@ class PinUvAuthService(
         }
         //spec| The authenticator sets the pinRetries counter to maximum value.
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
+        authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
+        //spec| Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all pinUvAuthProtocols
+        //spec| supported by this authenticator.
+        protocols.forEach { it.resetPinUvAuthToken() }
+        // forcePINChange is not currently supported (always false). When authenticatorConfig
+        // setMinPINLength is implemented, this flag may be set to true.
+        protocol.tokenState.beginUsingPinUvAuthToken(false)
+        // noMcGaPermissionsWithClientPin option is absent, so default permissions (mc|ga) are granted.
+        protocol.tokenState.permissions = PinUvAuthTokenPermissions(PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA)
         //spec| The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
         //spec| i.e. encrypt(shared secret, pinUvAuthToken).
         val pinTokenEnc = protocol.encrypt(sharedSecret, protocol.pinUvAuthToken)
@@ -270,9 +437,357 @@ class PinUvAuthService(
         return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
     }
 
+    //spec| 6.5.5.7.2. Getting pinUvAuthToken using getPinUvAuthTokenUsingPinWithPermissions (ClientPIN)
+    //spec| subCommand: getPinUvAuthTokenUsingPinWithPermissions (0x09)
+    //spec| This subCommand MUST be implemented if the authenticator includes both clientPin and pinUvAuthToken
+    //spec| Option IDs set to true in the authenticatorGetInfo response.
+    //spec| Platform collects PIN from the user. Platform obtains the shared secret from the authenticator and sends
+    //spec| the authenticatorClientPIN command with getPinUvAuthTokenUsingPinWithPermissions(0x09) subCommand.
+    //spec| Authenticator performs following operations upon receiving the request:
+    //spec|   1. If the authenticator does not receive mandatory parameters for this command,
+    //spec|      it returns CTAP2_ERR_MISSING_PARAMETER error.
+    //spec|   2. If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   3. If the authenticator receives a permissions parameter with value 0, return
+    //spec|      CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   4. The below statements each relate a pinUvAuthToken permission to a given state for a
+    //spec|      authenticatorGetInfo option ID. For each pinUvAuthToken permission present in the permissions parameter,
+    //spec|      if the statement corresponding to the permission is currently true, terminate these steps and return
+    //spec|      CTAP2_ERR_UNAUTHORIZED_PERMISSION. Undefined permissions present in the permissions parameter are ignored.
+    //spec|      - cm: credMgmt is false or absent.
+    //spec|      - be: bioEnroll is absent.
+    //spec|      - lbw: largeBlobs is false or absent.
+    //spec|      - acfg: authnrCfg is false or absent.
+    //spec|      - mc: noMcGaPermissionsWithClientPin is present and set to true.
+    //spec|      - ga: noMcGaPermissionsWithClientPin is present and set to true.
+    //spec|      - pcmr: perCredMgmtRO is false or absent, or any other pinUvAuthToken permission is requested.
+    //spec|   5. If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+    //spec|   6. The authenticator calls decapsulate on the provided platform key-agreement key to obtain the shared
+    //spec|      secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   7. If the authenticator has a display, request user consent for the requested permissions. If this is not
+    //spec|      approved, return CTAP2_ERR_OPERATION_DENIED.
+    //spec|   8. The authenticator decrements the pinRetries counter by 1.
+    //spec|   9. The authenticator decrypts pinHashEnc using decrypt and verifies against its internally stored
+    //spec|      CurrentStoredPIN.
+    //spec|      9.1. If an error results, or a mismatch is detected, the authenticator performs the following operations:
+    //spec|           9.1.1. Calls regenerate for the selected pinUvAuthProtocol.
+    //spec|           9.1.2. The authenticator returns errors according to following conditions:
+    //spec|                  - If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+    //spec|                  - If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
+    //spec|                    indicating that power cycling is needed for further operations. This is done so that malware
+    //spec|                    running on the platform should not be able to block the device without user interaction.
+    //spec|                  - Else return CTAP2_ERR_PIN_INVALID error.
+    //spec|   10. The authenticator sets the pinRetries counter to maximum value.
+    //spec|   11. If the value of the forcePINChange member of the authenticatorGetInfo response is true,
+    //spec|       authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
+    //spec|       Platform on receiving such error response SHOULD direct the user to change the PIN.
+    //spec|   12. If the value of the requested permissions is pcmr:
+    //spec|       12.1. Assign pcmr permission to the persistentPinUvAuthToken.
+    //spec|       12.2. The authenticator returns the encrypted persistentPinUvAuthToken for the specified
+    //spec|             pinUvAuthProtocol, i.e. encrypt(shared secret, persistentPinUvAuthToken).
+    //spec|   13. Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all pinUvAuthProtocols supported by
+    //spec|       this authenticator. (I.e. all existing pinUvAuthTokens are invalidated.)
+    //spec|   14. Call beginUsingPinUvAuthToken(userIsPresent: false).
+    //spec|   15. Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
+    //spec|   16. If the rpId parameter is present, associate the permissions RP ID with the pinUvAuthToken.
+    //spec|   17. The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol, i.e.
+    //spec|       encrypt(shared secret, pinUvAuthToken).
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#getPinUvAuthTokenUsingPinWithPermissions">§6.5.5.7.2</a>
+    fun getPinUvAuthTokenUsingPinWithPermissions(
+        pinProtocol: PinProtocolVersion,
+        platformKeyAgreementKey: COSEKey?,
+        pinHashEnc: ByteArray?,
+        permissions: PinUvAuthTokenPermissions?,
+        rpId: String?
+    ): AuthenticatorClientPINResponse {
+        //spec| If the authenticator does not receive mandatory parameters for this command,
+        //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
+        if (platformKeyAgreementKey == null || pinHashEnc == null || permissions == null) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+        }
+
+        //spec| If the authenticator receives a permissions parameter with value 0,
+        //spec| return CTAP1_ERR_INVALID_PARAMETER.
+        if (permissions.isEmpty()) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+        }
+
+        // Validate requested permissions against authenticator capabilities
+        for (permission in permissions) {
+            when (permission) {
+                PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA -> {
+                    // Always authorized for PIN-based token issuance
+                }
+                PinUvAuthTokenPermission.CM -> {
+                    // TODO: check credMgmt option when authenticatorCredentialManagement is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+                PinUvAuthTokenPermission.BE -> {
+                    // TODO: check bioEnroll option when authenticatorBioEnrollment is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+                PinUvAuthTokenPermission.LBW -> {
+                    // TODO: check largeBlobs option when authenticatorLargeBlobs is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+                PinUvAuthTokenPermission.ACFG -> {
+                    // TODO: check authnrCfg option when authenticatorConfig is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+            }
+        }
+
+        //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+        if (authenticatorPropertyStore.loadPINRetries() == 0u) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
+        }
+        if (volatilePinRetryCounter <= 0) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
+        }
+
+        val protocol = getProtocol(pinProtocol)
+
+        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+        val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
+
+        //spec| The authenticator decrements the pinRetries counter by 1.
+        authenticatorPropertyStore.savePINRetries(authenticatorPropertyStore.loadPINRetries() - 1u)
+
+        //spec| The authenticator decrypts pinHashEnc and verifies against its internally stored
+        //spec| CurrentStoredPIN.
+        val pinHash = protocol.decrypt(sharedSecret, pinHashEnc)
+        val storedPinHash =
+            authenticatorPropertyStore.loadClientPIN() ?: return AuthenticatorClientPINResponse(
+                CtapStatusCode.CTAP2_ERR_PIN_NOT_SET
+            )
+        if (!Arrays.equals(pinHash, storedPinHash)) {
+            //spec| If an error results, or a mismatch is detected, the authenticator performs the following operations:
+            //spec| Calls regenerate for the selected pinUvAuthProtocol.
+            protocol.regenerate()
+            volatilePinRetryCounter--
+            //spec| The authenticator returns errors according to following conditions:
+            //spec| If the pinRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED error.
+            //spec| If the authenticator sees 3 consecutive mismatches, it returns CTAP2_ERR_PIN_AUTH_BLOCKED,
+            //spec| indicating that power cycling is needed for further operations. This is done so that malware
+            //spec| running on the platform should not be able to block the device without user interaction.
+            //spec| Else return CTAP2_ERR_PIN_INVALID error.
+            return when {
+                authenticatorPropertyStore.loadPINRetries() == 0u ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_BLOCKED)
+                volatilePinRetryCounter <= 0 ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_AUTH_BLOCKED)
+                else ->
+                    AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+            }
+        }
+
+        //spec| The authenticator sets the pinRetries counter to maximum value.
+        authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
+        authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
+        volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
+
+        // forcePINChange is not currently supported (always false). When authenticatorConfig
+        // setMinPINLength is implemented, this flag may be set to true.
+        // persistentPinUvAuthToken is not yet implemented. When authenticatorCredentialManagement
+        // is added, pcmr permission handling and resetPersistentPinUvAuthToken() will be needed.
+
+        //spec| Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
+        //spec| pinUvAuthProtocols supported by this authenticator.
+        for (p in protocols) {
+            p.resetPinUvAuthToken()
+        }
+
+        //spec| Call beginUsingPinUvAuthToken(userIsPresent: false).
+        protocol.tokenState.beginUsingPinUvAuthToken(false)
+
+        //spec| Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
+        protocol.tokenState.permissions = permissions
+
+        //spec| If the rpId parameter is present, associate the permissions RP ID with the pinUvAuthToken.
+        if (rpId != null) {
+            protocol.tokenState.permissionsRpId = rpId
+        }
+
+        //spec| The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
+        //spec| i.e. encrypt(shared secret, pinUvAuthToken).
+        val pinTokenEnc = protocol.encrypt(sharedSecret, protocol.pinUvAuthToken)
+        val responseData = AuthenticatorClientPINResponseData(null, pinTokenEnc, null)
+        return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
+    }
+
+    //spec| 6.5.5.7.3. Getting pinUvAuthToken using getPinUvAuthTokenUsingUvWithPermissions (built-in user
+    //spec| verification methods)
+    //spec| subCommand: getPinUvAuthTokenUsingUvWithPermissions (0x06)
+    //spec| This subCommand is only applicable when the authenticator supports built-in user verification methods.
+    //spec| This subCommand MUST be implemented if the authenticator returns both uv and pinUvAuthToken option IDs
+    //spec| set to true in the authenticatorGetInfo response.
+    //spec| Platform obtains the shared secret from the authenticator and sends the authenticatorClientPIN command
+    //spec| with getPinUvAuthTokenUsingUvWithPermissions(0x06) subCommand.
+    //spec| Authenticator performs following operations upon receiving the request:
+    //spec|   1. If the authenticator does not receive mandatory parameters for this command,
+    //spec|      it returns CTAP2_ERR_MISSING_PARAMETER error.
+    //spec|   2. If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   3. If the authenticator receives a permissions parameter with value 0, return
+    //spec|      CTAP1_ERR_INVALID_PARAMETER.
+    //spec|   4. The below statements each relate a pinUvAuthToken permission to a given state for a
+    //spec|      authenticatorGetInfo option ID. For each pinUvAuthToken permission present in the permissions parameter,
+    //spec|      if the statement corresponding to the permission is currently true, terminate these steps and return
+    //spec|      CTAP2_ERR_UNAUTHORIZED_PERMISSION. The mc and ga permissions are always considered authorized, thus they
+    //spec|      are not listed below. Undefined permissions present in the permissions are ignored.
+    //spec|      - cm: credMgmt is false or absent.
+    //spec|      - be: uvBioEnroll is false or absent.
+    //spec|      - lbw: largeBlobs is false or absent.
+    //spec|      - acfg: uvAcfg is false or absent.
+    //spec|      - pcmr: perCredMgmtRO is false or absent, or any other pinUvAuthToken permission is requested.
+    //spec|   5. If a built-in user verification method is supported but not configured, the authenticator
+    //spec|      returns CTAP2_ERR_NOT_ALLOWED.
+    //spec|   6. If preferredPlatformUvAttempts > 1 then let internalRetry be false. This indicates that the platform
+    //spec|      will try invoking this sub command preferably about preferredPlatformUvAttempts times.
+    //spec|      Else let internalRetry be true.
+    //spec|   7. If the uvRetries counter is 0, return CTAP2_ERR_UV_BLOCKED error.
+    //spec|   8. If the authenticator has a display, request user consent for the requested permissions. If this is not
+    //spec|      approved, return CTAP2_ERR_OPERATION_DENIED.
+    //spec|   9. Let uvState be the result of calling performBuiltInUv(internalRetry)
+    //spec|   10. If uvState is error:
+    //spec|       10.1. If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+    //spec|       10.2. If the uvRetries counter is 0, return CTAP2_ERR_UV_BLOCKED.
+    //spec|       10.3. Otherwise, return CTAP2_ERR_UV_INVALID.
+    //spec|   11. If the value of the requested permissions is pcmr:
+    //spec|       11.1. Assign pcmr permission to the persistentPinUvAuthToken.
+    //spec|       11.2. The authenticator returns the encrypted persistentPinUvAuthToken for the specified
+    //spec|             pinUvAuthProtocol, i.e. encrypt(shared secret, persistentPinUvAuthToken).
+    //spec|   12. Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all pinUvAuthProtocols supported by
+    //spec|       this authenticator. (I.e. all existing pinUvAuthTokens are invalidated.)
+    //spec|   13. If the employed built-in user verification method supplied evidence of user interaction, then call
+    //spec|       beginUsingPinUvAuthToken(userIsPresent: true).
+    //spec|       Otherwise (implying that user presence was not collected), call
+    //spec|       beginUsingPinUvAuthToken(userIsPresent: false).
+    //spec|   14. Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
+    //spec|   15. If the rpId parameter is present, use its value as the permissions RP ID and associate it with the
+    //spec|       pinUvAuthToken.
+    //spec|   16. The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol, i.e.
+    //spec|       encrypt(shared secret, pinUvAuthToken).
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#getPinUvAuthTokenUsingUvWithPermissions">§6.5.5.7.3</a>
+    fun getPinUvAuthTokenUsingUvWithPermissions(
+        pinProtocol: PinProtocolVersion,
+        platformKeyAgreementKey: COSEKey?,
+        permissions: PinUvAuthTokenPermissions?,
+        rpId: String?
+    ): AuthenticatorClientPINResponse {
+        //spec| If the authenticator does not receive mandatory parameters for this command,
+        //spec| it returns CTAP2_ERR_MISSING_PARAMETER error.
+        if (platformKeyAgreementKey == null || permissions == null) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+        }
+
+        //spec| If the authenticator receives a permissions parameter with value 0,
+        //spec| return CTAP1_ERR_INVALID_PARAMETER.
+        if (permissions.isEmpty()) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+        }
+
+        // Validate requested permissions against authenticator capabilities
+        for (permission in permissions) {
+            when (permission) {
+                PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA -> {
+                    // Always authorized for UV-based token issuance
+                }
+                PinUvAuthTokenPermission.CM -> {
+                    // TODO: check credMgmt option when authenticatorCredentialManagement is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+                PinUvAuthTokenPermission.BE -> {
+                    // TODO: check uvBioEnroll option when authenticatorBioEnrollment is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+                PinUvAuthTokenPermission.LBW -> {
+                    // TODO: check largeBlobs option when authenticatorLargeBlobs is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+                PinUvAuthTokenPermission.ACFG -> {
+                    // TODO: check uvAcfg option when authenticatorConfig is implemented
+                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                }
+            }
+        }
+        // Our virtual authenticator always supports and has configured built-in UV.
+        // A real authenticator would check the uv option ID in authenticatorGetInfo.
+
+        //spec| If the uvRetries counter is 0, return CTAP2_ERR_UV_BLOCKED error.
+        if (authenticatorPropertyStore.loadUVRetries() == 0u) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UV_BLOCKED)
+        }
+
+        val protocol = getProtocol(pinProtocol)
+
+        //spec| The authenticator calls decapsulate on the provided platform key-agreement key
+        //spec| to obtain the shared secret. If an error results, it returns CTAP1_ERR_INVALID_PARAMETER.
+        val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)
+
+        // Our virtual authenticator's built-in UV always succeeds.
+        // A real authenticator would call performBuiltInUv(internalRetry) here,
+        // decrement uvRetries on failure, and return appropriate errors
+        // (CTAP2_ERR_UV_INVALID, CTAP2_ERR_UV_BLOCKED, CTAP2_ERR_USER_ACTION_TIMEOUT).
+
+        //spec| Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
+        //spec| pinUvAuthProtocols supported by this authenticator.
+        for (p in protocols) {
+            p.resetPinUvAuthToken()
+        }
+
+        //spec| If the employed built-in user verification method supplied evidence of user interaction,
+        //spec| then call beginUsingPinUvAuthToken(userIsPresent: true).
+        //spec| Otherwise (implying that user presence was not collected),
+        //spec| call beginUsingPinUvAuthToken(userIsPresent: false).
+        // Our virtual authenticator's UV always implies user interaction
+        protocol.tokenState.beginUsingPinUvAuthToken(true)
+
+        // persistentPinUvAuthToken is not yet implemented. When authenticatorCredentialManagement
+        // is added, pcmr permission handling and resetPersistentPinUvAuthToken() will be needed.
+
+        //spec| Assign the requested permissions to the pinUvAuthToken, ignoring any undefined permissions.
+        protocol.tokenState.permissions = permissions
+
+        //spec| If the rpId parameter is present, use its value as the permissions RP ID and associate it with the pinUvAuthToken.
+        if (rpId != null) {
+            protocol.tokenState.permissionsRpId = rpId
+        }
+
+        //spec| The authenticator sets the pinRetries counter to maximum count.
+        authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
+        authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
+
+        //spec| The authenticator returns the encrypted pinUvAuthToken for the specified pinUvAuthProtocol,
+        //spec| i.e. encrypt(shared secret, pinUvAuthToken).
+        val pinTokenEnc = protocol.encrypt(sharedSecret, protocol.pinUvAuthToken)
+        val responseData = AuthenticatorClientPINResponseData(null, pinTokenEnc, null)
+        return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
+    }
+
+    //spec| 6.5.5.3. Platform getting UV Retries from Authenticator
+    //spec| UV retries count is the number of built-in UV attempts remaining before built-in UV is disabled on
+    //spec| the device. When the UV retries count nears zero, the platform can optionally warn the user to be
+    //spec| careful while performing user verification.
+    //spec| Platform performs the following operations to get uvRetries:
+    //spec|   1. Platform sends authenticatorClientPIN command
+    //spec|      with following parameters to the authenticator:
+    //spec|        subCommand: getUVRetries(0x07)
+    //spec|   2. Authenticator responds back with uvRetries.
+    // @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#gettingUVRetries">§6.5.5.3</a>
+    fun getUVRetries(): AuthenticatorClientPINResponse {
+        val uvRetries = authenticatorPropertyStore.loadUVRetries()
+        val responseData = AuthenticatorClientPINResponseData(null, null, null, null, uvRetries)
+        return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_OK, responseData)
+    }
+
     //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
     //spec| If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
-    fun verifyPinUvAuthParam(pinAuth: ByteArray?, clientDataHash: ByteArray?) {
+    fun verifyPinUvAuthParam(
+        pinAuth: ByteArray?,
+        clientDataHash: ByteArray?,
+        requiredPermission: PinUvAuthTokenPermission? = null,
+        rpId: String? = null
+    ) {
         if (pinAuth == null || clientDataHash == null) {
             throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
@@ -282,6 +797,19 @@ class PinUvAuthService(
                 protocol.pinUvAuthToken, clientDataHash
             )
             if (Arrays.equals(calculatedPinAuth, pinAuth)) {
+                if (protocol.tokenState.isInUse()) {
+                    if (requiredPermission != null && !protocol.tokenState.hasPermission(requiredPermission)) {
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                    }
+
+                    val tokenRpId = protocol.tokenState.permissionsRpId
+                    if (tokenRpId != null && rpId != null && tokenRpId != rpId) {
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                    }
+
+                    protocol.tokenState.recordPlatformUsage()
+                }
+
                 return
             }
         }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthTokenState.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthTokenState.kt
@@ -1,0 +1,193 @@
+package com.webauthn4j.ctap.authenticator
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
+
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * State associated with a pinUvAuthToken.
+ *
+ * Each [PinUvAuthProtocol] instance holds one [PinUvAuthTokenState] that tracks
+ * the token's permissions, bound RP ID, usage timer, and user-presence / user-verified flags.
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#pinUvAuthToken-state">6.5.2.1. pinUvAuthToken State</a>
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#pinUvAuthToken-state-maintenance">6.5.3.2. pinUvAuthToken State Maintenance Functions</a>
+ */
+class PinUvAuthTokenState(
+    private val transportInitialUsageTimeLimit: Duration = DEFAULT_INITIAL_USAGE_TIME_LIMIT,
+    private val transportUserPresentTimeLimit: Duration = transportInitialUsageTimeLimit,
+    //spec| A max usage time period value, which SHOULD default to a maximum of 10 minutes (600 seconds).
+    private val maxUsageTimePeriod: Duration = DEFAULT_MAX_USAGE_TIME_PERIOD
+) {
+
+    //spec| A permissions RP ID, initially null.
+    var permissionsRpId: String? = null
+        internal set
+
+    //spec| A permissions set whose possible values are those of pinUvAuthToken permissions. It is initially empty.
+    var permissions: PinUvAuthTokenPermissions = PinUvAuthTokenPermissions()
+        internal set
+
+    //spec| A usage timer, initially not running.
+    private var usageTimer: Instant? = null
+
+    //spec| An in use flag, initially set to false, meaning that the pinUvAuthToken is not in use.
+    //spec| When the in use flag is set to true, the pinUvAuthToken is said to be in use.
+    private var inUse: Boolean = false
+
+    //spec| A initial usage time limit, initially not set.
+    //spec| beginUsingPinUvAuthToken() sets this value according to the transport the platform is using to communicate with it.
+    //spec| The default maximum per-transport initial usage time limit values are:
+    //spec|   usb: 30 seconds
+    private var initialUsageTimeLimit: Duration = transportInitialUsageTimeLimit
+
+    //spec| A user present time limit defining the length of time the user is considered "present",
+    //spec| as represented by the userPresent flag, after user presence is collected.
+    //spec| The user present time limit defaults to the same default maximum per-transport values
+    //spec| as the initial usage time limit.
+    private var userPresentTimeLimit: Duration = transportUserPresentTimeLimit
+
+    //spec| A userVerified flag, initially false.
+    private var userVerifiedFlag: Boolean = false
+
+    //spec| A userPresent flag, initially false.
+    private var userPresentFlag: Boolean = false
+
+    private var platformHasUsedToken: Boolean = false
+
+    companion object {
+        val DEFAULT_INITIAL_USAGE_TIME_LIMIT: Duration = Duration.ofSeconds(30)
+        val DEFAULT_MAX_USAGE_TIME_PERIOD: Duration = Duration.ofMinutes(10)
+    }
+
+    //spec| beginUsingPinUvAuthToken(userIsPresent)
+    //spec|   Set the userPresent flag to the value of userIsPresent.
+    //spec|   Set the userVerified flag to true.
+    //spec|   Set the initial usage time limit to a transport-specific value, as described in § 6.5.2.1 pinUvAuthToken State.
+    //spec|   Start the pinUvAuthToken usage timer, set the in use flag to true,
+    //spec|   and assign pinUvAuthTokenUsageTimerObserver() to observe the usage timer. The pinUvAuthToken is now in use.
+    internal fun beginUsingPinUvAuthToken(userIsPresent: Boolean) {
+        userPresentFlag = userIsPresent
+        userVerifiedFlag = true
+        initialUsageTimeLimit = transportInitialUsageTimeLimit
+        usageTimer = Instant.now()
+        inUse = true
+        platformHasUsedToken = false
+    }
+
+    //spec| pinUvAuthTokenUsageTimerObserver()
+    //spec|   This function observes the pinUvAuthToken usage timer and takes appropriate action upon the specified conditions:
+    //spec|     If the usage timer is not running, return.
+    //spec|     While the overall usage timer has not reached the max usage time period, perform the following substeps:
+    //spec|       If the current user present time limit is reached, call clearUserPresentFlag().
+    //spec|       If the initial usage time limit is reached without the platform using the pinUvAuthToken
+    //spec|       in an authenticator operation then call stopUsingPinUvAuthToken(), and terminate these steps.
+    //spec|       If the authenticator does not utilize a rolling timer then continue.
+    //spec|       If the authenticator utilizes a rolling timer then:
+    //spec|         If the platform uses the pinUvAuthToken in an authenticator operation before the rolling timer expires then:
+    //spec|           Set the rolling timer to the applicable initial usage time limit and continue.
+    //spec|         Otherwise (implying the rolling timer expires) call stopUsingPinUvAuthToken(), and terminate these steps.
+    //spec|     Call stopUsingPinUvAuthToken(), and terminate these steps.
+    //
+    // The spec models this as a background observer continuously watching the usage timer.
+    // This implementation uses lazy evaluation instead: this function is called on-demand
+    // when token state is queried (getUserPresentFlagValue, getUserVerifiedFlagValue) or
+    // when the token is verified (verifyPinUvAuthParam in PinUvAuthService), rather than
+    // running as a background timer. The observable results are equivalent because token
+    // state only matters when it is read by an authenticator operation.
+    private fun pinUvAuthTokenUsageTimerObserver() {
+        val start = usageTimer ?: return
+        val elapsed = Duration.between(start, Instant.now())
+
+        if (elapsed >= maxUsageTimePeriod) {
+            stopUsingPinUvAuthToken()
+            return
+        }
+
+        if (elapsed >= userPresentTimeLimit) {
+            clearUserPresentFlag()
+        }
+
+        if (elapsed >= initialUsageTimeLimit && !platformHasUsedToken) {
+            stopUsingPinUvAuthToken()
+            return
+        }
+    }
+
+    internal fun recordPlatformUsage() {
+        platformHasUsedToken = true
+    }
+
+    //spec| stopUsingPinUvAuthToken()
+    //spec|   Set all of the pinUvAuthToken's state variables to their initial values as given in § 6.5.2.1 pinUvAuthToken State.
+    internal fun stopUsingPinUvAuthToken() {
+        permissionsRpId = null               // initially null
+        permissions = PinUvAuthTokenPermissions()             // initially empty
+        usageTimer = null                    // initially not running
+        inUse = false                        // initially false
+        initialUsageTimeLimit = transportInitialUsageTimeLimit  // initially not set
+        userPresentTimeLimit = transportUserPresentTimeLimit    // initially same as initial usage time limit
+        userVerifiedFlag = false                 // initially false
+        userPresentFlag = false                  // initially false
+        platformHasUsedToken = false
+    }
+
+    // Checks whether the token is currently in use, after running the timer observer.
+    internal fun isInUse(): Boolean {
+        pinUvAuthTokenUsageTimerObserver()
+        return inUse
+    }
+
+    //spec| getUserPresentFlagValue() → userPresentFlagValue
+    //spec|   If the pinUvAuthToken is in use then set the userPresentFlagValue to the current value of the pinUvAuthToken's userPresent flag.
+    //spec|   Otherwise (implying a pinUvAuthToken exists and is not in use, or does not exist), set userPresentFlagValue to false.
+    //spec|   Return userPresentFlagValue.
+    fun getUserPresentFlagValue(): Boolean {
+        pinUvAuthTokenUsageTimerObserver()
+        if (inUse) {
+            return userPresentFlag
+        }
+        return false
+    }
+
+    //spec| getUserVerifiedFlagValue() → userVerifiedFlagValue
+    //spec|   If the pinUvAuthToken is in use then set the userVerifiedFlagValue to the current value of the pinUvAuthToken's userVerified flag.
+    //spec|   Otherwise (implying a pinUvAuthToken exists and is not in use, or does not exist), set userVerifiedFlagValue to false.
+    //spec|   Return userVerifiedFlagValue.
+    fun getUserVerifiedFlagValue(): Boolean {
+        pinUvAuthTokenUsageTimerObserver()
+        if (inUse) {
+            return userVerifiedFlag
+        }
+        return false
+    }
+
+    //spec| clearUserPresentFlag()
+    //spec|   If the pinUvAuthToken is in use then set the pinUvAuthToken's userPresent flag to false, otherwise do nothing.
+    fun clearUserPresentFlag() {
+        if (inUse) {
+            userPresentFlag = false
+        }
+    }
+
+    //spec| clearUserVerifiedFlag()
+    //spec|   If the pinUvAuthToken is in use then set the pinUvAuthToken's userVerified flag to false, otherwise do nothing.
+    fun clearUserVerifiedFlag() {
+        if (inUse) {
+            userVerifiedFlag = false
+        }
+    }
+
+    //spec| clearPinUvAuthTokenPermissionsExceptLbw()
+    //spec|   If the pinUvAuthToken is in use then clear all of the pinUvAuthToken's permissions, except for lbw, otherwise do nothing.
+    fun clearPinUvAuthTokenPermissionsExceptLbw() {
+        if (inUse) {
+            permissions = PinUvAuthTokenPermissions(*permissions.filter { it == PinUvAuthTokenPermission.LBW }.toTypedArray())
+        }
+    }
+
+    internal fun hasPermission(permission: PinUvAuthTokenPermission): Boolean {
+        return permission in permissions
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthTokenState.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthTokenState.kt
@@ -93,7 +93,7 @@ class PinUvAuthTokenState(
     // The spec models this as a background observer continuously watching the usage timer.
     // This implementation uses lazy evaluation instead: this function is called on-demand
     // when token state is queried (getUserPresentFlagValue, getUserVerifiedFlagValue) or
-    // when the token is verified (verifyPinUvAuthParam in PinUvAuthService), rather than
+    // when the token is verified (in MakeCredentialExecution/GetAssertionExecution), rather than
     // running as a background timer. The observable results are equivalent because token
     // state only matters when it is read by an authenticator operation.
     private fun pinUvAuthTokenUsageTimerObserver() {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
@@ -33,6 +33,8 @@ internal class ClientPINExecution(
         val pinAuth = authenticatorClientPINRequest.pinAuth
         val newPinEnc = authenticatorClientPINRequest.newPinEnc
         val pinHashEnc = authenticatorClientPINRequest.pinHashEnc
+        val permissions = authenticatorClientPINRequest.permissions
+        val rpId = authenticatorClientPINRequest.rpId
         return when (authenticatorClientPINRequest.subCommand) {
             PinSubCommand.GET_PIN_RETRIES -> {
                 logger.debug("Processing clientPIN getRetries sub-command")
@@ -53,6 +55,18 @@ internal class ClientPINExecution(
             PinSubCommand.GET_PIN_TOKEN -> {
                 logger.debug("Processing clientPIN getPINToken sub-command (protocol={})", pinProtocol)
                 pinUvAuthService.getPinToken(pinProtocol, platformKeyAgreementKey, pinHashEnc)
+            }
+            PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_PIN_WITH_PERMISSIONS -> {
+                logger.debug("Processing clientPIN getPinUvAuthTokenUsingPinWithPermissions sub-command (protocol={})", pinProtocol)
+                pinUvAuthService.getPinUvAuthTokenUsingPinWithPermissions(pinProtocol, platformKeyAgreementKey, pinHashEnc, permissions, rpId)
+            }
+            PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_UV_WITH_PERMISSIONS -> {
+                logger.debug("Processing clientPIN getPinUvAuthTokenUsingUvWithPermissions sub-command (protocol={})", pinProtocol)
+                pinUvAuthService.getPinUvAuthTokenUsingUvWithPermissions(pinProtocol, platformKeyAgreementKey, permissions, rpId)
+            }
+            PinSubCommand.GET_UV_RETRIES -> {
+                logger.debug("Processing clientPIN getUVRetries sub-command")
+                pinUvAuthService.getUVRetries()
             }
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
@@ -27,7 +27,7 @@ internal class ClientPINExecution(
     }
 
     override suspend fun doExecute(): AuthenticatorClientPINResponse {
-        val pinUvAuthService = ctapAuthenticatorSession.pinUvAuthService
+        val pinUvAuthManager = ctapAuthenticatorSession.pinUvAuthManager
         val pinProtocol = authenticatorClientPINRequest.pinProtocol
         val platformKeyAgreementKey = authenticatorClientPINRequest.keyAgreement
         val pinAuth = authenticatorClientPINRequest.pinAuth
@@ -38,35 +38,35 @@ internal class ClientPINExecution(
         return when (authenticatorClientPINRequest.subCommand) {
             PinSubCommand.GET_PIN_RETRIES -> {
                 logger.debug("Processing clientPIN getRetries sub-command")
-                pinUvAuthService.getPinRetries()
+                pinUvAuthManager.getPinRetries()
             }
             PinSubCommand.GET_KEY_AGREEMENT -> {
                 logger.debug("Processing clientPIN getKeyAgreement sub-command (protocol={})", pinProtocol)
-                pinUvAuthService.getKeyAgreement(pinProtocol)
+                pinUvAuthManager.getKeyAgreement(pinProtocol)
             }
             PinSubCommand.SET_PIN -> {
                 logger.debug("Processing clientPIN setPIN sub-command (protocol={})", pinProtocol)
-                pinUvAuthService.setPIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc)
+                pinUvAuthManager.setPIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc)
             }
             PinSubCommand.CHANGE_PIN -> {
                 logger.debug("Processing clientPIN changePIN sub-command (protocol={})", pinProtocol)
-                pinUvAuthService.changePIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc, pinHashEnc)
+                pinUvAuthManager.changePIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc, pinHashEnc)
             }
             PinSubCommand.GET_PIN_TOKEN -> {
                 logger.debug("Processing clientPIN getPINToken sub-command (protocol={})", pinProtocol)
-                pinUvAuthService.getPinToken(pinProtocol, platformKeyAgreementKey, pinHashEnc)
+                pinUvAuthManager.getPinToken(pinProtocol, platformKeyAgreementKey, pinHashEnc)
             }
             PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_PIN_WITH_PERMISSIONS -> {
                 logger.debug("Processing clientPIN getPinUvAuthTokenUsingPinWithPermissions sub-command (protocol={})", pinProtocol)
-                pinUvAuthService.getPinUvAuthTokenUsingPinWithPermissions(pinProtocol, platformKeyAgreementKey, pinHashEnc, permissions, rpId)
+                pinUvAuthManager.getPinUvAuthTokenUsingPinWithPermissions(pinProtocol, platformKeyAgreementKey, pinHashEnc, permissions, rpId)
             }
             PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_UV_WITH_PERMISSIONS -> {
                 logger.debug("Processing clientPIN getPinUvAuthTokenUsingUvWithPermissions sub-command (protocol={})", pinProtocol)
-                pinUvAuthService.getPinUvAuthTokenUsingUvWithPermissions(pinProtocol, platformKeyAgreementKey, permissions, rpId)
+                pinUvAuthManager.getPinUvAuthTokenUsingUvWithPermissions(pinProtocol, platformKeyAgreementKey, permissions, rpId)
             }
             PinSubCommand.GET_UV_RETRIES -> {
                 logger.debug("Processing clientPIN getUVRetries sub-command")
-                pinUvAuthService.getUVRetries()
+                pinUvAuthManager.getUVRetries()
             }
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -15,6 +15,7 @@ import com.webauthn4j.ctap.authenticator.extension.AuthenticationExtensionContex
 import com.webauthn4j.ctap.authenticator.extension.AuthenticationExtensionProcessor
 import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.authenticator.store.StoreFullException
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
 import com.webauthn4j.ctap.core.data.*
 import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.core.util.internal.BooleanUtil
@@ -171,17 +172,12 @@ internal class GetAssertionExecution :
     private fun execStep6ProcessUserVerification() {
         // If pinUvAuthParam parameter is present and pinProtocol is supported,
         // verify it and set the "uv" bit to true in the response.
-        if (pinAuth != null && pinProtocol == PinProtocolVersion.VERSION_1) {
-            val clientDataHash = clientDataHash
-            val pinAuth = pinAuth
-            ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(pinAuth, clientDataHash)
+        if (pinAuth != null && pinProtocol != null) {
+            ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(
+                pinAuth, clientDataHash, PinUvAuthTokenPermission.GA, rpId
+            )
             userVerificationResult = true
             return
-        }
-        // If pinUvAuthParam parameter is present and the pinProtocol is not supported,
-        // return CTAP2_ERR_PIN_AUTH_INVALID.
-        if (pinAuth != null && pinProtocol != PinProtocolVersion.VERSION_1) {
-            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
         }
         // If pinUvAuthParam parameter is not present and clientPin has been set on the authenticator,
         // set the "uv" bit to false in the response.

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -17,6 +17,7 @@ import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.authenticator.store.StoreFullException
 import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
 import com.webauthn4j.ctap.core.data.*
+import java.util.Arrays
 import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.core.util.internal.BooleanUtil
 import com.webauthn4j.ctap.core.util.internal.CipherUtil
@@ -173,15 +174,34 @@ internal class GetAssertionExecution :
         // If pinUvAuthParam parameter is present and pinProtocol is supported,
         // verify it and set the "uv" bit to true in the response.
         if (pinAuth != null && pinProtocol != null) {
-            ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(
-                pinAuth, clientDataHash, PinUvAuthTokenPermission.GA, rpId
-            )
+            //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+            //spec| If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
+            val matchedProtocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
+                val calculatedPinAuth = protocol.authenticate(protocol.pinUvAuthToken, clientDataHash)
+                Arrays.equals(calculatedPinAuth, pinAuth)
+            } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+
+            //spec| Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
+            if (matchedProtocol.tokenState.isInUse() && !matchedProtocol.tokenState.hasPermission(PinUvAuthTokenPermission.GA)) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+            }
+            //spec| If the pinUvAuthToken has a permissions RP ID associated:
+            //spec| If the permissions RP ID does not match the rpId in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
+            val tokenRpId = matchedProtocol.tokenState.permissionsRpId
+            if (tokenRpId != null && tokenRpId != rpId) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+            }
+
+            if (matchedProtocol.tokenState.isInUse()) {
+                matchedProtocol.tokenState.recordPlatformUsage()
+            }
+
             userVerificationResult = true
             return
         }
         // If pinUvAuthParam parameter is not present and clientPin has been set on the authenticator,
         // set the "uv" bit to false in the response.
-        if (pinAuth == null && ctapAuthenticatorSession.pinUvAuthService.isClientPINReady) {
+        if (pinAuth == null && ctapAuthenticatorSession.isClientPINReady) {
             userVerificationResult = false
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -59,7 +59,7 @@ internal class GetInfoExecution(
         //spec| Client PIN is one of the ways to do user verification.
         val clientPin: ClientPINOption? = when (ctapAuthenticatorSession.clientPIN) {
             ClientPINSetting.ENABLED -> when {
-                ctapAuthenticatorSession.pinUvAuthService.isClientPINReady -> ClientPINOption.SET
+                ctapAuthenticatorSession.isClientPINReady -> ClientPINOption.SET
                 else -> ClientPINOption.NOT_SET
             }
             ClientPINSetting.DISABLED -> ClientPINOption.NOT_SUPPORTED

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -21,6 +21,7 @@ import com.webauthn4j.ctap.authenticator.internal.KeyPairUtil.createCredentialKe
 import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.authenticator.store.StoreFullException
 import com.webauthn4j.ctap.core.data.*
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
 import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.core.util.internal.CipherUtil
 import com.webauthn4j.ctap.core.validator.AuthenticatorMakeCredentialRequestValidator
@@ -266,7 +267,7 @@ internal class MakeCredentialExecution :
     private suspend fun execStep11ProcessUserVerification() {
         // Process pinAuth (formerly CTAP 2.0 Step 5)
         pinAuth.let {
-            if (it != null && pinProtocol == PinProtocolVersion.VERSION_1) {
+            if (it != null && pinProtocol != null) {
                 // Handle zero length pinAuth for authenticator selection
                 if (it.isEmpty()) {
                     requestUserConsent()
@@ -276,7 +277,9 @@ internal class MakeCredentialExecution :
                         throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
                     }
                 } else {
-                    ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(it, clientDataHash)
+                    ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(
+                        it, clientDataHash, PinUvAuthTokenPermission.MC, rpId
+                    )
                     userPresenceResult = true
                     userVerificationResult = true
                 }
@@ -288,11 +291,6 @@ internal class MakeCredentialExecution :
 //        if (authenticatorMakeCredentialRequest.pinAuth == null && ctapAuthenticatorSession.pinUvAuthService.clientPIN != null) {
 //            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_REQUIRED)
 //        }
-
-        // Validate pinProtocol (formerly CTAP 2.0 Step 7)
-        if (authenticatorMakeCredentialRequest.pinAuth != null && authenticatorMakeCredentialRequest.pinProtocol != PinProtocolVersion.VERSION_1) {
-            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-        }
     }
 
     //spec| Step 12. If the excludeList parameter is present and contains a credential ID created by this authenticator,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -23,6 +23,7 @@ import com.webauthn4j.ctap.authenticator.store.StoreFullException
 import com.webauthn4j.ctap.core.data.*
 import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
 import com.webauthn4j.data.PinProtocolVersion
+import java.util.Arrays
 import com.webauthn4j.ctap.core.util.internal.CipherUtil
 import com.webauthn4j.ctap.core.validator.AuthenticatorMakeCredentialRequestValidator
 import com.webauthn4j.data.PublicKeyCredentialDescriptor
@@ -271,15 +272,37 @@ internal class MakeCredentialExecution :
                 // Handle zero length pinAuth for authenticator selection
                 if (it.isEmpty()) {
                     requestUserConsent()
-                    if (ctapAuthenticatorSession.pinUvAuthService.isClientPINReady) {
+                    if (ctapAuthenticatorSession.isClientPINReady) {
                         throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
                     } else {
                         throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
                     }
                 } else {
-                    ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(
-                        it, clientDataHash, PinUvAuthTokenPermission.MC, rpId
-                    )
+                    //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+                    //spec| If the verification returns error, then end the operation by returning
+                    //spec| CTAP2_ERR_PIN_AUTH_INVALID error.
+                    val matchedProtocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
+                        val calculatedPinAuth = protocol.authenticate(protocol.pinUvAuthToken, clientDataHash)
+                        Arrays.equals(calculatedPinAuth, it)
+                    } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+
+                    //spec| Verify that the pinUvAuthToken has the mc permission, if not, then end the operation
+                    //spec| by returning CTAP2_ERR_PIN_AUTH_INVALID.
+                    if (matchedProtocol.tokenState.isInUse() && !matchedProtocol.tokenState.hasPermission(PinUvAuthTokenPermission.MC)) {
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                    }
+                    //spec| If the pinUvAuthToken has a permissions RP ID associated:
+                    //spec| If the permissions RP ID does not match the rp.id in this request,
+                    //spec| then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
+                    val tokenRpId = matchedProtocol.tokenState.permissionsRpId
+                    if (tokenRpId != null && rpId != null && tokenRpId != rpId) {
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                    }
+
+                    if (matchedProtocol.tokenState.isInUse()) {
+                        matchedProtocol.tokenState.recordPlatformUsage()
+                    }
+
                     userPresenceResult = true
                     userVerificationResult = true
                 }
@@ -288,7 +311,7 @@ internal class MakeCredentialExecution :
 
         // Validate clientPin requirement (formerly CTAP 2.0 Step 6)
         //TODO: to be fixed to align CTAP2.1 spec.
-//        if (authenticatorMakeCredentialRequest.pinAuth == null && ctapAuthenticatorSession.pinUvAuthService.clientPIN != null) {
+//        if (authenticatorMakeCredentialRequest.pinAuth == null && ctapAuthenticatorSession.isClientPINReady) {
 //            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_REQUIRED)
 //        }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/HMACSecretExtensionProcessor.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/HMACSecretExtensionProcessor.kt
@@ -81,7 +81,8 @@ class HMACSecretExtensionProcessor : RegistrationExtensionProcessor,
         //spec| then return CTAP2_ERR_PIN_AUTH_INVALID.
         val pinProtocol = hmacGetSecretAuthenticatorInput.pinUvAuthProtocol
             ?: PinProtocolVersion.VERSION_1
-        val protocol = context.ctapAuthenticatorSession.pinUvAuthService.getProtocol(pinProtocol)
+        val protocol = context.ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { it.version == pinProtocol }
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
 
         //spec| The authenticator calls decapsulate on the provided platform key-agreement key to obtain a shared secret.
         val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/AuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/AuthenticatorPropertyStore.kt
@@ -72,6 +72,9 @@ interface AuthenticatorPropertyStore {
     fun savePINRetries(pinRetries: UInt)
     fun loadPINRetries(): UInt
 
+    fun saveUVRetries(uvRetries: UInt)
+    fun loadUVRetries(): UInt
+
     fun loadDeviceWideCounter(): UInt
     fun saveDeviceWideCounter(deviceWideCounter: UInt)
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
@@ -22,8 +22,14 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
     private lateinit var credentialSourceEncryptionKey: SecretKey
     private lateinit var credentialSourceEncryptionIV: ByteArray
     private var clientPIN: ByteArray? = null
-    private var pinRetries: UInt = 0u
+    private var pinRetries: UInt = DEFAULT_MAX_PIN_RETRIES
+    private var uvRetries: UInt = DEFAULT_MAX_UV_RETRIES
     private var deviceWideCounter = 0u
+
+    companion object {
+        const val DEFAULT_MAX_PIN_RETRIES: UInt = 8u
+        const val DEFAULT_MAX_UV_RETRIES: UInt = 3u
+    }
 
     init {
         initializeKeys()
@@ -34,7 +40,8 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
         credentialSourceEncryptionKey = generateAESKey()
         credentialSourceEncryptionIV = generateIV()
         clientPIN = null
-        pinRetries = PinUvAuthService.MAX_PIN_RETRIES
+        pinRetries = DEFAULT_MAX_PIN_RETRIES
+        uvRetries = DEFAULT_MAX_UV_RETRIES
     }
 
     override fun createUserCredentialKey(
@@ -107,6 +114,14 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
 
     override fun savePINRetries(pinRetries: UInt) {
         this.pinRetries = pinRetries
+    }
+
+    override fun saveUVRetries(uvRetries: UInt) {
+        this.uvRetries = uvRetries
+    }
+
+    override fun loadUVRetries(): UInt {
+        return uvRetries
     }
 
     override fun clear() {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
@@ -1,6 +1,6 @@
 package com.webauthn4j.ctap.authenticator.store
 
-import com.webauthn4j.ctap.authenticator.PinUvAuthService
+import com.webauthn4j.ctap.authenticator.PinUvAuthManager
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentCredentialKey
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.internal.KeyPairUtil.createCredentialKeyPair

--- a/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
+++ b/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
@@ -1,6 +1,6 @@
 package com.webauthn4j.ctap.client
 
-import com.webauthn4j.ctap.authenticator.PinUvAuthService
+import com.webauthn4j.ctap.authenticator.PinUvAuthManager
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
 import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
@@ -74,14 +74,14 @@ internal class CtapServiceTest {
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
     fun getRetries_test() = runTest {
-        assertThat(target.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES)
+        assertThat(target.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES)
         try {
             target.changePIN("wrongPIN", "newPIN")
         } catch (e: RuntimeException) {
         }
-        assertThat(target.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES - 1u)
+        assertThat(target.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES - 1u)
         target.reset()
-        assertThat(target.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES)
+        assertThat(target.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES)
     }
 
     @ExperimentalCoroutinesApi

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorClientPINRequestSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorClientPINRequestSerializer.kt
@@ -10,6 +10,8 @@ class AuthenticatorClientPINRequestSerializer :
             FieldSerializationRule(3, AuthenticatorClientPINRequest::keyAgreement),
             FieldSerializationRule(4, AuthenticatorClientPINRequest::pinAuth),
             FieldSerializationRule(5, AuthenticatorClientPINRequest::newPinEnc),
-            FieldSerializationRule(6, AuthenticatorClientPINRequest::pinHashEnc)
+            FieldSerializationRule(6, AuthenticatorClientPINRequest::pinHashEnc),
+            FieldSerializationRule(9, AuthenticatorClientPINRequest::permissions),
+            FieldSerializationRule(10, AuthenticatorClientPINRequest::rpId)
         )
     )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorClientPINRequest.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorClientPINRequest.kt
@@ -14,7 +14,9 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
     @JsonProperty("3") keyAgreement: COSEKey?,
     @JsonProperty("4") pinAuth: ByteArray?,
     @JsonProperty("5") newPinEnc: ByteArray?,
-    @JsonProperty("6") pinHashEnc: ByteArray?
+    @JsonProperty("6") pinHashEnc: ByteArray?,
+    @JsonProperty("9") permissions: PinUvAuthTokenPermissions?,
+    @JsonProperty("10") rpId: String?
 ) : CtapRequest {
 
     override val command: CtapCommand = CtapCommand.CLIENT_PIN
@@ -28,6 +30,8 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
         get() = ArrayUtil.clone(field)
     val pinHashEnc: ByteArray? = ArrayUtil.clone(pinHashEnc)
         get() = ArrayUtil.clone(field)
+    val permissions: PinUvAuthTokenPermissions? = permissions
+    val rpId: String? = rpId
 
 
     companion object {
@@ -35,6 +39,8 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
             return AuthenticatorClientPINRequest(
                 PinProtocolVersion.VERSION_1,
                 PinSubCommand.GET_PIN_RETRIES,
+                null,
+                null,
                 null,
                 null,
                 null,
@@ -46,6 +52,8 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
             return AuthenticatorClientPINRequest(
                 PinProtocolVersion.VERSION_1,
                 PinSubCommand.GET_KEY_AGREEMENT,
+                null,
+                null,
                 null,
                 null,
                 null,
@@ -64,6 +72,8 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
                 keyAgreement,
                 pinAuth,
                 newPinEnc,
+                null,
+                null,
                 null
             )
         }
@@ -80,7 +90,9 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
                 keyAgreement,
                 pinAuth,
                 newPinEnc,
-                pinHashEnc
+                pinHashEnc,
+                null,
+                null
             )
         }
 
@@ -94,7 +106,61 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
                 keyAgreement,
                 null,
                 null,
-                pinHashEnc
+                pinHashEnc,
+                null,
+                null
+            )
+        }
+
+        fun createGetPinUvAuthTokenUsingPinWithPermissions(
+            pinProtocol: PinProtocolVersion,
+            keyAgreement: COSEKey?,
+            pinHashEnc: ByteArray?,
+            permissions: PinUvAuthTokenPermissions,
+            rpId: String?
+        ): AuthenticatorClientPINRequest {
+            return AuthenticatorClientPINRequest(
+                pinProtocol,
+                PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_PIN_WITH_PERMISSIONS,
+                keyAgreement,
+                null,
+                null,
+                pinHashEnc,
+                permissions,
+                rpId
+            )
+        }
+
+        fun createGetPinUvAuthTokenUsingUvWithPermissions(
+            pinProtocol: PinProtocolVersion,
+            keyAgreement: COSEKey?,
+            permissions: PinUvAuthTokenPermissions,
+            rpId: String?
+        ): AuthenticatorClientPINRequest {
+            return AuthenticatorClientPINRequest(
+                pinProtocol,
+                PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_UV_WITH_PERMISSIONS,
+                keyAgreement,
+                null,
+                null,
+                null,
+                permissions,
+                rpId
+            )
+        }
+
+        fun createGetUVRetries(
+            pinProtocol: PinProtocolVersion
+        ): AuthenticatorClientPINRequest {
+            return AuthenticatorClientPINRequest(
+                pinProtocol,
+                PinSubCommand.GET_UV_RETRIES,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
             )
         }
     }
@@ -129,7 +195,7 @@ class AuthenticatorClientPINRequest @JsonCreator constructor(
             HexUtil.encodeToString(
                 pinHashEnc
             )
-        })"
+        }, permissions=$permissions, rpId=$rpId)"
     }
 
 }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorClientPINResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorClientPINResponseData.kt
@@ -10,13 +10,19 @@ import com.webauthn4j.util.ArrayUtil
 class AuthenticatorClientPINResponseData @JsonCreator constructor(
     @JsonProperty("1") keyAgreement: COSEKey?,
     @JsonProperty("2") pinToken: ByteArray?,
-    @JsonProperty("3") retries: UInt?
+    @JsonProperty("3") retries: UInt?,
+    @JsonProperty("4") powerCycleState: Boolean?,
+    @JsonProperty("5") uvRetries: UInt?
 ) : CtapResponseData {
 
     val keyAgreement: COSEKey? = keyAgreement
     val pinToken: ByteArray? = ArrayUtil.clone(pinToken)
         get() = ArrayUtil.clone(field)
     val retries: UInt? = retries
+    val powerCycleState: Boolean? = powerCycleState
+    val uvRetries: UInt? = uvRetries
+
+    constructor(keyAgreement: COSEKey?, pinToken: ByteArray?, retries: UInt?) : this(keyAgreement, pinToken, retries, null, null)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -26,6 +32,8 @@ class AuthenticatorClientPINResponseData @JsonCreator constructor(
 
         if (keyAgreement != other.keyAgreement) return false
         if (retries != other.retries) return false
+        if (powerCycleState != other.powerCycleState) return false
+        if (uvRetries != other.uvRetries) return false
 
         return true
     }
@@ -33,13 +41,15 @@ class AuthenticatorClientPINResponseData @JsonCreator constructor(
     override fun hashCode(): Int {
         var result = keyAgreement?.hashCode() ?: 0
         result = 31 * result + (retries?.hashCode() ?: 0)
+        result = 31 * result + (powerCycleState?.hashCode() ?: 0)
+        result = 31 * result + (uvRetries?.hashCode() ?: 0)
         return result
     }
 
     override fun toString(): String {
         return "AuthenticatorClientPINResponseData(keyAgreement=$keyAgreement, pinToken=${
             HexUtil.encodeToString(pinToken)
-        }, retries=$retries)"
+        }, retries=$retries, powerCycleState=$powerCycleState, uvRetries=$uvRetries)"
     }
 
 

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapStatusCode.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapStatusCode.kt
@@ -49,6 +49,9 @@ class CtapStatusCode(private val value: Byte) {
         val CTAP2_ERR_REQUEST_TOO_LARGE = CtapStatusCode(0x39)
         val CTAP2_ERR_ACTION_TIMEOUT = CtapStatusCode(0x3A)
         val CTAP2_ERR_UP_REQUIRED = CtapStatusCode(0x3B)
+        val CTAP2_ERR_UV_BLOCKED = CtapStatusCode(0x3C)
+        val CTAP2_ERR_UV_INVALID = CtapStatusCode(0x3F)
+        val CTAP2_ERR_UNAUTHORIZED_PERMISSION = CtapStatusCode(0x40)
         val CTAP1_ERR_OTHER = CtapStatusCode(0x7F)
 
         private val map: Map<CtapStatusCode, String>
@@ -96,6 +99,9 @@ class CtapStatusCode(private val value: Byte) {
             tmp[CTAP2_ERR_REQUEST_TOO_LARGE] = "CTAP2_ERR_REQUEST_TOO_LARGE"
             tmp[CTAP2_ERR_ACTION_TIMEOUT] = "CTAP2_ERR_ACTION_TIMEOUT"
             tmp[CTAP2_ERR_UP_REQUIRED] = "CTAP2_ERR_UP_REQUIRED"
+            tmp[CTAP2_ERR_UV_BLOCKED] = "CTAP2_ERR_UV_BLOCKED"
+            tmp[CTAP2_ERR_UV_INVALID] = "CTAP2_ERR_UV_INVALID"
+            tmp[CTAP2_ERR_UNAUTHORIZED_PERMISSION] = "CTAP2_ERR_UNAUTHORIZED_PERMISSION"
             tmp[CTAP1_ERR_OTHER] = "CTAP1_ERR_OTHER"
             map = HashMap(tmp)
         }
@@ -145,6 +151,9 @@ class CtapStatusCode(private val value: Byte) {
                 "CTAP2_ERR_REQUEST_TOO_LARGE" -> CTAP2_ERR_REQUEST_TOO_LARGE
                 "CTAP2_ERR_ACTION_TIMEOUT" -> CTAP2_ERR_ACTION_TIMEOUT
                 "CTAP2_ERR_UP_REQUIRED" -> CTAP2_ERR_UP_REQUIRED
+                "CTAP2_ERR_UV_BLOCKED" -> CTAP2_ERR_UV_BLOCKED
+                "CTAP2_ERR_UV_INVALID" -> CTAP2_ERR_UV_INVALID
+                "CTAP2_ERR_UNAUTHORIZED_PERMISSION" -> CTAP2_ERR_UNAUTHORIZED_PERMISSION
                 "CTAP1_ERR_OTHER" -> CTAP1_ERR_OTHER
 
                 else -> throw IllegalArgumentException("value '$value' is out of range")

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinSubCommand.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinSubCommand.kt
@@ -9,7 +9,10 @@ enum class PinSubCommand(@get:JsonValue val value: UInt) {
     GET_KEY_AGREEMENT(0x02u),
     SET_PIN(0x03u),
     CHANGE_PIN(0x04u),
-    GET_PIN_TOKEN(0x05u);
+    GET_PIN_TOKEN(0x05u),
+    GET_PIN_UV_AUTH_TOKEN_USING_UV_WITH_PERMISSIONS(0x06u),
+    GET_UV_RETRIES(0x07u),
+    GET_PIN_UV_AUTH_TOKEN_USING_PIN_WITH_PERMISSIONS(0x09u);
 
     companion object {
         @JvmStatic
@@ -21,6 +24,9 @@ enum class PinSubCommand(@get:JsonValue val value: UInt) {
                 0x03u -> SET_PIN
                 0x04u -> CHANGE_PIN
                 0x05u -> GET_PIN_TOKEN
+                0x06u -> GET_PIN_UV_AUTH_TOKEN_USING_UV_WITH_PERMISSIONS
+                0x07u -> GET_UV_RETRIES
+                0x09u -> GET_PIN_UV_AUTH_TOKEN_USING_PIN_WITH_PERMISSIONS
                 else -> throw IllegalArgumentException("value '$value' is out of range")
             }
         }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermission.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermission.kt
@@ -1,0 +1,25 @@
+package com.webauthn4j.ctap.core.data
+
+// @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#getPinUvAuthTokenUsingPinWithPermissions">6.5.5.7. Operations to Obtain a pinUvAuthToken</a>
+//spec| mc (0x01): This allows the pinUvAuthToken to be used for authenticatorMakeCredential operations with the provided rpId parameter.
+//spec| ga (0x02): This allows the pinUvAuthToken to be used for authenticatorGetAssertion operations with the provided rpId parameter.
+//spec| cm (0x04): This allows the pinUvAuthToken to be used with the authenticatorCredentialManagement command.
+//spec| be (0x08): This allows the pinUvAuthToken to be used with the authenticatorBioEnrollment command.
+//spec| lbw (0x10): This allows the pinUvAuthToken to be used with the authenticatorLargeBlobs command.
+//spec| acfg (0x20): This allows the pinUvAuthToken to be used with the authenticatorConfig command.
+enum class PinUvAuthTokenPermission(val value: Int) {
+    MC(0x01),
+    GA(0x02),
+    CM(0x04),
+    BE(0x08),
+    LBW(0x10),
+    ACFG(0x20);
+
+    companion object {
+        fun fromBitfield(bitfield: Int): Set<PinUvAuthTokenPermission> =
+            entries.filter { bitfield and it.value != 0 }.toSet()
+
+        fun toBitfield(permissions: Set<PinUvAuthTokenPermission>): Int =
+            permissions.fold(0) { acc, p -> acc or p.value }
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermissions.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermissions.kt
@@ -1,0 +1,24 @@
+package com.webauthn4j.ctap.core.data
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+class PinUvAuthTokenPermissions : AbstractSet<PinUvAuthTokenPermission> {
+
+    private val permissions: Set<PinUvAuthTokenPermission>
+
+    @JsonCreator
+    constructor(bitfield: Int) {
+        permissions = PinUvAuthTokenPermission.fromBitfield(bitfield)
+    }
+
+    constructor(vararg perms: PinUvAuthTokenPermission) {
+        permissions = perms.toSet()
+    }
+
+    @JsonValue
+    fun toBitfield(): Int = PinUvAuthTokenPermission.toBitfield(permissions)
+
+    override val size: Int get() = permissions.size
+    override fun iterator(): Iterator<PinUvAuthTokenPermission> = permissions.iterator()
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorClientPINRequestValidator.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorClientPINRequestValidator.kt
@@ -47,6 +47,25 @@ class AuthenticatorClientPINRequestValidator {
                 requireNotNull(value.keyAgreement)
                 requireNotNull(value.pinHashEnc)
             }
+            //spec| getPinUvAuthTokenUsingUvWithPermissions (0x06)
+            //spec| Platform sends:
+            //spec|   pinUvAuthProtocol, keyAgreement, permissions
+            PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_UV_WITH_PERMISSIONS -> {
+                requireNotNull(value.keyAgreement)
+                requireNotNull(value.permissions)
+            }
+            //spec| getUVRetries (0x07)
+            PinSubCommand.GET_UV_RETRIES -> {
+                // nop - no required parameters beyond pinProtocol and subCommand
+            }
+            //spec| getPinUvAuthTokenUsingPinWithPermissions (0x09)
+            //spec| Platform sends:
+            //spec|   pinUvAuthProtocol, keyAgreement, pinHashEnc, permissions
+            PinSubCommand.GET_PIN_UV_AUTH_TOKEN_USING_PIN_WITH_PERMISSIONS -> {
+                requireNotNull(value.keyAgreement)
+                requireNotNull(value.pinHashEnc)
+                requireNotNull(value.permissions)
+            }
         }
     }
 }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
@@ -1,6 +1,6 @@
 package integration.setting.authenticator
 
-import com.webauthn4j.ctap.authenticator.PinUvAuthService
+import com.webauthn4j.ctap.authenticator.PinUvAuthManager
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.transport.internal.InternalTransport
 import com.webauthn4j.ctap.client.CtapClient
@@ -90,12 +90,12 @@ class ClientPINTest {
 
     @Test
     fun getRetries_test() = runTest {
-        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES)
+        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES)
         try {
             clientPINTestCase.clientPlatform.ctapService.changePIN("invalid-PIN", "invalid-PIN")
         } catch (e: CtapErrorException) { /* nop */
         }
-        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES - 1u)
+        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES - 1u)
     }
 
     @Disabled


### PR DESCRIPTION
- Add PinUvAuthTokenState for token state management (permissions, RP ID, in-use flag, user present/verified flags, usage timer) per CTAP 2.3 §6.5.2.1
- Add getPinUvAuthTokenUsingPinWithPermissions (0x09) and getPinUvAuthTokenUsingUvWithPermissions (0x06) subcommands
- Add getUVRetries (0x07) subcommand with uvRetries counter in AuthenticatorPropertyStore
- Add verify() in-use check per §6.5.6/§6.5.7
- Enforce permission (mc/ga) and RP ID checks in verifyPinUvAuthParam for MakeCredential and GetAssertion
- Add CTAP2_ERR_UV_BLOCKED, CTAP2_ERR_UV_INVALID, CTAP2_ERR_UNAUTHORIZED_PERMISSION status codes