### PR TITLE
Align MakeCredential and GetAssertion UP/UV flow with CTAP 2.3 spec

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -105,6 +105,8 @@ class CtapAuthenticator(
     var resetProtection: ResetProtectionSetting = ResetProtectionSetting.DISABLED
     var userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED
     var userVerification: UserVerificationSetting = UserVerificationSetting.READY
+    var alwaysUv: Boolean = false
+    var makeCredUvNotRqd: Boolean = false
     var credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.AUTHENTICATOR
 
     fun createSession(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -9,7 +9,9 @@ import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FAttestationStatement
 import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FBasicAttestationStatementProvider
 import com.webauthn4j.ctap.authenticator.attestation.NoneAttestationStatementProvider
 import com.webauthn4j.ctap.authenticator.data.credential.Credential
+import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
+import com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.data.settings.AttachmentSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResetProtectionSetting
@@ -105,8 +107,8 @@ class CtapAuthenticator(
     var resetProtection: ResetProtectionSetting = ResetProtectionSetting.DISABLED
     var userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED
     var userVerification: UserVerificationSetting = UserVerificationSetting.READY
-    var alwaysUv: Boolean = false
-    var makeCredUvNotRqd: Boolean = false
+    var alwaysUv: AlwaysUvSetting = AlwaysUvSetting.DISABLED
+    var makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.DISABLED
     var credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.AUTHENTICATOR
 
     fun createSession(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -77,8 +77,8 @@ class CtapAuthenticatorSession internal constructor(
     val credentialSelector: CredentialSelectorSetting = ctapAuthenticator.credentialSelector
     val userPresence: UserPresenceSetting = ctapAuthenticator.userPresence
     val userVerification: UserVerificationSetting = ctapAuthenticator.userVerification
-    val alwaysUv: Boolean = ctapAuthenticator.alwaysUv
-    val makeCredUvNotRqd: Boolean = ctapAuthenticator.makeCredUvNotRqd
+    val alwaysUv: AlwaysUvSetting = ctapAuthenticator.alwaysUv
+    val makeCredUvNotRqd: MakeCredUvNotRqdSetting = ctapAuthenticator.makeCredUvNotRqd
 
     // Authenticator properties
     val aaguid: AAGUID = ctapAuthenticator.aaguid

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -77,6 +77,8 @@ class CtapAuthenticatorSession internal constructor(
     val credentialSelector: CredentialSelectorSetting = ctapAuthenticator.credentialSelector
     val userPresence: UserPresenceSetting = ctapAuthenticator.userPresence
     val userVerification: UserVerificationSetting = ctapAuthenticator.userVerification
+    val alwaysUv: Boolean = ctapAuthenticator.alwaysUv
+    val makeCredUvNotRqd: Boolean = ctapAuthenticator.makeCredUvNotRqd
 
     // Authenticator properties
     val aaguid: AAGUID = ctapAuthenticator.aaguid

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
@@ -1,0 +1,17 @@
+package com.webauthn4j.ctap.authenticator.data.settings
+
+enum class AlwaysUvSetting(val value: String) {
+    ENABLED("enabled"),
+    DISABLED("disabled");
+
+    companion object {
+        @JvmStatic
+        fun create(value: String): AlwaysUvSetting {
+            return when (value) {
+                "enabled" -> ENABLED
+                "disabled" -> DISABLED
+                else -> throw IllegalArgumentException("value '$value' is out of range")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
@@ -1,0 +1,17 @@
+package com.webauthn4j.ctap.authenticator.data.settings
+
+enum class MakeCredUvNotRqdSetting(val value: String) {
+    ENABLED("enabled"),
+    DISABLED("disabled");
+
+    companion object {
+        @JvmStatic
+        fun create(value: String): MakeCredUvNotRqdSetting {
+            return when (value) {
+                "enabled" -> ENABLED
+                "disabled" -> DISABLED
+                else -> throw IllegalArgumentException("value '$value' is out of range")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -171,6 +171,8 @@ internal class GetAssertionExecution :
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private suspend fun execStep1ZeroLengthPinUvAuthParam() {
         if (pinAuth != null && pinAuth.isEmpty()) {
+            //spec| Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+            //spec| If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
             val consent = ctapAuthenticatorSession.withUserPresenceWait {
                 ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(
                     GetAssertionConsentRequest(rpId, true, false)
@@ -179,6 +181,8 @@ internal class GetAssertionExecution :
             if (!consent) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
             }
+            //spec| If evidence of user interaction is provided in this step then return either
+            //spec| CTAP2_ERR_PIN_NOT_SET if PIN is not set or CTAP2_ERR_PIN_INVALID if PIN has been set.
             if (ctapAuthenticatorSession.isClientPINReady) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
             } else {
@@ -194,9 +198,11 @@ internal class GetAssertionExecution :
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep2ValidatePinUvAuthProtocol() {
         if (pinAuth != null) {
+            //spec| If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
             if (pinProtocol == null) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
             }
+            //spec| If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
             if (ctapAuthenticatorSession.pinProtocols.none { it == pinProtocol }) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
             }
@@ -218,16 +224,21 @@ internal class GetAssertionExecution :
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep4ProcessOptions() {
         if (options != null) {
+            //spec| If the pinUvAuthParam is present, let the "uv" option be treated as being present with the value false.
             userVerificationPlan = if (pinAuth != null) {
                 false
             } else {
                 when {
+                    //spec| If the "uv" option is present and true then:
+                    //spec|   If the authenticator does not support a built-in user verification method end the operation by returning CTAP2_ERR_INVALID_OPTION.
+                    //spec|   If the built-in user verification method has not yet been enabled, end the operation by returning CTAP2_ERR_INVALID_OPTION.
                     BooleanUtil.isTrue(options.uv) -> {
                         when (ctapAuthenticatorSession.userVerification) {
                             UserVerificationSetting.READY -> true
                             else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
                         }
                     }
+                    //spec| If the "uv" option is absent, let the "uv" option be treated as being present with the value false. (This is the default)
                     else -> false
                 }
             }
@@ -240,6 +251,8 @@ internal class GetAssertionExecution :
                 false
             }
         } else {
+            //spec| If the "up" option is not present then:
+            //spec|   Let the "up" option be treated as being present with the value true. (This is the default)
             userPresencePlan = when (ctapAuthenticatorSession.userPresence) {
                 UserPresenceSetting.SUPPORTED -> true
                 else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
@@ -260,7 +273,12 @@ internal class GetAssertionExecution :
         if (!ctapAuthenticatorSession.alwaysUv) return
         if (!userPresencePlan) return
 
+        //spec| If the authenticator is not protected by some form of user verification:
         if (!isProtectedByUserVerification) {
+            //spec| If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false:
+            //spec|   End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+            //spec| Else (clientPin is not supported):
+            //spec|   End the operation by returning CTAP2_ERR_OPERATION_DENIED.
             if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
             } else {
@@ -268,6 +286,11 @@ internal class GetAssertionExecution :
             }
         }
 
+        //spec| If the pinUvAuthParam is present then go to Step 6.
+        //spec| If the "uv" option is true then go to Step 6.
+        //spec| If the "uv" option is false and the authenticator supports a built-in user verification method,
+        //spec| and the user verification method is enabled then:
+        //spec|   Let the "uv" option be treated as being present with the value true.
         if (pinAuth == null && !userVerificationPlan) {
             if (ctapAuthenticatorSession.userVerification == UserVerificationSetting.READY) {
                 userVerificationPlan = true
@@ -307,37 +330,50 @@ internal class GetAssertionExecution :
     private fun execStep6ProcessUserVerification() {
         if (!isProtectedByUserVerification) return
 
-        // Step 6.1
+        //spec| 6.1 If pinUvAuthParam parameter is present (implying the "uv" option is treated as false, see Step 4):
         if (pinAuth != null && pinProtocol != null) {
+            //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+            //spec| If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
             val protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
                 protocol.verify(protocol.pinUvAuthToken, clientDataHash, pinAuth)
             } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
 
+            //spec| If the verification returns success, set the "uv" bit to true in the response.
             userVerificationResult = true
 
+            //spec| Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
+            //spec| If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
             if (!protocol.tokenState.getUserVerifiedFlagValue()) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
 
+            //spec| Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
             if (!protocol.tokenState.hasPermission(PinUvAuthTokenPermission.GA)) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
 
+            //spec| If the pinUvAuthToken has a permissions RP ID associated:
+            //spec|   If the permissions RP ID does not match the rpId in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
             val tokenRpId = protocol.tokenState.permissionsRpId
             if (tokenRpId != null && tokenRpId != rpId) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
 
+            //spec| If the pinUvAuthToken does not have a permissions RP ID associated:
+            //spec|   Associate the request's rpId parameter value with the pinUvAuthToken as its permissions RP ID.
             if (protocol.tokenState.permissionsRpId == null) {
                 protocol.tokenState.permissionsRpId = rpId
             }
 
             protocol.tokenState.recordPlatformUsage()
             matchedProtocol = protocol
+            //spec| Go to Step 7.
             return
         }
 
-        // Step 6.2: built-in UV is handled via the consent flow in Step 9.
+        //spec| 6.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
+        //spec| and that the authenticator supports an enabled built-in user verification method, see Step 4):
+        // Built-in UV is handled via the consent flow in Step 9.
         // userVerificationPlan remains true and will be processed during consent.
     }
 
@@ -480,7 +516,10 @@ internal class GetAssertionExecution :
         if (userPresencePlan) {
             var needsInteraction = false
 
+            //spec| If the pinUvAuthParam parameter is present then:
             if (pinAuth != null) {
+                //spec| Let userPresentFlagValue be the result of calling getUserPresentFlagValue().
+                //spec| If userPresentFlagValue is false:
                 val protocol = matchedProtocol
                 if (protocol != null && !protocol.tokenState.getUserPresentFlagValue()) {
                     needsInteraction = true
@@ -488,12 +527,16 @@ internal class GetAssertionExecution :
                     needsInteraction = true
                 }
             } else {
+                //spec| Else (implying the pinUvAuthParam parameter is not present):
+                //spec|   If the "up" bit is false in the response:
                 if (!userPresenceResult) {
                     needsInteraction = true
                 }
             }
 
             if (needsInteraction) {
+                //spec| Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+                //spec| If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
                 val consentRequest = GetAssertionConsentRequest(rpId, userPresencePlan, userVerificationPlan)
                 val consent = ctapAuthenticatorSession.withUserPresenceWait {
                     ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(consentRequest)
@@ -506,9 +549,10 @@ internal class GetAssertionExecution :
                 }
             }
 
+            //spec| Set the "up" bit to true in the response.
             userPresenceResult = true
 
-            // Clear cached UP/UV state
+            //spec| Call clearUserPresentFlag(), clearUserVerifiedFlag(), and clearPinUvAuthTokenPermissionsExceptLbw().
             ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.forEach { protocol ->
                 protocol.tokenState.clearUserPresentFlag()
                 protocol.tokenState.clearUserVerifiedFlag()

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -4,10 +4,12 @@ import tools.jackson.core.type.TypeReference
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
 import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
 import com.webauthn4j.ctap.authenticator.GetAssertionSession
+import com.webauthn4j.ctap.authenticator.PinUvAuthProtocol
 import com.webauthn4j.ctap.authenticator.SignatureCalculator.calculate
 import com.webauthn4j.ctap.authenticator.U2FKeyEnvelope
 import com.webauthn4j.ctap.authenticator.data.credential.*
 import com.webauthn4j.ctap.authenticator.data.event.GetAssertionEvent
+import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
@@ -37,7 +39,11 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import kotlin.experimental.or
 
-// @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+/**
+ * GetAssertion command execution
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">CTAP 2.3 §6.2.2 authenticatorGetAssertion Algorithm</a>
+ */
 @Suppress("ConvertSecondaryConstructorToPrimary")
 internal class GetAssertionExecution :
     CtapCommandExecutionBase<AuthenticatorGetAssertionRequest, AuthenticatorGetAssertionResponse> {
@@ -74,8 +80,17 @@ internal class GetAssertionExecution :
 
     private var userVerificationPlan = false
     private var userPresencePlan = false
+
+    //spec| Step 3. Create a new authenticatorGetAssertion response structure and initialize both its "uv" bit and "up" bit as false.
     private var userVerificationResult = false
     private var userPresenceResult = false
+
+    private var matchedProtocol: PinUvAuthProtocol? = null
+    private var uvPerformedViaBuiltIn = false
+
+    private val isProtectedByUserVerification: Boolean
+        get() = ctapAuthenticatorSession.isClientPINReady ||
+                ctapAuthenticatorSession.userVerification == UserVerificationSetting.READY
 
 
     constructor(
@@ -104,14 +119,14 @@ internal class GetAssertionExecution :
     }
 
     override suspend fun doExecute(): AuthenticatorGetAssertionResponse {
-        // execStep1ZeroLengthPinUvAuthParam()     // TODO: CTAP 2.1
-        // execStep2ValidatePinUvAuthProtocol()     // TODO: CTAP 2.1
-        // execStep3InitializeResponseStructure()   // TODO: CTAP 2.1
+        execStep1ZeroLengthPinUvAuthParam()
+        execStep2ValidatePinUvAuthProtocol()
+        // Step 3: response structure initialized via field declarations (userPresenceResult=false, userVerificationResult=false)
         execStep4ProcessOptions()
-        // execStep5ProcessAlwaysUv()               // TODO: CTAP 2.1
+        execStep5ProcessAlwaysUv()
         execStep6ProcessUserVerification()
         execStep7LocateCredentials()
-        // execStep8SetUpFromBuiltInUv()            // TODO: CTAP 2.1
+        execStep8SetUpFromBuiltInUv()
         execStep9RequestUserConsent()
         execStep10ProcessExtensions()
         execStep11And12SelectCredential()
@@ -146,76 +161,198 @@ internal class GetAssertionExecution :
         return AuthenticatorGetAssertionResponse(statusCode)
     }
 
-    //spec| Step 4
-    //spec| If the options parameter is present, process all option keys and values present in the parameter.
-    //spec| Treat any option keys that are not understood as absent.
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
-    private fun execStep4ProcessOptions() {
-        if (options != null) {
-            if (BooleanUtil.isTrue(options.uv)) {
-                userVerificationPlan = when (ctapAuthenticatorSession.userVerification) {
-                    UserVerificationSetting.READY -> true
-                    else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
-                }
+    //spec| Step 1. If authenticator supports either pinUvAuthToken or clientPin features and the platform sends a
+    //spec| zero length pinUvAuthParam:
+    //spec|   Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|   If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   If evidence of user interaction is provided in this step then return either
+    //spec|   CTAP2_ERR_PIN_NOT_SET if PIN is not set or CTAP2_ERR_PIN_INVALID if PIN has been set.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private suspend fun execStep1ZeroLengthPinUvAuthParam() {
+        if (pinAuth != null && pinAuth.isEmpty()) {
+            val consent = ctapAuthenticatorSession.withUserPresenceWait {
+                ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(
+                    GetAssertionConsentRequest(rpId, true, false)
+                )
             }
-            if (options.up != false) {
-                userPresencePlan = when (ctapAuthenticatorSession.userPresence) {
-                    UserPresenceSetting.SUPPORTED -> true
-                    else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
-                }
+            if (!consent) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+            if (ctapAuthenticatorSession.isClientPINReady) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
             }
         }
     }
 
-    //spec| Step 6
-    //spec| If the authenticator is protected by some form of user verification, then:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 2. If the pinUvAuthParam parameter is present:
+    //spec|   If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
+    //spec|   If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private fun execStep2ValidatePinUvAuthProtocol() {
+        if (pinAuth != null) {
+            if (pinProtocol == null) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+            }
+            if (ctapAuthenticatorSession.pinProtocols.none { it == pinProtocol }) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+            }
+        }
+    }
+
+    //spec| Step 4. If the options parameter is present, process all option keys and values present in the parameter.
+    //spec| Treat any option keys that are not understood as absent.
+    //spec|   If the "uv" option is absent, let the "uv" option be treated as being present with the value false. (This is the default)
+    //spec|   If the pinUvAuthParam is present, let the "uv" option be treated as being present with the value false.
+    //spec|   If the "uv" option is present and true then:
+    //spec|     If the authenticator does not support a built-in user verification method end the operation by returning CTAP2_ERR_INVALID_OPTION.
+    //spec|     If the built-in user verification method has not yet been enabled, end the operation by returning CTAP2_ERR_INVALID_OPTION.
+    //spec|   If the "rk" option is present then:
+    //spec|     Return CTAP2_ERR_UNSUPPORTED_OPTION.
+    //spec|   If the "up" option is not present then:
+    //spec|     Let the "up" option be treated as being present with the value true. (This is the default)
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private fun execStep4ProcessOptions() {
+        if (options != null) {
+            userVerificationPlan = if (pinAuth != null) {
+                false
+            } else {
+                when {
+                    BooleanUtil.isTrue(options.uv) -> {
+                        when (ctapAuthenticatorSession.userVerification) {
+                            UserVerificationSetting.READY -> true
+                            else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+                        }
+                    }
+                    else -> false
+                }
+            }
+            userPresencePlan = if (options.up != false) {
+                when (ctapAuthenticatorSession.userPresence) {
+                    UserPresenceSetting.SUPPORTED -> true
+                    else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+                }
+            } else {
+                false
+            }
+        } else {
+            userPresencePlan = when (ctapAuthenticatorSession.userPresence) {
+                UserPresenceSetting.SUPPORTED -> true
+                else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+            }
+        }
+    }
+
+    //spec| Step 5. If the alwaysUv option ID is present and true and the "up" option is present and true then:
+    //spec|   If the authenticator is not protected by some form of user verification:
+    //spec|     If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false
+    //spec|     (clientPin is supported for the ga permission):
+    //spec|       End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|     Else (clientPin is not supported):
+    //spec|       End the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private fun execStep5ProcessAlwaysUv() {
+        if (!ctapAuthenticatorSession.alwaysUv) return
+        if (!userPresencePlan) return
+
+        if (!isProtectedByUserVerification) {
+            if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+        }
+
+        if (pinAuth == null && !userVerificationPlan) {
+            if (ctapAuthenticatorSession.userVerification == UserVerificationSetting.READY) {
+                userVerificationPlan = true
+            } else if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+        }
+    }
+
+    //spec| Step 6. If the authenticator is protected by some form of user verification, then:
+    //spec|   6.1 If pinUvAuthParam parameter is present (implying the "uv" option is treated as false, see Step 4):
+    //spec|     Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+    //spec|     If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
+    //spec|     If the verification returns success, set the "uv" bit to true in the response.
+    //spec|     Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
+    //spec|     If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     If the pinUvAuthToken has a permissions RP ID associated:
+    //spec|       If the permissions RP ID does not match the rpId in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     If the pinUvAuthToken does not have a permissions RP ID associated:
+    //spec|       Associate the request's rpId parameter value with the pinUvAuthToken as its permissions RP ID.
+    //spec|     Go to Step 7.
+    //spec|   6.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
+    //spec|   and that the authenticator supports an enabled built-in user verification method, see Step 4):
+    //spec|     Let internalRetry be true.
+    //spec|     Let uvState be the result of calling performBuiltInUv(internalRetry)
+    //spec|     If uvState is error:
+    //spec|       If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+    //spec|       If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
+    //spec|       Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|     If uvState is success:
+    //spec|       Set the "uv" bit to true in the response.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep6ProcessUserVerification() {
-        // If pinUvAuthParam parameter is present and pinProtocol is supported,
-        // verify it and set the "uv" bit to true in the response.
+        if (!isProtectedByUserVerification) return
+
+        // Step 6.1
         if (pinAuth != null && pinProtocol != null) {
-            //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
-            //spec| If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
-            val matchedProtocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
-                val calculatedPinAuth = protocol.authenticate(protocol.pinUvAuthToken, clientDataHash)
-                Arrays.equals(calculatedPinAuth, pinAuth)
+            val protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
+                protocol.verify(protocol.pinUvAuthToken, clientDataHash, pinAuth)
             } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
 
-            //spec| Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
-            if (matchedProtocol.tokenState.isInUse() && !matchedProtocol.tokenState.hasPermission(PinUvAuthTokenPermission.GA)) {
+            userVerificationResult = true
+
+            if (!protocol.tokenState.getUserVerifiedFlagValue()) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
-            //spec| If the pinUvAuthToken has a permissions RP ID associated:
-            //spec| If the permissions RP ID does not match the rpId in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
-            val tokenRpId = matchedProtocol.tokenState.permissionsRpId
+
+            if (!protocol.tokenState.hasPermission(PinUvAuthTokenPermission.GA)) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+            }
+
+            val tokenRpId = protocol.tokenState.permissionsRpId
             if (tokenRpId != null && tokenRpId != rpId) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
 
-            if (matchedProtocol.tokenState.isInUse()) {
-                matchedProtocol.tokenState.recordPlatformUsage()
+            if (protocol.tokenState.permissionsRpId == null) {
+                protocol.tokenState.permissionsRpId = rpId
             }
 
-            userVerificationResult = true
+            protocol.tokenState.recordPlatformUsage()
+            matchedProtocol = protocol
             return
         }
-        // If pinUvAuthParam parameter is not present and clientPin has been set on the authenticator,
-        // set the "uv" bit to false in the response.
-        if (pinAuth == null && ctapAuthenticatorSession.isClientPINReady) {
-            userVerificationResult = false
-        }
+
+        // Step 6.2: built-in UV is handled via the consent flow in Step 9.
+        // userVerificationPlan remains true and will be processed during consent.
     }
 
-    //spec| Step 7
-    //spec| Locate all credentials that are eligible for retrieval under the specified criteria:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 7. Locate all credentials that are eligible for retrieval under the specified criteria:
+    //spec|   If the allowList parameter is present and is non-empty, locate all
+    //spec|   denoted credentials created by this authenticator and bound to the specified rpId.
+    //spec|   If an allowList is not present, locate all discoverable credentials that are
+    //spec|   created by this authenticator and bound to the specified rpId.
+    //spec|   Create an applicable credentials list populated with the located credentials.
+    //spec|   If the applicable credentials list is empty, return CTAP2_ERR_NO_CREDENTIALS.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep7LocateCredentials() {
         val rpId = rpId
 
-        //spec| If the allowList parameter is present and is non-empty, locate all
-        //spec| denoted credentials created by this authenticator and bound to the specified rpId.
-        //spec| If an allowList is not present, locate all discoverable credentials that are
-        //spec| created by this authenticator and bound to the specified rpId.
         credentials = if (allowList != null && allowList.isNotEmpty()) {
             val storedCredentials = authenticatorPropertyStore.loadUserCredentials(rpId)
                 .filter {
@@ -238,7 +375,6 @@ internal class GetAssertionExecution :
             )
         }
 
-        //spec| If the applicable credentials list is empty, return CTAP2_ERR_NO_CREDENTIALS.
         if (credentials.isEmpty()) {
             throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
         }
@@ -309,29 +445,85 @@ internal class GetAssertionExecution :
         return null
     }
 
-    //spec| Step 9
-    //spec| If the "up" option is set to true or not present:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
-    private suspend fun execStep9RequestUserConsent() {
-        val options = GetAssertionConsentRequest(rpId, userPresencePlan, userVerificationPlan)
-        val consent = ctapAuthenticatorSession.withUserPresenceWait {
-            ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(options)
+    //spec| Step 8. If evidence of user interaction was provided as part of Step 6.2 (i.e., by invoking performBuiltInUv()):
+    //spec|   Set the "up" bit to true in the response.
+    //spec|   Go to Step 10
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private fun execStep8SetUpFromBuiltInUv(): Boolean {
+        if (uvPerformedViaBuiltIn) {
+            userPresenceResult = true
+            return true
         }
-        if (consent) {
-            if (userVerificationPlan) {
-                userVerificationResult = true
+        return false
+    }
+
+    //spec| Step 9. If the "up" option is set to true or not present:
+    //spec|   If the pinUvAuthParam parameter is present then:
+    //spec|     Let userPresentFlagValue be the result of calling getUserPresentFlagValue().
+    //spec|     If userPresentFlagValue is false:
+    //spec|       Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|       If the authenticator has a display, show the rpId parameter value to the user,
+    //spec|       and request permission to create an assertion.
+    //spec|       If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   Else (implying the pinUvAuthParam parameter is not present):
+    //spec|     If the "up" bit is false in the response:
+    //spec|       Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|       If the authenticator has a display, show the rpId parameter value to the user,
+    //spec|       and request permission to create an assertion.
+    //spec|       If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   Set the "up" bit to true in the response.
+    //spec|   Call clearUserPresentFlag(), clearUserVerifiedFlag(), and clearPinUvAuthTokenPermissionsExceptLbw().
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private suspend fun execStep9RequestUserConsent() {
+        if (userPresencePlan) {
+            var needsInteraction = false
+
+            if (pinAuth != null) {
+                val protocol = matchedProtocol
+                if (protocol != null && !protocol.tokenState.getUserPresentFlagValue()) {
+                    needsInteraction = true
+                } else if (protocol == null) {
+                    needsInteraction = true
+                }
+            } else {
+                if (!userPresenceResult) {
+                    needsInteraction = true
+                }
             }
-            if (userPresencePlan) {
-                userPresenceResult = true
+
+            if (needsInteraction) {
+                val consentRequest = GetAssertionConsentRequest(rpId, userPresencePlan, userVerificationPlan)
+                val consent = ctapAuthenticatorSession.withUserPresenceWait {
+                    ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(consentRequest)
+                }
+                if (!consent) {
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+                }
+                if (userVerificationPlan) {
+                    userVerificationResult = true
+                }
             }
-        } else {
-            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+
+            userPresenceResult = true
+
+            // Clear cached UP/UV state
+            ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.forEach { protocol ->
+                protocol.tokenState.clearUserPresentFlag()
+                protocol.tokenState.clearUserVerifiedFlag()
+                protocol.tokenState.clearPinUvAuthTokenPermissionsExceptLbw()
+            }
         }
     }
 
-    //spec| Step 10
-    //spec| If the extensions parameter is present:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 10. If the extensions parameter is present:
+    //spec|   Process any extensions that this authenticator supports, ignoring any that it does not support.
+    //spec|   Authenticator extension outputs generated by the authenticator extension processing
+    //spec|   are returned in the authenticator data.
+    //spec|   The set of keys in the authenticator extension outputs map MUST be equal to, or a subset of, the keys of the authenticator extension inputs map.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep10ProcessExtensions() {
         val inputs = this.authenticationExtensionsAuthenticatorInputs
         assertionObjects = credentials.map { credential ->
@@ -356,17 +548,18 @@ internal class GetAssertionExecution :
         }
     }
 
-    //spec| Step 11
-    //spec| If the allowList parameter is present:
-    //spec| Step 12
-    //spec| If allowList is not present:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 11. If the allowList parameter is present:
+    //spec|   Select any credential from the applicable credentials list.
+    //spec| Step 12. If allowList is not present:
+    //spec|   Order the credentials in the applicable credentials list by the time when they were created in reverse order.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private suspend fun execStep11And12SelectCredential() {
         // Sort credentials by creation time in reverse order (most recent first)
         assertionObjects = assertionObjects.sortedByDescending { it.credential.createdAt.epochSecond }
 
         // Mask user identifiable information if user verification was not performed
-        if (!(userVerificationPlan || authenticatorGetAssertionRequest.pinAuth != null)) {
+        if (!userVerificationResult && pinAuth == null) {
             assertionObjects.map {
                 it.maskUserIdentifiableInfo = true
             }
@@ -403,9 +596,9 @@ internal class GetAssertionExecution :
         }
     }
 
-    //spec| Step 13
-    //spec| Sign the clientDataHash along with authData with the selected credential, using the structure specified in [WebAuthn].
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 13. Sign the clientDataHash along with authData with the selected credential, using the structure specified in [WebAuthn].
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep13Sign(): AuthenticatorGetAssertionResponse {
         val assertionObject = onGoingGetAssertionSession.nextAssertionObject()
         val credential = assertionObject.credential
@@ -423,10 +616,6 @@ internal class GetAssertionExecution :
         )
         val authData = ctapAuthenticatorSession.authenticatorDataConverter.convert(authenticatorDataObject)
 
-        // Let signature be the assertion signature of the concatenation authenticatorData || hash using
-        // the privateKey of selectedCredential as shown in Figure 2, below. A simple, un-delimited concatenation is
-        // safe to use here because the authenticator data describes its own length.
-        // The hash of the serialized client data (which potentially has a variable length) is always the last element.
         val clientDataHash = onGoingGetAssertionSession.clientDataHash
         val signedData = ByteBuffer.allocate(authData.size + clientDataHash.size).put(authData)
             .put(clientDataHash).array()
@@ -454,7 +643,6 @@ internal class GetAssertionExecution :
         }
         val numberOfCredentials = onGoingGetAssertionSession.numberOfAssertionObjects
 
-        //spec| On success, the authenticator returns an attestation object in its response as defined in [WebAuthn]:
         val responseData = AuthenticatorGetAssertionResponseData(
             descriptor,
             authData,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -9,6 +9,7 @@ import com.webauthn4j.ctap.authenticator.SignatureCalculator.calculate
 import com.webauthn4j.ctap.authenticator.U2FKeyEnvelope
 import com.webauthn4j.ctap.authenticator.data.credential.*
 import com.webauthn4j.ctap.authenticator.data.event.GetAssertionEvent
+import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
@@ -270,7 +271,7 @@ internal class GetAssertionExecution :
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep5ProcessAlwaysUv() {
-        if (!ctapAuthenticatorSession.alwaysUv) return
+        if (ctapAuthenticatorSession.alwaysUv != AlwaysUvSetting.ENABLED) return
         if (!userPresencePlan) return
 
         //spec| If the authenticator is not protected by some form of user verification:

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -2,8 +2,10 @@ package com.webauthn4j.ctap.authenticator.execution
 
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.AttachmentSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
+import com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoRequest
@@ -81,8 +83,14 @@ internal class GetInfoExecution(
         //spec| If absent, it indicates that the device is not capable of user verification within itself.
         //spec| A device that can only do Client PIN will not return the "uv" parameter.
         val uv: UserVerificationOption? = ctapAuthenticatorSession.userVerificationHandler.getUserVerificationOption(null)
-        val alwaysUv: AlwaysUvOption? = if (ctapAuthenticatorSession.alwaysUv) AlwaysUvOption.ENABLED else null
-        val makeCredUvNotRqd: MakeCredUvNotRqdOption? = if (ctapAuthenticatorSession.makeCredUvNotRqd) MakeCredUvNotRqdOption.ENABLED else null
+        val alwaysUv: AlwaysUvOption? = when (ctapAuthenticatorSession.alwaysUv) {
+            AlwaysUvSetting.ENABLED -> AlwaysUvOption.ENABLED
+            AlwaysUvSetting.DISABLED -> null
+        }
+        val makeCredUvNotRqd: MakeCredUvNotRqdOption? = when (ctapAuthenticatorSession.makeCredUvNotRqd) {
+            MakeCredUvNotRqdSetting.ENABLED -> MakeCredUvNotRqdOption.ENABLED
+            MakeCredUvNotRqdSetting.DISABLED -> null
+        }
         val extensions = ctapAuthenticatorSession.extensionProcessors.map { it.extensionId }
         return AuthenticatorGetInfoResponse(
             CtapStatusCode.CTAP2_OK,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -10,7 +10,9 @@ import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
 import com.webauthn4j.ctap.core.data.CtapStatusCode
+import com.webauthn4j.ctap.core.data.options.AlwaysUvOption
 import com.webauthn4j.ctap.core.data.options.ClientPINOption
+import com.webauthn4j.ctap.core.data.options.MakeCredUvNotRqdOption
 import com.webauthn4j.ctap.core.data.options.PlatformOption
 import com.webauthn4j.ctap.core.data.options.ResidentKeyOption
 import com.webauthn4j.ctap.core.data.options.UserPresenceOption
@@ -79,8 +81,8 @@ internal class GetInfoExecution(
         //spec| If absent, it indicates that the device is not capable of user verification within itself.
         //spec| A device that can only do Client PIN will not return the "uv" parameter.
         val uv: UserVerificationOption? = ctapAuthenticatorSession.userVerificationHandler.getUserVerificationOption(null)
-        val alwaysUv: Boolean? = if (ctapAuthenticatorSession.alwaysUv) true else null
-        val makeCredUvNotRqd: Boolean? = if (ctapAuthenticatorSession.makeCredUvNotRqd) true else null
+        val alwaysUv: AlwaysUvOption? = if (ctapAuthenticatorSession.alwaysUv) AlwaysUvOption.ENABLED else null
+        val makeCredUvNotRqd: MakeCredUvNotRqdOption? = if (ctapAuthenticatorSession.makeCredUvNotRqd) MakeCredUvNotRqdOption.ENABLED else null
         val extensions = ctapAuthenticatorSession.extensionProcessors.map { it.extensionId }
         return AuthenticatorGetInfoResponse(
             CtapStatusCode.CTAP2_OK,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -79,6 +79,8 @@ internal class GetInfoExecution(
         //spec| If absent, it indicates that the device is not capable of user verification within itself.
         //spec| A device that can only do Client PIN will not return the "uv" parameter.
         val uv: UserVerificationOption? = ctapAuthenticatorSession.userVerificationHandler.getUserVerificationOption(null)
+        val alwaysUv: Boolean? = if (ctapAuthenticatorSession.alwaysUv) true else null
+        val makeCredUvNotRqd: Boolean? = if (ctapAuthenticatorSession.makeCredUvNotRqd) true else null
         val extensions = ctapAuthenticatorSession.extensionProcessors.map { it.extensionId }
         return AuthenticatorGetInfoResponse(
             CtapStatusCode.CTAP2_OK,
@@ -86,7 +88,7 @@ internal class GetInfoExecution(
                 CtapAuthenticator.VERSIONS,       // versions (0x01): Required
                 extensions,                        // extensions (0x02): Optional
                 ctapAuthenticatorSession.aaguid,   // aaguid (0x03): Required
-                AuthenticatorGetInfoResponseData.Options(plat, rk, clientPin, up, uv), // options (0x04): Optional
+                AuthenticatorGetInfoResponseData.Options(plat, rk, clientPin, up, uv, alwaysUv, makeCredUvNotRqd), // options (0x04): Optional
                 2048u,                             // maxMsgSize (0x05): Optional
                 ctapAuthenticatorSession.pinProtocols,   // pinProtocols (0x06): Optional
                 null,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -201,7 +201,10 @@ internal class MakeCredentialExecution :
         if (pinAuth != null && pinAuth.isEmpty()) {
             //spec| Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
             //spec| If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
-            requestUserConsent()
+            val consent = requestUserConsent()
+            if (!consent) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
             //spec| If evidence of user interaction is provided in this step then return either
             //spec| CTAP2_ERR_PIN_NOT_SET if PIN is not set or CTAP2_ERR_PIN_INVALID if PIN has been set.
             if (ctapAuthenticatorSession.isClientPINReady) {
@@ -305,8 +308,16 @@ internal class MakeCredentialExecution :
     }
 
     //spec| Step 6. If the alwaysUv option ID is present and true then:
-    //spec|   Let the makeCredUvNotRqd option ID be treated as false.
-    //spec|   If the authenticator is not protected by some form of user verification:
+    //spec|   6.1 Let the makeCredUvNotRqd option ID be treated as false.
+    //spec|   6.2 If the authenticator is not protected by some form of user verification:
+    //spec|     If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false
+    //spec|     (clientPin is supported for the mc permission):
+    //spec|       End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|     Else (clientPin is not supported):
+    //spec|       End the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   6.3 If the pinUvAuthParam is not present, and the uv option ID is true,
+    //spec|   let the "uv" option be treated as being present with the value true.
+    //spec|   6.4 If the pinUvAuthParam is not present, and the "uv" option is false or absent:
     //spec|     If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false
     //spec|     (clientPin is supported for the mc permission):
     //spec|       End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
@@ -317,8 +328,10 @@ internal class MakeCredentialExecution :
     private fun execStep6ProcessAlwaysUv() {
         if (!ctapAuthenticatorSession.alwaysUv) return
 
-        //spec| Let the makeCredUvNotRqd option ID be treated as false.
-        //spec| If the authenticator is not protected by some form of user verification:
+        //spec| 6.1 Let the makeCredUvNotRqd option ID be treated as false.
+        // (effectiveMakeCredUvNotRqd is computed in Step 7/8/10 using alwaysUv flag)
+
+        //spec| 6.2 If the authenticator is not protected by some form of user verification:
         if (!isProtectedByUserVerification) {
             //spec| If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false:
             //spec|   End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
@@ -330,7 +343,12 @@ internal class MakeCredentialExecution :
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
             }
         }
-        //spec| If the pinUvAuthParam is not present, and the "uv" option is false or absent:
+
+        //spec| 6.3 If the pinUvAuthParam is not present, and the uv option ID is true,
+        //spec| let the "uv" option be treated as being present with the value true.
+        // (userVerificationPlan is already true from Step 5 when uv=true)
+
+        //spec| 6.4 If the pinUvAuthParam is not present, and the "uv" option is false or absent:
         if (pinAuth == null && !userVerificationPlan) {
             if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -13,7 +13,9 @@ import com.webauthn4j.ctap.authenticator.data.credential.NonResidentUserCredenti
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.data.credential.UserCredential
 import com.webauthn4j.ctap.authenticator.data.event.MakeCredentialEvent
+import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
+import com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
@@ -326,7 +328,7 @@ internal class MakeCredentialExecution :
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep6ProcessAlwaysUv() {
-        if (!ctapAuthenticatorSession.alwaysUv) return
+        if (ctapAuthenticatorSession.alwaysUv != AlwaysUvSetting.ENABLED) return
 
         //spec| 6.1 Let the makeCredUvNotRqd option ID be treated as false.
         // (effectiveMakeCredUvNotRqd is computed in Step 7/8/10 using alwaysUv flag)
@@ -371,7 +373,7 @@ internal class MakeCredentialExecution :
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep7ProcessMakeCredUvNotRqd() {
-        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv) false else ctapAuthenticatorSession.makeCredUvNotRqd
+        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv == AlwaysUvSetting.ENABLED) false else ctapAuthenticatorSession.makeCredUvNotRqd == MakeCredUvNotRqdSetting.ENABLED
         if (!effectiveMakeCredUvNotRqd) return
 
         if (isProtectedByUserVerification && !userVerificationPlan && pinAuth == null && residentKeyPlan) {
@@ -395,7 +397,7 @@ internal class MakeCredentialExecution :
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep8ProcessMakeCredUvNotRqdElse() {
-        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv) false else ctapAuthenticatorSession.makeCredUvNotRqd
+        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv == AlwaysUvSetting.ENABLED) false else ctapAuthenticatorSession.makeCredUvNotRqd == MakeCredUvNotRqdSetting.ENABLED
         if (effectiveMakeCredUvNotRqd) return
 
         if (isProtectedByUserVerification && !userVerificationPlan && pinAuth == null) {
@@ -415,7 +417,7 @@ internal class MakeCredentialExecution :
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep10CheckUvNotRequired() {
-        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv) false else ctapAuthenticatorSession.makeCredUvNotRqd
+        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv == AlwaysUvSetting.ENABLED) false else ctapAuthenticatorSession.makeCredUvNotRqd == MakeCredUvNotRqdSetting.ENABLED
         if (!residentKeyPlan && !userVerificationPlan && effectiveMakeCredUvNotRqd && pinAuth == null) {
             uvNotRequired = true
         }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -4,6 +4,7 @@ package com.webauthn4j.ctap.authenticator.execution
 import tools.jackson.dataformat.cbor.CBORMapper
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
 import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
+import com.webauthn4j.ctap.authenticator.PinUvAuthProtocol
 import com.webauthn4j.ctap.authenticator.UserCredentialBuilder
 import com.webauthn4j.ctap.authenticator.attestation.AttestationStatementRequest
 import com.webauthn4j.ctap.authenticator.data.credential.CredentialKey
@@ -12,6 +13,7 @@ import com.webauthn4j.ctap.authenticator.data.credential.NonResidentUserCredenti
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.data.credential.UserCredential
 import com.webauthn4j.ctap.authenticator.data.event.MakeCredentialEvent
+import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
@@ -88,11 +90,22 @@ internal class MakeCredentialExecution :
     private var residentKeyPlan = false
     private var userVerificationPlan = false
     private var userPresencePlan = false
+
+    //spec| Step 4. Create a new authenticatorMakeCredential response structure and initialize both its "uv" bit and "up" bit as false.
     private var userVerificationResult = false
     private var userPresenceResult = false
+
     private lateinit var algorithmIdentifier: COSEAlgorithmIdentifier
 
+    private var matchedProtocol: PinUvAuthProtocol? = null
+    private var uvPerformedViaBuiltIn = false
+    private var uvNotRequired = false
+
     private var registrationExtensionAuthenticatorOutputs: AuthenticationExtensionsAuthenticatorOutputs<RegistrationExtensionAuthenticatorOutput> = AuthenticationExtensionsAuthenticatorOutputs()
+
+    private val isProtectedByUserVerification: Boolean
+        get() = ctapAuthenticatorSession.isClientPINReady ||
+                ctapAuthenticatorSession.userVerification == UserVerificationSetting.READY
 
     constructor(
         ctapAuthenticatorSession: CtapAuthenticatorSession,
@@ -140,49 +153,23 @@ internal class MakeCredentialExecution :
         }
         ctapAuthenticatorSession.onGoingGetAssertionSession = null
 
-        // Step 1: TODO: CTAP 2.1 - zero length pinUvAuthParam handling
-        //spec| Step 1. If authenticator supports either pinUvAuthToken or clientPin features and the platform sends a zero length pinUvAuthParam:
-        // execStep1ZeroLengthPinUvAuthParam()
-
-        // Step 2: TODO: CTAP 2.1 - pinUvAuthProtocol validation
-        //spec| Step 2. If the pinUvAuthParam parameter is present:
-        // execStep2ValidatePinUvAuthProtocol()
-
+        execStep1ZeroLengthPinUvAuthParam()
+        execStep2ValidatePinUvAuthProtocol()
         execStep3ValidatePubKeyCredParams()
-
-        // Step 4: TODO: CTAP 2.1 - initialize response structure
-        //spec| Step 4. Create a new authenticatorMakeCredential response structure and initialize both its "uv" bit and "up" bit as false.
-        // execStep4InitializeResponseStructure()
-
+        // Step 4: response structure initialized via field declarations (userPresenceResult=false, userVerificationResult=false)
         execStep5ProcessOptions()
+        execStep6ProcessAlwaysUv()
+        execStep7ProcessMakeCredUvNotRqd()
+        execStep8ProcessMakeCredUvNotRqdElse()
+        // Step 9: enterpriseAttestation — not implemented
+        execStep10CheckUvNotRequired()
 
-        // Step 6: TODO: CTAP 2.1 - alwaysUv processing
-        //spec| Step 6. If the alwaysUv option ID is present and true then:
-        // execStep6ProcessAlwaysUv()
+        if (!uvNotRequired) {
+            execStep11ProcessUserVerification()
+        }
 
-        // Step 7: TODO: CTAP 2.1 - makeCredUvNotRqd (present and true)
-        //spec| Step 7. If the makeCredUvNotRqd option ID is present and set to true in the authenticatorGetInfo response:
-        // execStep7ProcessMakeCredUvNotRqd()
-
-        // Step 8: TODO: CTAP 2.1 - makeCredUvNotRqd (absent or false)
-        //spec| Step 8. Else: (the makeCredUvNotRqd option ID in authenticatorGetInfo's response is present with the value false or is absent):
-        // execStep8ProcessMakeCredUvNotRqdElse()
-
-        // Step 9: TODO: CTAP 2.1 - enterprise attestation
-        //spec| Step 9. If the enterpriseAttestation parameter is present:
-        // execStep9ProcessEnterpriseAttestation()
-
-        // Step 10: TODO: CTAP 2.1 - UV not required check
-        //spec| Step 10. If the following statements are all true:
-        // execStep10CheckUvNotRequired()
-
-        execStep11ProcessUserVerification()
         execStep12ValidateExcludeList()
-
-        // Step 13: TODO: CTAP 2.1 - set up from built-in UV
-        //spec| Step 13. If evidence of user interaction was provided as part of Step 11 (i.e., by invoking performBuiltInUv()):
-        // execStep13SetUpFromBuiltInUv()
-
+        // Step 13: built-in UV evidence sets UP — handled within Step 14 consent flow
         execStep14RequestUserConsent()
         execStep15ProcessExtensions()
         val response = execStep16to19GenerateCredentialAndAttestation()
@@ -202,11 +189,45 @@ internal class MakeCredentialExecution :
         return AuthenticatorMakeCredentialResponse(statusCode)
     }
 
+    //spec| Step 1. If authenticator supports either pinUvAuthToken or clientPin features and the platform sends a
+    //spec| zero length pinUvAuthParam:
+    //spec|   Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|   If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   If evidence of user interaction is provided in this step then return either
+    //spec|   CTAP2_ERR_PIN_NOT_SET if PIN is not set or CTAP2_ERR_PIN_INVALID if PIN has been set.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
+    private suspend fun execStep1ZeroLengthPinUvAuthParam() {
+        if (pinAuth != null && pinAuth.isEmpty()) {
+            requestUserConsent()
+            if (ctapAuthenticatorSession.isClientPINReady) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
+            }
+        }
+    }
+
+    //spec| Step 2. If the pinUvAuthParam parameter is present:
+    //spec|   If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
+    //spec|   If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
+    private fun execStep2ValidatePinUvAuthProtocol() {
+        if (pinAuth != null) {
+            if (pinProtocol == null) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+            }
+            if (ctapAuthenticatorSession.pinProtocols.none { it == pinProtocol }) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+            }
+        }
+    }
 
     //spec| Step 3. Validate pubKeyCredParams with the following steps:
-    //spec| For each element of pubKeyCredParams:
-    //spec| If the element specifies an algorithm that is supported by the authenticator, and no algorithm has yet been chosen by this loop, then let the algorithm specified by the current element be the chosen algorithm.
-    //spec| If the loop completes and no algorithm was chosen then return CTAP2_ERR_UNSUPPORTED_ALGORITHM.
+    //spec|   For each element of pubKeyCredParams:
+    //spec|     If the element specifies an algorithm that is supported by the authenticator, and no algorithm has yet been chosen by this loop, then let the algorithm specified by the current element be the chosen algorithm.
+    //spec|   If the loop completes and no algorithm was chosen then return CTAP2_ERR_UNSUPPORTED_ALGORITHM.
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep3ValidatePubKeyCredParams() {
@@ -219,6 +240,15 @@ internal class MakeCredentialExecution :
     //spec| Treat any option keys that are not understood as absent.
     //spec| Note: As this specification defines normative behaviours for the "rk", "up", and "uv" option keys,
     //spec| they MUST be understood by all authenticators.
+    //spec|   If the "uv" option is absent, let the "uv" option be treated as being present with the value false. (This is the default)
+    //spec|   If the pinUvAuthParam is present, let the "uv" option be treated as being present with the value false.
+    //spec|   If the "uv" option is true then:
+    //spec|     If the authenticator does not support a built-in user verification method end the operation by returning CTAP2_ERR_INVALID_OPTION.
+    //spec|     If the built-in user verification method has not yet been enabled, end the operation by returning CTAP2_ERR_INVALID_OPTION.
+    //spec|   If the "up" option is present then:
+    //spec|     If the "up" option is false, end the operation by returning CTAP2_ERR_INVALID_OPTION.
+    //spec|   If the "up" option is absent, let the "up" option be treated as being present with the value true
+    //spec|   (i.e., this is the default for both CTAP2.0 and CTAP2.1 authenticators).
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep5ProcessOptions() {
@@ -227,8 +257,8 @@ internal class MakeCredentialExecution :
                 residentKeyPlan = ctapAuthenticatorSession.residentKey == ResidentKeySetting.ALWAYS
             }
             else -> {
-                if(requestOptions.up == false){
-                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
+                if (requestOptions.up == false) {
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
                 }
                 residentKeyPlan = when (requestOptions.rk) {
                     true -> when (ctapAuthenticatorSession.residentKey) {
@@ -237,91 +267,187 @@ internal class MakeCredentialExecution :
                     }
                     else -> ctapAuthenticatorSession.residentKey == ResidentKeySetting.ALWAYS
                 }
-                userVerificationPlan = when (requestOptions.uv) {
-                    true -> {
-                        when (ctapAuthenticatorSession.userVerification) {
-                            UserVerificationSetting.READY -> true
-                            else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
+                userVerificationPlan = if (pinAuth != null) {
+                    false
+                } else {
+                    when (requestOptions.uv) {
+                        true -> {
+                            when (ctapAuthenticatorSession.userVerification) {
+                                UserVerificationSetting.READY -> true
+                                else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+                            }
                         }
+                        else -> false
                     }
-                    else -> false
                 }
             }
         }
         userPresencePlan = when (ctapAuthenticatorSession.userPresence) {
             UserPresenceSetting.SUPPORTED -> true
-            else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
+            else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+        }
+    }
+
+    //spec| Step 6. If the alwaysUv option ID is present and true then:
+    //spec|   Let the makeCredUvNotRqd option ID be treated as false.
+    //spec|   If the authenticator is not protected by some form of user verification:
+    //spec|     If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false
+    //spec|     (clientPin is supported for the mc permission):
+    //spec|       End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|     Else (clientPin is not supported):
+    //spec|       End the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
+    private fun execStep6ProcessAlwaysUv() {
+        if (!ctapAuthenticatorSession.alwaysUv) return
+
+        if (!isProtectedByUserVerification) {
+            if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+        }
+        if (pinAuth == null && !userVerificationPlan) {
+            if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+        }
+    }
+
+    //spec| Step 7. If the makeCredUvNotRqd option ID is present and set to true in the authenticatorGetInfo response:
+    //spec|   If the following statements are all true:
+    //spec|     The authenticator is protected by some form of user verification.
+    //spec|     The "uv" option is set to false.
+    //spec|     The pinUvAuthParam parameter is not present.
+    //spec|     The "rk" option is present and set to true.
+    //spec|   Then:
+    //spec|     If ClientPin option ID is true and the noMcGaPermissionsWithClientPin option ID is absent or false,
+    //spec|     end the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|     Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
+    private fun execStep7ProcessMakeCredUvNotRqd() {
+        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv) false else ctapAuthenticatorSession.makeCredUvNotRqd
+        if (!effectiveMakeCredUvNotRqd) return
+
+        if (isProtectedByUserVerification && !userVerificationPlan && pinAuth == null && residentKeyPlan) {
+            if (ctapAuthenticatorSession.isClientPINReady) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+        }
+    }
+
+    //spec| Step 8. Else: (the makeCredUvNotRqd option ID in authenticatorGetInfo's response is present with the value false or is absent):
+    //spec|   If the following statements are all true:
+    //spec|     The authenticator is protected by some form of user verification.
+    //spec|     The "uv" option is set to false.
+    //spec|     The pinUvAuthParam parameter is not present.
+    //spec|   Then:
+    //spec|     If the ClientPin option ID is true and the noMcGaPermissionsWithClientPin option ID is absent or false,
+    //spec|     end the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|     Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
+    private fun execStep8ProcessMakeCredUvNotRqdElse() {
+        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv) false else ctapAuthenticatorSession.makeCredUvNotRqd
+        if (effectiveMakeCredUvNotRqd) return
+
+        if (isProtectedByUserVerification && !userVerificationPlan && pinAuth == null) {
+            if (ctapAuthenticatorSession.isClientPINReady) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+        }
+    }
+
+    //spec| Step 10. If the following statements are all true:
+    //spec|   "rk" and "uv" options are both set to false or omitted.
+    //spec|   the makeCredUvNotRqd option ID in authenticatorGetInfo's response is present with the value true.
+    //spec|   the pinUvAuthParam parameter is not present.
+    //spec| Then go to Step 12.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
+    private fun execStep10CheckUvNotRequired() {
+        val effectiveMakeCredUvNotRqd = if (ctapAuthenticatorSession.alwaysUv) false else ctapAuthenticatorSession.makeCredUvNotRqd
+        if (!residentKeyPlan && !userVerificationPlan && effectiveMakeCredUvNotRqd && pinAuth == null) {
+            uvNotRequired = true
         }
     }
 
     //spec| Step 11. If the authenticator is protected by some form of user verification, then:
-    //spec| If pinUvAuthParam parameter is present (implying the "uv" option is false (see Step 5)):
-    //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
-    //spec| If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
-    //spec| If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
-    //spec| and that the authenticator supports an enabled built-in user verification method, see Step 5):
-    //
-    // This method merges the CTAP 2.0 steps 5 (pinAuth processing), 6 (clientPin validation),
-    // and 7 (pinProtocol validation) into a single user verification step aligned with CTAP 2.3.
+    //spec|   11.1 If pinUvAuthParam parameter is present (implying the "uv" option is false (see Step 5)):
+    //spec|     Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+    //spec|     If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
+    //spec|     Verify that the pinUvAuthToken has the mc permission, if not, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     If the pinUvAuthToken has a permissions RP ID associated:
+    //spec|       If the permissions RP ID does not match the rp.id in this request, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
+    //spec|     If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     If userVerifiedFlagValue is true then set the "uv" bit to true in the response.
+    //spec|     If the pinUvAuthToken does not have a permissions RP ID associated:
+    //spec|       Associate the request's rp.id parameter value with the pinUvAuthToken as its permissions RP ID.
+    //spec|     Go to Step 12.
+    //spec|   11.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
+    //spec|   and that the authenticator supports an enabled built-in user verification method, see Step 5):
+    //spec|     Let internalRetry be true.
+    //spec|     Let uvState be the result of calling performBuiltInUv(internalRetry)
+    //spec|     If uvState is error:
+    //spec|       If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+    //spec|       If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
+    //spec|       Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|     If uvState is success:
+    //spec|       Set the "uv" bit to true in the response.
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
-    private suspend fun execStep11ProcessUserVerification() {
-        // Process pinAuth (formerly CTAP 2.0 Step 5)
-        pinAuth.let {
-            if (it != null && pinProtocol != null) {
-                // Handle zero length pinAuth for authenticator selection
-                if (it.isEmpty()) {
-                    requestUserConsent()
-                    if (ctapAuthenticatorSession.isClientPINReady) {
-                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
-                    } else {
-                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
-                    }
-                } else {
-                    //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
-                    //spec| If the verification returns error, then end the operation by returning
-                    //spec| CTAP2_ERR_PIN_AUTH_INVALID error.
-                    val matchedProtocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
-                        val calculatedPinAuth = protocol.authenticate(protocol.pinUvAuthToken, clientDataHash)
-                        Arrays.equals(calculatedPinAuth, it)
-                    } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+    private fun execStep11ProcessUserVerification() {
+        if (!isProtectedByUserVerification) return
 
-                    //spec| Verify that the pinUvAuthToken has the mc permission, if not, then end the operation
-                    //spec| by returning CTAP2_ERR_PIN_AUTH_INVALID.
-                    if (matchedProtocol.tokenState.isInUse() && !matchedProtocol.tokenState.hasPermission(PinUvAuthTokenPermission.MC)) {
-                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-                    }
-                    //spec| If the pinUvAuthToken has a permissions RP ID associated:
-                    //spec| If the permissions RP ID does not match the rp.id in this request,
-                    //spec| then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
-                    val tokenRpId = matchedProtocol.tokenState.permissionsRpId
-                    if (tokenRpId != null && rpId != null && tokenRpId != rpId) {
-                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-                    }
+        // Step 11.1
+        if (pinAuth != null && pinProtocol != null) {
+            val protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
+                protocol.verify(protocol.pinUvAuthToken, clientDataHash, pinAuth)
+            } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
 
-                    if (matchedProtocol.tokenState.isInUse()) {
-                        matchedProtocol.tokenState.recordPlatformUsage()
-                    }
-
-                    userPresenceResult = true
-                    userVerificationResult = true
-                }
+            if (!protocol.tokenState.hasPermission(PinUvAuthTokenPermission.MC)) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
+
+            val tokenRpId = protocol.tokenState.permissionsRpId
+            if (tokenRpId != null && rpId != null && tokenRpId != rpId) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+            }
+
+            if (!protocol.tokenState.getUserVerifiedFlagValue()) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+            }
+
+            userVerificationResult = true
+
+            if (protocol.tokenState.permissionsRpId == null && rpId != null) {
+                protocol.tokenState.permissionsRpId = rpId
+            }
+
+            protocol.tokenState.recordPlatformUsage()
+            matchedProtocol = protocol
+            return
         }
 
-        // Validate clientPin requirement (formerly CTAP 2.0 Step 6)
-        //TODO: to be fixed to align CTAP2.1 spec.
-//        if (authenticatorMakeCredentialRequest.pinAuth == null && ctapAuthenticatorSession.isClientPINReady) {
-//            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_REQUIRED)
-//        }
+        // Step 11.2: built-in UV is handled via the consent flow in Step 14.
+        // userVerificationPlan remains true and will be processed during consent.
     }
 
     //spec| Step 12. If the excludeList parameter is present and contains a credential ID created by this authenticator,
     //spec| that is bound to the specified rp.id:
-    //spec| If the credential's credProtect value is not userVerificationRequired, then:
-    //spec| Wait for user presence.
-    //spec| Regardless of whether user presence is obtained or the authenticator times out,
-    //spec| terminate this procedure and return CTAP2_ERR_CREDENTIAL_EXCLUDED.
+    //spec|   If the credential's credProtect value is not userVerificationRequired, then:
+    //spec|     Wait for user presence.
+    //spec|     Regardless of whether user presence is obtained or the authenticator times out,
+    //spec|     terminate this procedure and return CTAP2_ERR_CREDENTIAL_EXCLUDED.
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private suspend fun execStep12ValidateExcludeList() {
@@ -372,32 +498,72 @@ internal class MakeCredentialExecution :
         }
     }
 
+    //spec| Step 13. If evidence of user interaction was provided as part of Step 11 (i.e., by invoking performBuiltInUv()):
+    //spec|   Set the "up" bit to true in the response.
+    //spec|   Go to Step 15
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
+    private fun execStep13SetUpFromBuiltInUv(): Boolean {
+        if (uvPerformedViaBuiltIn) {
+            userPresenceResult = true
+            return true
+        }
+        return false
+    }
+
     //spec| Step 14. If the "up" option is set to true:
-    //spec| If the pinUvAuthParam parameter is present then:
-    //spec| Let userPresentFlagValue be the result of calling getUserPresentFlagValue().
-    //spec| If userPresentFlagValue is false:
-    //spec| Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
-    //spec| If the authenticator has a display, show the items contained within the user and rp parameter structures to the user, and request permission to create a credential.
-    //spec| If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
-    //spec| Else (implying the pinUvAuthParam parameter is not present):
-    //spec| If the "up" bit is false in the response:
-    //spec| Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
-    //spec| If the authenticator has a display, show the items contained within the user and rp parameter structures to the user, and request permission to create a credential.
-    //spec| If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
-    //spec| Set the "up" bit to true in the response.
+    //spec|   If the pinUvAuthParam parameter is present then:
+    //spec|     Let userPresentFlagValue be the result of calling getUserPresentFlagValue().
+    //spec|     If userPresentFlagValue is false:
+    //spec|       Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|       If the authenticator has a display, show the items contained within the user and rp parameter structures to the user,
+    //spec|       and request permission to create a credential.
+    //spec|       If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   Else (implying the pinUvAuthParam parameter is not present):
+    //spec|     If the "up" bit is false in the response:
+    //spec|       Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|       If the authenticator has a display, show the items contained within the user and rp parameter structures to the user,
+    //spec|       and request permission to create a credential.
+    //spec|       If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   Set the "up" bit to true in the response.
+    //spec|   Call clearUserPresentFlag(), clearUserVerifiedFlag(), and clearPinUvAuthTokenPermissionsExceptLbw().
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private suspend fun execStep14RequestUserConsent() {
-        val consent: Boolean = requestUserConsent()
-        if (consent) {
-            if (userPresencePlan) {
-                userPresenceResult = true
+        if (userPresencePlan) {
+            var needsInteraction = false
+
+            if (pinAuth != null) {
+                val protocol = matchedProtocol
+                if (protocol != null && !protocol.tokenState.getUserPresentFlagValue()) {
+                    needsInteraction = true
+                } else if (protocol == null) {
+                    needsInteraction = true
+                }
+            } else {
+                if (!userPresenceResult) {
+                    needsInteraction = true
+                }
             }
-            if (userVerificationPlan) {
-                userVerificationResult = true
+
+            if (needsInteraction) {
+                val consent = requestUserConsent()
+                if (!consent) {
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+                }
+                if (userVerificationPlan) {
+                    userVerificationResult = true
+                }
             }
-        } else {
-            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+
+            userPresenceResult = true
+
+            // Clear cached UP/UV state
+            ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.forEach { protocol ->
+                protocol.tokenState.clearUserPresentFlag()
+                protocol.tokenState.clearUserVerifiedFlag()
+                protocol.tokenState.clearPinUvAuthTokenPermissionsExceptLbw()
+            }
         }
     }
 
@@ -414,10 +580,10 @@ internal class MakeCredentialExecution :
     }
 
     //spec| Step 15. If the extensions parameter is present:
-    //spec| Process any extensions that this authenticator supports, ignoring any that it does not support.
-    //spec| Authenticator extension outputs generated by the authenticator extension processing
-    //spec| are returned in the authenticator data.
-    //spec| The set of keys in the authenticator extension outputs map MUST be equal to, or a subset of, the keys of the authenticator extension inputs map.
+    //spec|   Process any extensions that this authenticator supports, ignoring any that it does not support.
+    //spec|   Authenticator extension outputs generated by the authenticator extension processing
+    //spec|   are returned in the authenticator data.
+    //spec|   The set of keys in the authenticator extension outputs map MUST be equal to, or a subset of, the keys of the authenticator extension inputs map.
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep15ProcessExtensions() {
@@ -436,14 +602,14 @@ internal class MakeCredentialExecution :
 
     //spec| Step 16. Generate a new credential key pair for the algorithm chosen in step 3.
     //spec| Step 17. If the "rk" option is set to true:
-    //spec| The authenticator MUST create a discoverable credential.
-    //spec| If a credential for the same rp.id and account ID already exists on the authenticator:
-    //spec| Overwrite that credential.
-    //spec| Store the user parameter along with the newly-created key pair.
-    //spec| If authenticator does not have enough internal storage to persist the new credential, return CTAP2_ERR_KEY_STORE_FULL.
+    //spec|   The authenticator MUST create a discoverable credential.
+    //spec|   If a credential for the same rp.id and account ID already exists on the authenticator:
+    //spec|     Overwrite that credential.
+    //spec|   Store the user parameter along with the newly-created key pair.
+    //spec|   If authenticator does not have enough internal storage to persist the new credential, return CTAP2_ERR_KEY_STORE_FULL.
     //spec| Step 18. Otherwise, if the "rk" option is false: the authenticator MUST create a non-discoverable credential.
     //spec| Step 19. If the authenticator doesn't support multiple attestation formats or the attestationFormatsPreference is absent or its value is the empty list,
-    //spec| generate an attestation statement for the newly-created credential using clientDataHash.
+    //spec|   generate an attestation statement for the newly-created credential using clientDataHash.
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private suspend fun execStep16to19GenerateCredentialAndAttestation(): AuthenticatorMakeCredentialResponse {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -199,7 +199,11 @@ internal class MakeCredentialExecution :
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private suspend fun execStep1ZeroLengthPinUvAuthParam() {
         if (pinAuth != null && pinAuth.isEmpty()) {
+            //spec| Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+            //spec| If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
             requestUserConsent()
+            //spec| If evidence of user interaction is provided in this step then return either
+            //spec| CTAP2_ERR_PIN_NOT_SET if PIN is not set or CTAP2_ERR_PIN_INVALID if PIN has been set.
             if (ctapAuthenticatorSession.isClientPINReady) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
             } else {
@@ -215,9 +219,11 @@ internal class MakeCredentialExecution :
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private fun execStep2ValidatePinUvAuthProtocol() {
         if (pinAuth != null) {
+            //spec| If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
             if (pinProtocol == null) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
             }
+            //spec| If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
             if (ctapAuthenticatorSession.pinProtocols.none { it == pinProtocol }) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
             }
@@ -254,9 +260,12 @@ internal class MakeCredentialExecution :
     private fun execStep5ProcessOptions() {
         when (val requestOptions = options) {
             null -> {
+                //spec| If the "rk" option is absent, let the "rk" option be treated as being present with the value false. (This is the default.)
                 residentKeyPlan = ctapAuthenticatorSession.residentKey == ResidentKeySetting.ALWAYS
             }
             else -> {
+                //spec| If the "up" option is present then:
+                //spec|   If the "up" option is false, end the operation by returning CTAP2_ERR_INVALID_OPTION.
                 if (requestOptions.up == false) {
                     throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
                 }
@@ -267,21 +276,28 @@ internal class MakeCredentialExecution :
                     }
                     else -> ctapAuthenticatorSession.residentKey == ResidentKeySetting.ALWAYS
                 }
+                //spec| If the pinUvAuthParam is present, let the "uv" option be treated as being present with the value false.
                 userVerificationPlan = if (pinAuth != null) {
                     false
                 } else {
                     when (requestOptions.uv) {
+                        //spec| If the "uv" option is true then:
+                        //spec|   If the authenticator does not support a built-in user verification method end the operation by returning CTAP2_ERR_INVALID_OPTION.
+                        //spec|   If the built-in user verification method has not yet been enabled, end the operation by returning CTAP2_ERR_INVALID_OPTION.
                         true -> {
                             when (ctapAuthenticatorSession.userVerification) {
                                 UserVerificationSetting.READY -> true
                                 else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
                             }
                         }
+                        //spec| If the "uv" option is absent, let the "uv" option be treated as being present with the value false. (This is the default)
                         else -> false
                     }
                 }
             }
         }
+        //spec| If the "up" option is absent, let the "up" option be treated as being present with the value true
+        //spec| (i.e., this is the default for both CTAP2.0 and CTAP2.1 authenticators).
         userPresencePlan = when (ctapAuthenticatorSession.userPresence) {
             UserPresenceSetting.SUPPORTED -> true
             else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
@@ -301,13 +317,20 @@ internal class MakeCredentialExecution :
     private fun execStep6ProcessAlwaysUv() {
         if (!ctapAuthenticatorSession.alwaysUv) return
 
+        //spec| Let the makeCredUvNotRqd option ID be treated as false.
+        //spec| If the authenticator is not protected by some form of user verification:
         if (!isProtectedByUserVerification) {
+            //spec| If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false:
+            //spec|   End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+            //spec| Else (clientPin is not supported):
+            //spec|   End the operation by returning CTAP2_ERR_OPERATION_DENIED.
             if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
             } else {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
             }
         }
+        //spec| If the pinUvAuthParam is not present, and the "uv" option is false or absent:
         if (pinAuth == null && !userVerificationPlan) {
             if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
@@ -408,37 +431,50 @@ internal class MakeCredentialExecution :
     private fun execStep11ProcessUserVerification() {
         if (!isProtectedByUserVerification) return
 
-        // Step 11.1
+        //spec| 11.1 If pinUvAuthParam parameter is present (implying the "uv" option is false (see Step 5)):
         if (pinAuth != null && pinProtocol != null) {
+            //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+            //spec| If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
             val protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
                 protocol.verify(protocol.pinUvAuthToken, clientDataHash, pinAuth)
             } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
 
+            //spec| Verify that the pinUvAuthToken has the mc permission, if not, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
             if (!protocol.tokenState.hasPermission(PinUvAuthTokenPermission.MC)) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
 
+            //spec| If the pinUvAuthToken has a permissions RP ID associated:
+            //spec|   If the permissions RP ID does not match the rp.id in this request, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
             val tokenRpId = protocol.tokenState.permissionsRpId
             if (tokenRpId != null && rpId != null && tokenRpId != rpId) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
 
+            //spec| Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
+            //spec| If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
             if (!protocol.tokenState.getUserVerifiedFlagValue()) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
             }
 
+            //spec| If userVerifiedFlagValue is true then set the "uv" bit to true in the response.
             userVerificationResult = true
 
+            //spec| If the pinUvAuthToken does not have a permissions RP ID associated:
+            //spec|   Associate the request's rp.id parameter value with the pinUvAuthToken as its permissions RP ID.
             if (protocol.tokenState.permissionsRpId == null && rpId != null) {
                 protocol.tokenState.permissionsRpId = rpId
             }
 
             protocol.tokenState.recordPlatformUsage()
             matchedProtocol = protocol
+            //spec| Go to Step 12.
             return
         }
 
-        // Step 11.2: built-in UV is handled via the consent flow in Step 14.
+        //spec| 11.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
+        //spec| and that the authenticator supports an enabled built-in user verification method, see Step 5):
+        // Built-in UV is handled via the consent flow in Step 14.
         // userVerificationPlan remains true and will be processed during consent.
     }
 
@@ -533,7 +569,10 @@ internal class MakeCredentialExecution :
         if (userPresencePlan) {
             var needsInteraction = false
 
+            //spec| If the pinUvAuthParam parameter is present then:
             if (pinAuth != null) {
+                //spec| Let userPresentFlagValue be the result of calling getUserPresentFlagValue().
+                //spec| If userPresentFlagValue is false:
                 val protocol = matchedProtocol
                 if (protocol != null && !protocol.tokenState.getUserPresentFlagValue()) {
                     needsInteraction = true
@@ -541,12 +580,16 @@ internal class MakeCredentialExecution :
                     needsInteraction = true
                 }
             } else {
+                //spec| Else (implying the pinUvAuthParam parameter is not present):
+                //spec|   If the "up" bit is false in the response:
                 if (!userPresenceResult) {
                     needsInteraction = true
                 }
             }
 
             if (needsInteraction) {
+                //spec| Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+                //spec| If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
                 val consent = requestUserConsent()
                 if (!consent) {
                     throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
@@ -556,9 +599,10 @@ internal class MakeCredentialExecution :
                 }
             }
 
+            //spec| Set the "up" bit to true in the response.
             userPresenceResult = true
 
-            // Clear cached UP/UV state
+            //spec| Call clearUserPresentFlag(), clearUserVerifiedFlag(), and clearPinUvAuthTokenPermissionsExceptLbw().
             ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.forEach { protocol ->
                 protocol.tokenState.clearUserPresentFlag()
                 protocol.tokenState.clearUserVerifiedFlag()

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
@@ -199,7 +199,7 @@ internal class GetAssertionExecutionTest {
     @CsvSource(
         value = [
             "true, SUPPORTED, CTAP2_OK",
-            "true, NOT_SUPPORTED, CTAP2_ERR_UNSUPPORTED_OPTION",
+            "true, NOT_SUPPORTED, CTAP2_ERR_INVALID_OPTION",
             "false, SUPPORTED, CTAP2_OK",
             "false, NOT_SUPPORTED, CTAP2_OK",
         ]
@@ -242,8 +242,8 @@ internal class GetAssertionExecutionTest {
     @CsvSource(
         value = [
             "true, READY, CTAP2_OK",
-            "true, NOT_READY, CTAP2_ERR_UNSUPPORTED_OPTION",
-            "true, NOT_SUPPORTED, CTAP2_ERR_UNSUPPORTED_OPTION",
+            "true, NOT_READY, CTAP2_ERR_INVALID_OPTION",
+            "true, NOT_SUPPORTED, CTAP2_ERR_INVALID_OPTION",
             "false, READY, CTAP2_OK",
             "false, NOT_READY, CTAP2_OK",
             "false, NOT_SUPPORTED, CTAP2_OK",
@@ -255,9 +255,11 @@ internal class GetAssertionExecutionTest {
         statusCode: CtapStatusCode
     ) = runTest {
         val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.userVerification = userVerificationSetting
         val connection = ctapAuthenticator.createSession()
-        makeCredential(connection, uv = false)
+        makeCredential(connection)
+
+        ctapAuthenticator.userVerification = userVerificationSetting
+        val connectionWithUpdatedSetting = ctapAuthenticator.createSession()
 
         val clientDataHash = ByteArray(0)
         val allowList: List<PublicKeyCredentialDescriptor> = emptyList()
@@ -275,7 +277,7 @@ internal class GetAssertionExecutionTest {
             pinAuth,
             pinProtocol
         )
-        val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
+        val response: AuthenticatorGetAssertionResponse = connectionWithUpdatedSetting.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(statusCode)
     }
 

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
@@ -1,5 +1,6 @@
 package com.webauthn4j.ctap.authenticator
 
+import com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
@@ -155,7 +156,7 @@ internal class MakeCredentialExecutionTest {
 
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.residentKey = residentKeySetting
-        ctapAuthenticator.makeCredUvNotRqd = true
+        ctapAuthenticator.makeCredUvNotRqd = MakeCredUvNotRqdSetting.ENABLED
         ctapAuthenticator.userVerification = UserVerificationSetting.NOT_SUPPORTED
         ctapAuthenticator.clientPIN = com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting.DISABLED
         val connection = ctapAuthenticator.createSession()

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
@@ -155,6 +155,9 @@ internal class MakeCredentialExecutionTest {
 
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.residentKey = residentKeySetting
+        ctapAuthenticator.makeCredUvNotRqd = true
+        ctapAuthenticator.userVerification = UserVerificationSetting.NOT_SUPPORTED
+        ctapAuthenticator.clientPIN = com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting.DISABLED
         val connection = ctapAuthenticator.createSession()
 
         val response = connection.makeCredential(command)
@@ -225,9 +228,9 @@ internal class MakeCredentialExecutionTest {
     @CsvSource(
         value = [
             "true, READY, CTAP2_OK",
-            "true, NOT_READY, CTAP2_ERR_UNSUPPORTED_OPTION",
-            "true, NOT_SUPPORTED, CTAP2_ERR_UNSUPPORTED_OPTION",
-            "false, READY, CTAP2_OK",
+            "true, NOT_READY, CTAP2_ERR_INVALID_OPTION",
+            "true, NOT_SUPPORTED, CTAP2_ERR_INVALID_OPTION",
+            "false, READY, CTAP2_ERR_OPERATION_DENIED",
             "false, NOT_READY, CTAP2_OK",
             "false, NOT_SUPPORTED, CTAP2_OK",
         ]
@@ -278,7 +281,7 @@ internal class MakeCredentialExecutionTest {
     @CsvSource(
         value = [
             "SUPPORTED, CTAP2_OK",
-            "NOT_SUPPORTED, CTAP2_ERR_UNSUPPORTED_OPTION",
+            "NOT_SUPPORTED, CTAP2_ERR_INVALID_OPTION",
         ]
     )
     fun userPresence_test(userPresenceSetting: UserPresenceSetting, statusCode: CtapStatusCode) =
@@ -295,7 +298,7 @@ internal class MakeCredentialExecutionTest {
             val excludeList: List<PublicKeyCredentialDescriptor> = emptyList()
             val extensions =
                 AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
-            val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = false)
+            val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = true)
             val pinAuth: ByteArray? = null
             val pinProtocol: PinProtocolVersion? = null
             val command = AuthenticatorMakeCredentialRequest(

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
@@ -10,5 +10,7 @@ class AuthenticatorGetInfoResponseDataOptionsSerializer :
             FieldSerializationRule("up") { it.up?.value },
             FieldSerializationRule("uv") { it.uv?.value },
             FieldSerializationRule("plat") { it.plat?.value },
-            FieldSerializationRule("clientPin") { it.clientPin?.value }
+            FieldSerializationRule("clientPin") { it.clientPin?.value },
+            FieldSerializationRule("alwaysUv") { it.alwaysUv },
+            FieldSerializationRule("makeCredUvNotRqd") { it.makeCredUvNotRqd }
         ))

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
@@ -11,6 +11,6 @@ class AuthenticatorGetInfoResponseDataOptionsSerializer :
             FieldSerializationRule("uv") { it.uv?.value },
             FieldSerializationRule("plat") { it.plat?.value },
             FieldSerializationRule("clientPin") { it.clientPin?.value },
-            FieldSerializationRule("alwaysUv") { it.alwaysUv },
-            FieldSerializationRule("makeCredUvNotRqd") { it.makeCredUvNotRqd }
+            FieldSerializationRule("alwaysUv") { it.alwaysUv?.value },
+            FieldSerializationRule("makeCredUvNotRqd") { it.makeCredUvNotRqd?.value }
         ))

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
@@ -112,12 +112,12 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
         @param:JsonProperty("clientPin") val clientPin: ClientPINOption?,
         @param:JsonProperty("up") val up: UserPresenceOption?,
         @param:JsonProperty("uv") val uv: UserVerificationOption?,
-        @param:JsonProperty("alwaysUv") val alwaysUv: Boolean? = null,
-        @param:JsonProperty("makeCredUvNotRqd") val makeCredUvNotRqd: Boolean? = null
+        @param:JsonProperty("alwaysUv") val alwaysUv: AlwaysUvOption? = null,
+        @param:JsonProperty("makeCredUvNotRqd") val makeCredUvNotRqd: MakeCredUvNotRqdOption? = null
     ) {
 
         override fun toString(): String {
-            return "Options(plat=${plat?.value}, rk=${rk?.value}, clientPin=${clientPin?.value}, up=${up?.value}, uv=${uv?.value}, alwaysUv=$alwaysUv, makeCredUvNotRqd=$makeCredUvNotRqd)"
+            return "Options(plat=${plat?.value}, rk=${rk?.value}, clientPin=${clientPin?.value}, up=${up?.value}, uv=${uv?.value}, alwaysUv=${alwaysUv?.value}, makeCredUvNotRqd=${makeCredUvNotRqd?.value})"
         }
 
         override fun equals(other: Any?): Boolean {

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
@@ -111,11 +111,13 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
         @param:JsonProperty("rk") val rk: ResidentKeyOption?,
         @param:JsonProperty("clientPin") val clientPin: ClientPINOption?,
         @param:JsonProperty("up") val up: UserPresenceOption?,
-        @param:JsonProperty("uv") val uv: UserVerificationOption?
+        @param:JsonProperty("uv") val uv: UserVerificationOption?,
+        @param:JsonProperty("alwaysUv") val alwaysUv: Boolean? = null,
+        @param:JsonProperty("makeCredUvNotRqd") val makeCredUvNotRqd: Boolean? = null
     ) {
 
         override fun toString(): String {
-            return "Options(plat=${plat?.value}, rk=${rk?.value}, clientPin=${clientPin?.value}, up=${up?.value}, uv=${uv?.value})"
+            return "Options(plat=${plat?.value}, rk=${rk?.value}, clientPin=${clientPin?.value}, up=${up?.value}, uv=${uv?.value}, alwaysUv=$alwaysUv, makeCredUvNotRqd=$makeCredUvNotRqd)"
         }
 
         override fun equals(other: Any?): Boolean {
@@ -129,6 +131,8 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
             if (clientPin != other.clientPin) return false
             if (up != other.up) return false
             if (uv != other.uv) return false
+            if (alwaysUv != other.alwaysUv) return false
+            if (makeCredUvNotRqd != other.makeCredUvNotRqd) return false
 
             return true
         }
@@ -139,6 +143,8 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
             result = 31 * result + (clientPin?.hashCode() ?: 0)
             result = 31 * result + (up?.hashCode() ?: 0)
             result = 31 * result + (uv?.hashCode() ?: 0)
+            result = 31 * result + (alwaysUv?.hashCode() ?: 0)
+            result = 31 * result + (makeCredUvNotRqd?.hashCode() ?: 0)
             return result
         }
 

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapStatusCode.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapStatusCode.kt
@@ -50,6 +50,7 @@ class CtapStatusCode(private val value: Byte) {
         val CTAP2_ERR_ACTION_TIMEOUT = CtapStatusCode(0x3A)
         val CTAP2_ERR_UP_REQUIRED = CtapStatusCode(0x3B)
         val CTAP2_ERR_UV_BLOCKED = CtapStatusCode(0x3C)
+        val CTAP2_ERR_PUAT_REQUIRED = CtapStatusCode(0x3D)
         val CTAP2_ERR_UV_INVALID = CtapStatusCode(0x3F)
         val CTAP2_ERR_UNAUTHORIZED_PERMISSION = CtapStatusCode(0x40)
         val CTAP1_ERR_OTHER = CtapStatusCode(0x7F)
@@ -100,6 +101,7 @@ class CtapStatusCode(private val value: Byte) {
             tmp[CTAP2_ERR_ACTION_TIMEOUT] = "CTAP2_ERR_ACTION_TIMEOUT"
             tmp[CTAP2_ERR_UP_REQUIRED] = "CTAP2_ERR_UP_REQUIRED"
             tmp[CTAP2_ERR_UV_BLOCKED] = "CTAP2_ERR_UV_BLOCKED"
+            tmp[CTAP2_ERR_PUAT_REQUIRED] = "CTAP2_ERR_PUAT_REQUIRED"
             tmp[CTAP2_ERR_UV_INVALID] = "CTAP2_ERR_UV_INVALID"
             tmp[CTAP2_ERR_UNAUTHORIZED_PERMISSION] = "CTAP2_ERR_UNAUTHORIZED_PERMISSION"
             tmp[CTAP1_ERR_OTHER] = "CTAP1_ERR_OTHER"
@@ -152,6 +154,7 @@ class CtapStatusCode(private val value: Byte) {
                 "CTAP2_ERR_ACTION_TIMEOUT" -> CTAP2_ERR_ACTION_TIMEOUT
                 "CTAP2_ERR_UP_REQUIRED" -> CTAP2_ERR_UP_REQUIRED
                 "CTAP2_ERR_UV_BLOCKED" -> CTAP2_ERR_UV_BLOCKED
+                "CTAP2_ERR_PUAT_REQUIRED" -> CTAP2_ERR_PUAT_REQUIRED
                 "CTAP2_ERR_UV_INVALID" -> CTAP2_ERR_UV_INVALID
                 "CTAP2_ERR_UNAUTHORIZED_PERMISSION" -> CTAP2_ERR_UNAUTHORIZED_PERMISSION
                 "CTAP1_ERR_OTHER" -> CTAP1_ERR_OTHER

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/AlwaysUvOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/AlwaysUvOption.kt
@@ -1,0 +1,28 @@
+package com.webauthn4j.ctap.core.data.options
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class AlwaysUvOption constructor(@get:JsonValue val value: Boolean) {
+
+    companion object {
+        @JvmField
+        val ENABLED = AlwaysUvOption(true)
+
+        @JvmField
+        val DISABLED = AlwaysUvOption(false)
+
+        @JvmField
+        val NULL: AlwaysUvOption? = null
+
+        @JvmStatic
+        @JsonCreator
+        fun create(value: Boolean?): AlwaysUvOption? {
+            return when {
+                value == null -> NULL
+                value -> ENABLED
+                else -> DISABLED
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/MakeCredUvNotRqdOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/MakeCredUvNotRqdOption.kt
@@ -1,0 +1,28 @@
+package com.webauthn4j.ctap.core.data.options
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class MakeCredUvNotRqdOption constructor(@get:JsonValue val value: Boolean) {
+
+    companion object {
+        @JvmField
+        val ENABLED = MakeCredUvNotRqdOption(true)
+
+        @JvmField
+        val DISABLED = MakeCredUvNotRqdOption(false)
+
+        @JvmField
+        val NULL: MakeCredUvNotRqdOption? = null
+
+        @JvmStatic
+        @JsonCreator
+        fun create(value: Boolean?): MakeCredUvNotRqdOption? {
+            return when {
+                value == null -> NULL
+                value -> ENABLED
+                else -> DISABLED
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorSecondFactorUseCaseTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorSecondFactorUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
 import com.webauthn4j.ctap.client.exception.UPNotSupportedException
+import com.webauthn4j.data.UserVerificationRequirement
 import integration.usecase.testcase.SecondFactorTestCase
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
@@ -21,6 +22,9 @@ internal class AuthenticatorSecondFactorUseCaseTest {
         @Test
         fun residentKey_always_test() = runTest {
             secondFactorTestCase.authenticator.residentKeySetting = ResidentKeySetting.ALWAYS
+            secondFactorTestCase.relyingParty.registration.frontend.userVerification =
+                UserVerificationRequirement.REQUIRED
+            secondFactorTestCase.relyingParty.registration.backend.userVerificationRequired = true
             secondFactorTestCase.run()
         }
 

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
@@ -115,6 +115,7 @@ abstract class IntegrationTestCaseBase {
             ctapAuthenticator.userPresence = userPresenceSetting
             ctapAuthenticator.userVerification = userVerificationSetting
             ctapAuthenticator.credentialSelector = credentialSelectorSetting
+            ctapAuthenticator.makeCredUvNotRqd = true
 
             return@TestParameter ctapAuthenticator
         }.depends(

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
@@ -115,7 +115,7 @@ abstract class IntegrationTestCaseBase {
             ctapAuthenticator.userPresence = userPresenceSetting
             ctapAuthenticator.userVerification = userVerificationSetting
             ctapAuthenticator.credentialSelector = credentialSelectorSetting
-            ctapAuthenticator.makeCredUvNotRqd = true
+            ctapAuthenticator.makeCredUvNotRqd = com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting.ENABLED
 
             return@TestParameter ctapAuthenticator
         }.depends(

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/SecondFactorTestCase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/SecondFactorTestCase.kt
@@ -8,6 +8,7 @@ import com.webauthn4j.data.PublicKeyCredentialDescriptor
 import com.webauthn4j.data.PublicKeyCredentialType
 import com.webauthn4j.data.RegistrationParameters
 import com.webauthn4j.data.RegistrationRequest
+import com.webauthn4j.data.ResidentKeyRequirement
 import com.webauthn4j.data.UserVerificationRequirement
 import org.junit.jupiter.api.fail
 
@@ -15,6 +16,7 @@ class SecondFactorTestCase : IntegrationTestCaseBase() {
 
     init {
         relyingParty.registration.frontend.requireResidentKey = false
+        relyingParty.registration.frontend.residentKey = ResidentKeyRequirement.DISCOURAGED
         relyingParty.registration.frontend.userVerification =
             UserVerificationRequirement.DISCOURAGED
         relyingParty.registration.backend.userVerificationRequired = false


### PR DESCRIPTION
## Summary

- Implement missing UP/UV processing steps in MakeCredential (§6.1.2) and GetAssertion (§6.2.2) per CTAP 2.3 specification
- Add `alwaysUv` and `makeCredUvNotRqd` authenticator options with GetInfo response support
- Add `CTAP2_ERR_PUAT_REQUIRED` (0x3D) status code
- Enforce UV requirements: discoverable credentials now require user verification when the authenticator is protected
- Add `getUserVerifiedFlagValue()` check and permissions RP ID auto-binding in pinUvAuthParam verification
- Call `clearUserPresentFlag()`, `clearUserVerifiedFlag()`, and `clearPinUvAuthTokenPermissionsExceptLbw()` after user presence test
- All spec comments (`//spec|`) are verbatim quotes from the CTAP 2.3 specification