### PR TITLE
Rename ClientPINService to PinUvAuthService

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -55,7 +55,7 @@ class CtapAuthenticatorSession internal constructor(
     val pinProtocols: List<PinProtocolVersion> = ctapAuthenticator.pinProtocols
         .sortedByDescending { it.value }
 
-    val clientPINService: ClientPINService = ClientPINService(
+    val pinUvAuthService: PinUvAuthService = PinUvAuthService(
         authenticatorPropertyStore,
         pinProtocols.map { version ->
             when (version) {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthService.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthService.kt
@@ -20,7 +20,7 @@ import java.util.Arrays
  *
  * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorClientPIN">6.5. authenticatorClientPIN</a>
  */
-class ClientPINService(
+class PinUvAuthService(
     private val authenticatorPropertyStore: AuthenticatorPropertyStore,
     private val protocols: List<PinUvAuthProtocol> = listOf(PinUvAuthProtocolV1())
 ) {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/ClientPINExecution.kt
@@ -27,7 +27,7 @@ internal class ClientPINExecution(
     }
 
     override suspend fun doExecute(): AuthenticatorClientPINResponse {
-        val clientPINService = ctapAuthenticatorSession.clientPINService
+        val pinUvAuthService = ctapAuthenticatorSession.pinUvAuthService
         val pinProtocol = authenticatorClientPINRequest.pinProtocol
         val platformKeyAgreementKey = authenticatorClientPINRequest.keyAgreement
         val pinAuth = authenticatorClientPINRequest.pinAuth
@@ -36,23 +36,23 @@ internal class ClientPINExecution(
         return when (authenticatorClientPINRequest.subCommand) {
             PinSubCommand.GET_PIN_RETRIES -> {
                 logger.debug("Processing clientPIN getRetries sub-command")
-                clientPINService.getPinRetries()
+                pinUvAuthService.getPinRetries()
             }
             PinSubCommand.GET_KEY_AGREEMENT -> {
                 logger.debug("Processing clientPIN getKeyAgreement sub-command (protocol={})", pinProtocol)
-                clientPINService.getKeyAgreement(pinProtocol)
+                pinUvAuthService.getKeyAgreement(pinProtocol)
             }
             PinSubCommand.SET_PIN -> {
                 logger.debug("Processing clientPIN setPIN sub-command (protocol={})", pinProtocol)
-                clientPINService.setPIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc)
+                pinUvAuthService.setPIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc)
             }
             PinSubCommand.CHANGE_PIN -> {
                 logger.debug("Processing clientPIN changePIN sub-command (protocol={})", pinProtocol)
-                clientPINService.changePIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc, pinHashEnc)
+                pinUvAuthService.changePIN(pinProtocol, platformKeyAgreementKey, pinAuth, newPinEnc, pinHashEnc)
             }
             PinSubCommand.GET_PIN_TOKEN -> {
                 logger.debug("Processing clientPIN getPINToken sub-command (protocol={})", pinProtocol)
-                clientPINService.getPinToken(pinProtocol, platformKeyAgreementKey, pinHashEnc)
+                pinUvAuthService.getPinToken(pinProtocol, platformKeyAgreementKey, pinHashEnc)
             }
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -174,7 +174,7 @@ internal class GetAssertionExecution :
         if (pinAuth != null && pinProtocol == PinProtocolVersion.VERSION_1) {
             val clientDataHash = clientDataHash
             val pinAuth = pinAuth
-            ctapAuthenticatorSession.clientPINService.verifyPinUvAuthParam(pinAuth, clientDataHash)
+            ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(pinAuth, clientDataHash)
             userVerificationResult = true
             return
         }
@@ -185,7 +185,7 @@ internal class GetAssertionExecution :
         }
         // If pinUvAuthParam parameter is not present and clientPin has been set on the authenticator,
         // set the "uv" bit to false in the response.
-        if (pinAuth == null && ctapAuthenticatorSession.clientPINService.isClientPINReady) {
+        if (pinAuth == null && ctapAuthenticatorSession.pinUvAuthService.isClientPINReady) {
             userVerificationResult = false
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -59,7 +59,7 @@ internal class GetInfoExecution(
         //spec| Client PIN is one of the ways to do user verification.
         val clientPin: ClientPINOption? = when (ctapAuthenticatorSession.clientPIN) {
             ClientPINSetting.ENABLED -> when {
-                ctapAuthenticatorSession.clientPINService.isClientPINReady -> ClientPINOption.SET
+                ctapAuthenticatorSession.pinUvAuthService.isClientPINReady -> ClientPINOption.SET
                 else -> ClientPINOption.NOT_SET
             }
             ClientPINSetting.DISABLED -> ClientPINOption.NOT_SUPPORTED

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -270,13 +270,13 @@ internal class MakeCredentialExecution :
                 // Handle zero length pinAuth for authenticator selection
                 if (it.isEmpty()) {
                     requestUserConsent()
-                    if (ctapAuthenticatorSession.clientPINService.isClientPINReady) {
+                    if (ctapAuthenticatorSession.pinUvAuthService.isClientPINReady) {
                         throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
                     } else {
                         throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
                     }
                 } else {
-                    ctapAuthenticatorSession.clientPINService.verifyPinUvAuthParam(it, clientDataHash)
+                    ctapAuthenticatorSession.pinUvAuthService.verifyPinUvAuthParam(it, clientDataHash)
                     userPresenceResult = true
                     userVerificationResult = true
                 }
@@ -285,7 +285,7 @@ internal class MakeCredentialExecution :
 
         // Validate clientPin requirement (formerly CTAP 2.0 Step 6)
         //TODO: to be fixed to align CTAP2.1 spec.
-//        if (authenticatorMakeCredentialRequest.pinAuth == null && ctapAuthenticatorSession.clientPINService.clientPIN != null) {
+//        if (authenticatorMakeCredentialRequest.pinAuth == null && ctapAuthenticatorSession.pinUvAuthService.clientPIN != null) {
 //            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_REQUIRED)
 //        }
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/HMACSecretExtensionProcessor.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/extension/HMACSecretExtensionProcessor.kt
@@ -81,7 +81,7 @@ class HMACSecretExtensionProcessor : RegistrationExtensionProcessor,
         //spec| then return CTAP2_ERR_PIN_AUTH_INVALID.
         val pinProtocol = hmacGetSecretAuthenticatorInput.pinUvAuthProtocol
             ?: PinProtocolVersion.VERSION_1
-        val protocol = context.ctapAuthenticatorSession.clientPINService.getProtocol(pinProtocol)
+        val protocol = context.ctapAuthenticatorSession.pinUvAuthService.getProtocol(pinProtocol)
 
         //spec| The authenticator calls decapsulate on the provided platform key-agreement key to obtain a shared secret.
         val sharedSecret = protocol.decapsulate(platformKeyAgreementKey)

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
@@ -1,6 +1,6 @@
 package com.webauthn4j.ctap.authenticator.store
 
-import com.webauthn4j.ctap.authenticator.ClientPINService
+import com.webauthn4j.ctap.authenticator.PinUvAuthService
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentCredentialKey
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.internal.KeyPairUtil.createCredentialKeyPair
@@ -34,7 +34,7 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
         credentialSourceEncryptionKey = generateAESKey()
         credentialSourceEncryptionIV = generateIV()
         clientPIN = null
-        pinRetries = ClientPINService.MAX_PIN_RETRIES
+        pinRetries = PinUvAuthService.MAX_PIN_RETRIES
     }
 
     override fun createUserCredentialKey(

--- a/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
+++ b/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
@@ -1,6 +1,6 @@
 package com.webauthn4j.ctap.client
 
-import com.webauthn4j.ctap.authenticator.ClientPINService
+import com.webauthn4j.ctap.authenticator.PinUvAuthService
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
 import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
@@ -74,14 +74,14 @@ internal class CtapServiceTest {
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
     fun getRetries_test() = runTest {
-        assertThat(target.getRetries()).isEqualTo(ClientPINService.MAX_PIN_RETRIES)
+        assertThat(target.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES)
         try {
             target.changePIN("wrongPIN", "newPIN")
         } catch (e: RuntimeException) {
         }
-        assertThat(target.getRetries()).isEqualTo(ClientPINService.MAX_PIN_RETRIES - 1u)
+        assertThat(target.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES - 1u)
         target.reset()
-        assertThat(target.getRetries()).isEqualTo(ClientPINService.MAX_PIN_RETRIES)
+        assertThat(target.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES)
     }
 
     @ExperimentalCoroutinesApi

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
@@ -1,6 +1,6 @@
 package integration.setting.authenticator
 
-import com.webauthn4j.ctap.authenticator.ClientPINService
+import com.webauthn4j.ctap.authenticator.PinUvAuthService
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.transport.internal.InternalTransport
 import com.webauthn4j.ctap.client.CtapClient
@@ -90,12 +90,12 @@ class ClientPINTest {
 
     @Test
     fun getRetries_test() = runTest {
-        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(ClientPINService.MAX_PIN_RETRIES)
+        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES)
         try {
             clientPINTestCase.clientPlatform.ctapService.changePIN("invalid-PIN", "invalid-PIN")
         } catch (e: CtapErrorException) { /* nop */
         }
-        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(ClientPINService.MAX_PIN_RETRIES - 1u)
+        assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(PinUvAuthService.MAX_PIN_RETRIES - 1u)
     }
 
     @Disabled


### PR DESCRIPTION
- The service handles both PIN and built-in UV operations (getPinUvAuthTokenUsingUvWithPermissions, getUVRetries), so the old name was misleading
- Rename class, file, and all property references (clientPINService → pinUvAuthService)