### PR TITLE
Add alwaysUv and makeCredUvNotRqd options infrastructure

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -9,7 +9,9 @@ import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FAttestationStatement
 import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FBasicAttestationStatementProvider
 import com.webauthn4j.ctap.authenticator.attestation.NoneAttestationStatementProvider
 import com.webauthn4j.ctap.authenticator.data.credential.Credential
+import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
+import com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.data.settings.AttachmentSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResetProtectionSetting
@@ -105,6 +107,8 @@ class CtapAuthenticator(
     var resetProtection: ResetProtectionSetting = ResetProtectionSetting.DISABLED
     var userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED
     var userVerification: UserVerificationSetting = UserVerificationSetting.READY
+    var alwaysUv: AlwaysUvSetting = AlwaysUvSetting.DISABLED
+    var makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.DISABLED
     var credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.AUTHENTICATOR
 
     fun createSession(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -77,6 +77,8 @@ class CtapAuthenticatorSession internal constructor(
     val credentialSelector: CredentialSelectorSetting = ctapAuthenticator.credentialSelector
     val userPresence: UserPresenceSetting = ctapAuthenticator.userPresence
     val userVerification: UserVerificationSetting = ctapAuthenticator.userVerification
+    val alwaysUv: AlwaysUvSetting = ctapAuthenticator.alwaysUv
+    val makeCredUvNotRqd: MakeCredUvNotRqdSetting = ctapAuthenticator.makeCredUvNotRqd
 
     // Authenticator properties
     val aaguid: AAGUID = ctapAuthenticator.aaguid

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
@@ -1,16 +1,15 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
-enum class AlwaysUvSetting(val value: String) {
-    ENABLED("enabled"),
-    DISABLED("disabled");
+enum class AlwaysUvSetting(val value: Boolean) {
+    ENABLED(true),
+    DISABLED(false);
 
     companion object {
         @JvmStatic
-        fun create(value: String): AlwaysUvSetting {
-            return when (value) {
-                "enabled" -> ENABLED
-                "disabled" -> DISABLED
-                else -> throw IllegalArgumentException("value '$value' is out of range")
+        fun create(value: Boolean): AlwaysUvSetting {
+            return when {
+                value -> ENABLED
+                else -> DISABLED
             }
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
@@ -1,0 +1,17 @@
+package com.webauthn4j.ctap.authenticator.data.settings
+
+enum class AlwaysUvSetting(val value: String) {
+    ENABLED("enabled"),
+    DISABLED("disabled");
+
+    companion object {
+        @JvmStatic
+        fun create(value: String): AlwaysUvSetting {
+            return when (value) {
+                "enabled" -> ENABLED
+                "disabled" -> DISABLED
+                else -> throw IllegalArgumentException("value '$value' is out of range")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AlwaysUvSetting.kt
@@ -1,7 +1,18 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls the alwaysUv option reported in authenticatorGetInfo.
+ *
+ * When [ENABLED], the authenticator requires user verification for every
+ * MakeCredential and GetAssertion operation, regardless of the RP's request.
+ * The makeCredUvNotRqd option is treated as false when alwaysUv is enabled.
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-feature-descriptions-alwaysUv">CTAP 2.3 §6.1.2 Step 6, §6.2.2 Step 5</a>
+ */
 enum class AlwaysUvSetting(val value: Boolean) {
+    /** Every operation requires user verification. */
     ENABLED(true),
+    /** User verification is required only when requested by the RP or platform. */
     DISABLED(false);
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AttachmentSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AttachmentSetting.kt
@@ -2,8 +2,16 @@ package com.webauthn4j.ctap.authenticator.data.settings
 
 import com.webauthn4j.data.AuthenticatorAttachment
 
+/**
+ * Controls the plat option reported in authenticatorGetInfo.
+ *
+ * Indicates whether the authenticator is a platform authenticator (built into the client device)
+ * or a roaming (cross-platform) authenticator.
+ */
 enum class AttachmentSetting(val value: String) {
+    /** The authenticator is built into the client device and cannot be removed. */
     PLATFORM("platform"),
+    /** The authenticator is an external roaming device (e.g., USB security key). */
     CROSS_PLATFORM("cross-platform");
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AttestationStatementFormatSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AttestationStatementFormatSetting.kt
@@ -2,6 +2,9 @@ package com.webauthn4j.ctap.authenticator.data.settings
 
 import com.fasterxml.jackson.annotation.JsonValue
 
+/**
+ * Controls which attestation statement format the authenticator uses when generating attestation objects.
+ */
 enum class AttestationStatementFormatSetting(@get:JsonValue val value: String) {
     COMPOUND("compound"),
     ANDROID_KEY("android-key"),

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AttestationTypeSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/AttestationTypeSetting.kt
@@ -3,9 +3,15 @@ package com.webauthn4j.ctap.authenticator.data.settings
 import com.fasterxml.jackson.annotation.JsonValue
 import com.webauthn4j.data.attestation.statement.AttestationType
 
+/**
+ * Controls the type of attestation the authenticator provides during credential creation.
+ */
 enum class AttestationTypeSetting(@get:JsonValue val value: String) {
+    /** Attestation signed by a manufacturer-provisioned attestation key. */
     BASIC("basic"),
+    /** Self-attestation: the credential key signs its own attestation statement. */
     SELF("self"),
+    /** No attestation is provided. */
     NONE("none");
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ClientPINSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ClientPINSetting.kt
@@ -1,7 +1,16 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls whether the authenticator supports the clientPin feature.
+ *
+ * When [ENABLED], the authenticator accepts PIN operations (set, change, getPinToken, etc.).
+ * The clientPin option in authenticatorGetInfo reports true/false depending on whether a PIN
+ * has actually been configured. When [DISABLED], clientPin is absent from authenticatorGetInfo.
+ */
 enum class ClientPINSetting(val value: String) {
+    /** The authenticator supports the clientPin feature. */
     ENABLED("enabled"),
+    /** The authenticator does not support the clientPin feature. */
     DISABLED("disabled");
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ConsentCachingSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ConsentCachingSetting.kt
@@ -1,7 +1,15 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls whether the authenticator caches user consent across operations.
+ *
+ * When [ENABLED], a previously granted consent may be reused for subsequent operations
+ * without prompting the user again, within the consent validity period.
+ */
 enum class ConsentCachingSetting(val value: Boolean) {
+    /** User consent is cached and may be reused. */
     ENABLED(true),
+    /** Each operation requires fresh user consent. */
     DISABLED(false);
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/CredentialSelectorSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/CredentialSelectorSetting.kt
@@ -1,7 +1,15 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls which entity selects a credential when multiple credentials match a GetAssertion request.
+ *
+ * When [AUTHENTICATOR], the authenticator's display is used to let the user pick a credential.
+ * When [CLIENT_PLATFORM], the full credential list is returned to the platform for selection.
+ */
 enum class CredentialSelectorSetting(val value: String) {
+    /** The authenticator prompts the user to select a credential on its own display. */
     AUTHENTICATOR("authenticator"),
+    /** The platform handles credential selection via authenticatorGetNextAssertion. */
     CLIENT_PLATFORM("client-platform");
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
@@ -1,7 +1,18 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls the makeCredUvNotRqd option reported in authenticatorGetInfo.
+ *
+ * When [ENABLED], the authenticator allows creating non-discoverable credentials
+ * without user verification. Discoverable credentials (rk=true) still require UV.
+ * This option is overridden to false when alwaysUv is enabled.
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-feature-descriptions-makeCredUvNotRqd">CTAP 2.3 §6.1.2 Steps 7, 8, 10</a>
+ */
 enum class MakeCredUvNotRqdSetting(val value: Boolean) {
+    /** Non-discoverable credentials can be created without user verification. */
     ENABLED(true),
+    /** All credentials require user verification when the authenticator is protected. */
     DISABLED(false);
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
@@ -1,16 +1,15 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
-enum class MakeCredUvNotRqdSetting(val value: String) {
-    ENABLED("enabled"),
-    DISABLED("disabled");
+enum class MakeCredUvNotRqdSetting(val value: Boolean) {
+    ENABLED(true),
+    DISABLED(false);
 
     companion object {
         @JvmStatic
-        fun create(value: String): MakeCredUvNotRqdSetting {
-            return when (value) {
-                "enabled" -> ENABLED
-                "disabled" -> DISABLED
-                else -> throw IllegalArgumentException("value '$value' is out of range")
+        fun create(value: Boolean): MakeCredUvNotRqdSetting {
+            return when {
+                value -> ENABLED
+                else -> DISABLED
             }
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
@@ -1,0 +1,17 @@
+package com.webauthn4j.ctap.authenticator.data.settings
+
+enum class MakeCredUvNotRqdSetting(val value: String) {
+    ENABLED("enabled"),
+    DISABLED("disabled");
+
+    companion object {
+        @JvmStatic
+        fun create(value: String): MakeCredUvNotRqdSetting {
+            return when (value) {
+                "enabled" -> ENABLED
+                "disabled" -> DISABLED
+                else -> throw IllegalArgumentException("value '$value' is out of range")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ResetProtectionSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ResetProtectionSetting.kt
@@ -1,15 +1,15 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
 /**
- * Controls whether the authenticator restricts the authenticatorReset command.
+ * Controls whether the authenticator allows the authenticatorReset command.
  *
- * When [ENABLED], reset is only allowed within a limited time window after power-up,
- * preventing accidental or unauthorized erasure of credentials.
+ * When [ENABLED], the authenticator always rejects reset requests with CTAP2_ERR_OPERATION_DENIED.
+ * When [DISABLED], reset clears all stored credentials and state.
  */
 enum class ResetProtectionSetting(val value: Boolean) {
-    /** Reset is restricted to a time window after power-up. */
+    /** Reset is always rejected. */
     ENABLED(true),
-    /** Reset is allowed at any time. */
+    /** Reset is allowed. */
     DISABLED(false);
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ResetProtectionSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ResetProtectionSetting.kt
@@ -1,7 +1,15 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls whether the authenticator restricts the authenticatorReset command.
+ *
+ * When [ENABLED], reset is only allowed within a limited time window after power-up,
+ * preventing accidental or unauthorized erasure of credentials.
+ */
 enum class ResetProtectionSetting(val value: Boolean) {
+    /** Reset is restricted to a time window after power-up. */
     ENABLED(true),
+    /** Reset is allowed at any time. */
     DISABLED(false);
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ResidentKeySetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/ResidentKeySetting.kt
@@ -1,19 +1,17 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls how the authenticator handles discoverable (resident) credential storage.
+ *
+ * Maps to the rk option in authenticatorGetInfo. [ALWAYS] and [IF_REQUIRED] report rk=true;
+ * [NEVER] reports rk=false.
+ */
 enum class ResidentKeySetting(val value: String) {
-    /**
-     * Always save as resident-key
-     */
+    /** Always create discoverable credentials, even if the RP does not request rk=true. */
     ALWAYS("always"),
-
-    /**
-     * If required, save as resident-key
-     */
+    /** Create discoverable credentials only when the RP requests rk=true. */
     IF_REQUIRED("if-required"),
-
-    /**
-     * Never save as resident-key
-     */
+    /** Never create discoverable credentials; rk=true requests are rejected. */
     NEVER("never");
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/UserPresenceSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/UserPresenceSetting.kt
@@ -1,7 +1,14 @@
 package com.webauthn4j.ctap.authenticator.data.settings
 
+/**
+ * Controls the up option reported in authenticatorGetInfo.
+ *
+ * Indicates whether the authenticator can test user presence (e.g., button press, touch).
+ */
 enum class UserPresenceSetting(val value: String) {
+    /** The authenticator supports user presence testing. */
     SUPPORTED("supported"),
+    /** The authenticator does not support user presence testing. */
     NOT_SUPPORTED("not-supported");
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/UserVerificationSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/UserVerificationSetting.kt
@@ -2,9 +2,18 @@ package com.webauthn4j.ctap.authenticator.data.settings
 
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
 
+/**
+ * Controls the uv option reported in authenticatorGetInfo.
+ *
+ * Indicates whether the authenticator has a built-in user verification method (e.g., biometrics, on-device PIN)
+ * and whether it has been configured.
+ */
 enum class UserVerificationSetting(val value: String) {
+    /** Built-in user verification is supported and configured (uv=true in GetInfo). */
     READY("ready"),
+    /** Built-in user verification is supported but not yet configured (uv=false in GetInfo). */
     NOT_READY("not-ready"),
+    /** Built-in user verification is not supported (uv absent from GetInfo). */
     NOT_SUPPORTED("not-supported");
 
     companion object {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -2,15 +2,19 @@ package com.webauthn4j.ctap.authenticator.execution
 
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.AttachmentSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
+import com.webauthn4j.ctap.authenticator.data.settings.MakeCredUvNotRqdSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ResidentKeySetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
 import com.webauthn4j.ctap.core.data.CtapStatusCode
+import com.webauthn4j.ctap.core.data.options.AlwaysUvOption
 import com.webauthn4j.ctap.core.data.options.ClientPINOption
+import com.webauthn4j.ctap.core.data.options.MakeCredUvNotRqdOption
 import com.webauthn4j.ctap.core.data.options.PlatformOption
 import com.webauthn4j.ctap.core.data.options.ResidentKeyOption
 import com.webauthn4j.ctap.core.data.options.UserPresenceOption
@@ -79,6 +83,14 @@ internal class GetInfoExecution(
         //spec| If absent, it indicates that the device is not capable of user verification within itself.
         //spec| A device that can only do Client PIN will not return the "uv" parameter.
         val uv: UserVerificationOption? = ctapAuthenticatorSession.userVerificationHandler.getUserVerificationOption(null)
+        val alwaysUv: AlwaysUvOption? = when (ctapAuthenticatorSession.alwaysUv) {
+            AlwaysUvSetting.ENABLED -> AlwaysUvOption.ENABLED
+            AlwaysUvSetting.DISABLED -> null
+        }
+        val makeCredUvNotRqd: MakeCredUvNotRqdOption? = when (ctapAuthenticatorSession.makeCredUvNotRqd) {
+            MakeCredUvNotRqdSetting.ENABLED -> MakeCredUvNotRqdOption.ENABLED
+            MakeCredUvNotRqdSetting.DISABLED -> null
+        }
         val extensions = ctapAuthenticatorSession.extensionProcessors.map { it.extensionId }
         return AuthenticatorGetInfoResponse(
             CtapStatusCode.CTAP2_OK,
@@ -86,7 +98,7 @@ internal class GetInfoExecution(
                 CtapAuthenticator.VERSIONS,       // versions (0x01): Required
                 extensions,                        // extensions (0x02): Optional
                 ctapAuthenticatorSession.aaguid,   // aaguid (0x03): Required
-                AuthenticatorGetInfoResponseData.Options(plat, rk, clientPin, up, uv), // options (0x04): Optional
+                AuthenticatorGetInfoResponseData.Options(plat, rk, clientPin, up, uv, alwaysUv, makeCredUvNotRqd), // options (0x04): Optional
                 2048u,                             // maxMsgSize (0x05): Optional
                 ctapAuthenticatorSession.pinProtocols,   // pinProtocols (0x06): Optional
                 null,

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
@@ -10,5 +10,7 @@ class AuthenticatorGetInfoResponseDataOptionsSerializer :
             FieldSerializationRule("up") { it.up?.value },
             FieldSerializationRule("uv") { it.uv?.value },
             FieldSerializationRule("plat") { it.plat?.value },
-            FieldSerializationRule("clientPin") { it.clientPin?.value }
+            FieldSerializationRule("clientPin") { it.clientPin?.value },
+            FieldSerializationRule("alwaysUv") { it.alwaysUv?.value },
+            FieldSerializationRule("makeCredUvNotRqd") { it.makeCredUvNotRqd?.value }
         ))

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
@@ -111,11 +111,13 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
         @param:JsonProperty("rk") val rk: ResidentKeyOption?,
         @param:JsonProperty("clientPin") val clientPin: ClientPINOption?,
         @param:JsonProperty("up") val up: UserPresenceOption?,
-        @param:JsonProperty("uv") val uv: UserVerificationOption?
+        @param:JsonProperty("uv") val uv: UserVerificationOption?,
+        @param:JsonProperty("alwaysUv") val alwaysUv: AlwaysUvOption? = null,
+        @param:JsonProperty("makeCredUvNotRqd") val makeCredUvNotRqd: MakeCredUvNotRqdOption? = null
     ) {
 
         override fun toString(): String {
-            return "Options(plat=${plat?.value}, rk=${rk?.value}, clientPin=${clientPin?.value}, up=${up?.value}, uv=${uv?.value})"
+            return "Options(plat=${plat?.value}, rk=${rk?.value}, clientPin=${clientPin?.value}, up=${up?.value}, uv=${uv?.value}, alwaysUv=${alwaysUv?.value}, makeCredUvNotRqd=${makeCredUvNotRqd?.value})"
         }
 
         override fun equals(other: Any?): Boolean {
@@ -129,6 +131,8 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
             if (clientPin != other.clientPin) return false
             if (up != other.up) return false
             if (uv != other.uv) return false
+            if (alwaysUv != other.alwaysUv) return false
+            if (makeCredUvNotRqd != other.makeCredUvNotRqd) return false
 
             return true
         }
@@ -139,6 +143,8 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
             result = 31 * result + (clientPin?.hashCode() ?: 0)
             result = 31 * result + (up?.hashCode() ?: 0)
             result = 31 * result + (uv?.hashCode() ?: 0)
+            result = 31 * result + (alwaysUv?.hashCode() ?: 0)
+            result = 31 * result + (makeCredUvNotRqd?.hashCode() ?: 0)
             return result
         }
 

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
@@ -112,8 +112,8 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
         @param:JsonProperty("clientPin") val clientPin: ClientPINOption?,
         @param:JsonProperty("up") val up: UserPresenceOption?,
         @param:JsonProperty("uv") val uv: UserVerificationOption?,
-        @param:JsonProperty("alwaysUv") val alwaysUv: AlwaysUvOption? = null,
-        @param:JsonProperty("makeCredUvNotRqd") val makeCredUvNotRqd: MakeCredUvNotRqdOption? = null
+        @param:JsonProperty("alwaysUv") val alwaysUv: AlwaysUvOption?,
+        @param:JsonProperty("makeCredUvNotRqd") val makeCredUvNotRqd: MakeCredUvNotRqdOption?
     ) {
 
         override fun toString(): String {

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapStatusCode.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapStatusCode.kt
@@ -50,6 +50,7 @@ class CtapStatusCode(private val value: Byte) {
         val CTAP2_ERR_ACTION_TIMEOUT = CtapStatusCode(0x3A)
         val CTAP2_ERR_UP_REQUIRED = CtapStatusCode(0x3B)
         val CTAP2_ERR_UV_BLOCKED = CtapStatusCode(0x3C)
+        val CTAP2_ERR_PUAT_REQUIRED = CtapStatusCode(0x3D)
         val CTAP2_ERR_UV_INVALID = CtapStatusCode(0x3F)
         val CTAP2_ERR_UNAUTHORIZED_PERMISSION = CtapStatusCode(0x40)
         val CTAP1_ERR_OTHER = CtapStatusCode(0x7F)
@@ -100,6 +101,7 @@ class CtapStatusCode(private val value: Byte) {
             tmp[CTAP2_ERR_ACTION_TIMEOUT] = "CTAP2_ERR_ACTION_TIMEOUT"
             tmp[CTAP2_ERR_UP_REQUIRED] = "CTAP2_ERR_UP_REQUIRED"
             tmp[CTAP2_ERR_UV_BLOCKED] = "CTAP2_ERR_UV_BLOCKED"
+            tmp[CTAP2_ERR_PUAT_REQUIRED] = "CTAP2_ERR_PUAT_REQUIRED"
             tmp[CTAP2_ERR_UV_INVALID] = "CTAP2_ERR_UV_INVALID"
             tmp[CTAP2_ERR_UNAUTHORIZED_PERMISSION] = "CTAP2_ERR_UNAUTHORIZED_PERMISSION"
             tmp[CTAP1_ERR_OTHER] = "CTAP1_ERR_OTHER"
@@ -152,6 +154,7 @@ class CtapStatusCode(private val value: Byte) {
                 "CTAP2_ERR_ACTION_TIMEOUT" -> CTAP2_ERR_ACTION_TIMEOUT
                 "CTAP2_ERR_UP_REQUIRED" -> CTAP2_ERR_UP_REQUIRED
                 "CTAP2_ERR_UV_BLOCKED" -> CTAP2_ERR_UV_BLOCKED
+                "CTAP2_ERR_PUAT_REQUIRED" -> CTAP2_ERR_PUAT_REQUIRED
                 "CTAP2_ERR_UV_INVALID" -> CTAP2_ERR_UV_INVALID
                 "CTAP2_ERR_UNAUTHORIZED_PERMISSION" -> CTAP2_ERR_UNAUTHORIZED_PERMISSION
                 "CTAP1_ERR_OTHER" -> CTAP1_ERR_OTHER

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/AlwaysUvOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/AlwaysUvOption.kt
@@ -1,0 +1,28 @@
+package com.webauthn4j.ctap.core.data.options
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class AlwaysUvOption constructor(@get:JsonValue val value: Boolean) {
+
+    companion object {
+        @JvmField
+        val ENABLED = AlwaysUvOption(true)
+
+        @JvmField
+        val DISABLED = AlwaysUvOption(false)
+
+        @JvmField
+        val NULL: AlwaysUvOption? = null
+
+        @JvmStatic
+        @JsonCreator
+        fun create(value: Boolean?): AlwaysUvOption? {
+            return when {
+                value == null -> NULL
+                value -> ENABLED
+                else -> DISABLED
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/MakeCredUvNotRqdOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/MakeCredUvNotRqdOption.kt
@@ -1,0 +1,28 @@
+package com.webauthn4j.ctap.core.data.options
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class MakeCredUvNotRqdOption constructor(@get:JsonValue val value: Boolean) {
+
+    companion object {
+        @JvmField
+        val ENABLED = MakeCredUvNotRqdOption(true)
+
+        @JvmField
+        val DISABLED = MakeCredUvNotRqdOption(false)
+
+        @JvmField
+        val NULL: MakeCredUvNotRqdOption? = null
+
+        @JvmStatic
+        @JsonCreator
+        fun create(value: Boolean?): MakeCredUvNotRqdOption? {
+            return when {
+                value == null -> NULL
+                value -> ENABLED
+                else -> DISABLED
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverterTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverterTest.kt
@@ -44,7 +44,9 @@ internal class CtapResponseConverterTest {
                 ResidentKeyOption.SUPPORTED,
                 ClientPINOption.NOT_SET,
                 UserPresenceOption.SUPPORTED,
-                UserVerificationOption.READY
+                UserVerificationOption.READY,
+                null,
+                null
             ),
             2048u,
             listOf(PinProtocolVersion.VERSION_1),

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializerTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializerTest.kt
@@ -27,7 +27,9 @@ internal class AuthenticatorGetInfoResponseDataOptionsSerializerTest {
             ResidentKeyOption.SUPPORTED,
             ClientPINOption.NOT_SET,
             UserPresenceOption.SUPPORTED,
-            UserVerificationOption.NOT_SUPPORTED
+            UserVerificationOption.NOT_SUPPORTED,
+            null,
+            null
         )
         val encoded = converter.writeValueAsBytes(original)
         Assertions.assertThat(encoded)

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataSerializerTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataSerializerTest.kt
@@ -53,7 +53,9 @@ internal class AuthenticatorGetInfoResponseDataSerializerTest {
                 ResidentKeyOption.SUPPORTED,
                 ClientPINOption.NOT_SET,
                 UserPresenceOption.SUPPORTED,
-                UserVerificationOption.READY
+                UserVerificationOption.READY,
+                null,
+                null
             ),
             2048u,
             listOf(PinProtocolVersion.VERSION_1),

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/data/hid/HIDMessageTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/data/hid/HIDMessageTest.kt
@@ -31,7 +31,9 @@ internal class HIDMessageTest {
                         ResidentKeyOption.SUPPORTED,
                         ClientPINOption.NOT_SET,
                         UserPresenceOption.SUPPORTED,
-                        UserVerificationOption.READY
+                        UserVerificationOption.READY,
+                        null,
+                        null
                     ),
                     1024u,
                     listOf(),


### PR DESCRIPTION
## Summary

- Add `AlwaysUvSetting` / `MakeCredUvNotRqdSetting` enum types for internal authenticator configuration, consistent with existing setting types (`ClientPINSetting`, `UserVerificationSetting`, etc.)
- Add `AlwaysUvOption` / `MakeCredUvNotRqdOption` types for GetInfo response, consistent with existing option types (`ClientPINOption`, `UserPresenceOption`, etc.)
- Wire through `CtapAuthenticator`, `CtapAuthenticatorSession`, `GetInfoExecution`, and the Options serializer
- Add `CTAP2_ERR_PUAT_REQUIRED` (0x3D) status code

This is preparatory infrastructure for the MakeCredential/GetAssertion UP/UV flow CTAP 2.1 update (follow-up PRs).