### PR TITLE
Align GetAssertion/GetNextAssertion UP/UV flow with CTAP 2.3 spec

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CredentialSelectionCanceledException.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CredentialSelectionCanceledException.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.ctap.authenticator
+
+class CredentialSelectionCanceledException : RuntimeException {
+    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    constructor(message: String?) : super(message)
+    constructor(cause: Throwable?) : super(cause)
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionSession.kt
@@ -5,11 +5,16 @@ import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthen
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorOutputs
 import java.time.Instant
 
+// Holds the state for an ongoing authenticatorGetAssertion flow, including
+// GetNextAssertion iteration. Corresponds to §6.2.2 Step 12.2.2.
 class GetAssertionSession(
+    // 12.2.2.1: remembered authenticatorGetAssertion parameters
     val assertionObjects: List<AssertionObject>,
     clientDataHash: ByteArray
 ) {
+    // 12.2.2.2: credential counter (zero-based index into assertionObjects)
     private var index = 0
+    // 12.2.2.3: timer for GetNextAssertion expiration (30 seconds)
     private var instant: Instant
     val clientDataHash: ByteArray
 
@@ -20,13 +25,15 @@ class GetAssertionSession(
 
     fun hasNext(): Boolean = index < assertionObjects.size
 
-    fun nextAssertionObject(): AssertionObject {
+    fun currentAssertionObject(): AssertionObject {
         if (assertionObjects.size <= index) {
             throw NoSuchElementException()
         }
-        val assertionObject = assertionObjects[index]
+        return assertionObjects[index]
+    }
+
+    fun incrementCredentialCounter() {
         index++
-        return assertionObject
     }
 
     val numberOfAssertionObjects: Int

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthTokenState.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthTokenState.kt
@@ -54,7 +54,7 @@ class PinUvAuthTokenState(
     //spec| A userPresent flag, initially false.
     private var userPresentFlag: Boolean = false
 
-    private var platformHasUsedToken: Boolean = false
+    private var tokenUsed: Boolean = false
 
     companion object {
         val DEFAULT_INITIAL_USAGE_TIME_LIMIT: Duration = Duration.ofSeconds(30)
@@ -73,7 +73,7 @@ class PinUvAuthTokenState(
         initialUsageTimeLimit = transportInitialUsageTimeLimit
         usageTimer = Instant.now()
         inUse = true
-        platformHasUsedToken = false
+        tokenUsed = false
     }
 
     //spec| pinUvAuthTokenUsageTimerObserver()
@@ -109,14 +109,14 @@ class PinUvAuthTokenState(
             clearUserPresentFlag()
         }
 
-        if (elapsed >= initialUsageTimeLimit && !platformHasUsedToken) {
+        if (elapsed >= initialUsageTimeLimit && !tokenUsed) {
             stopUsingPinUvAuthToken()
             return
         }
     }
 
-    internal fun recordPlatformUsage() {
-        platformHasUsedToken = true
+    internal fun recordTokenUsage() {
+        tokenUsed = true
     }
 
     //spec| stopUsingPinUvAuthToken()
@@ -130,7 +130,7 @@ class PinUvAuthTokenState(
         userPresentTimeLimit = transportUserPresentTimeLimit    // initially same as initial usage time limit
         userVerifiedFlag = false                 // initially false
         userPresentFlag = false                  // initially false
-        platformHasUsedToken = false
+        tokenUsed = false
     }
 
     // Checks whether the token is currently in use, after running the timer observer.

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -2,12 +2,16 @@ package com.webauthn4j.ctap.authenticator.execution
 
 import tools.jackson.core.type.TypeReference
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.authenticator.CredentialSelectionCanceledException
 import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
 import com.webauthn4j.ctap.authenticator.GetAssertionSession
+import com.webauthn4j.ctap.authenticator.PinUvAuthProtocol
 import com.webauthn4j.ctap.authenticator.SignatureCalculator.calculate
 import com.webauthn4j.ctap.authenticator.U2FKeyEnvelope
 import com.webauthn4j.ctap.authenticator.data.credential.*
 import com.webauthn4j.ctap.authenticator.data.event.GetAssertionEvent
+import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
+import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
@@ -17,9 +21,7 @@ import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.authenticator.store.StoreFullException
 import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
 import com.webauthn4j.ctap.core.data.*
-import java.util.Arrays
 import com.webauthn4j.data.PinProtocolVersion
-import com.webauthn4j.ctap.core.util.internal.BooleanUtil
 import com.webauthn4j.ctap.core.util.internal.CipherUtil
 import com.webauthn4j.ctap.core.util.internal.HexUtil
 import com.webauthn4j.ctap.core.validator.AuthenticatorGetAssertionRequestValidator
@@ -37,46 +39,65 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import kotlin.experimental.or
 
-// @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+/**
+ * GetAssertion command execution
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">CTAP 2.3 §6.2.2 authenticatorGetAssertion Algorithm</a>
+ */
 @Suppress("ConvertSecondaryConstructorToPrimary")
 internal class GetAssertionExecution :
     CtapCommandExecutionBase<AuthenticatorGetAssertionRequest, AuthenticatorGetAssertionResponse> {
 
     override val commandName: String = "GetAssertion"
 
-    @Suppress("JoinDeclarationAndAssignment")
-    private val ctapAuthenticatorSession: CtapAuthenticatorSession
-
     private val logger: Logger = LoggerFactory.getLogger(GetAssertionExecution::class.java)
     private val getAssertionRequestValidator = AuthenticatorGetAssertionRequestValidator()
+
+    @Suppress("JoinDeclarationAndAssignment")
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession
+    private val authenticatorGetAssertionRequest: AuthenticatorGetAssertionRequest
+
     private val authenticatorPropertyStore: AuthenticatorPropertyStore
 
-    //Command properties
-    @Suppress("JoinDeclarationAndAssignment")
-    private val authenticatorGetAssertionRequest: AuthenticatorGetAssertionRequest
+    // command properties
     private val rpId: String
     private val rpIdHash: ByteArray
     private val clientDataHash: ByteArray
     private val allowList: List<PublicKeyCredentialDescriptor>?
     private val authenticationExtensionsAuthenticatorInputs: AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>?
     private val options: AuthenticatorGetAssertionRequest.Options?
-    private val pinAuth: ByteArray?
-    private val pinProtocol: PinProtocolVersion?
+    private val pinUvAuthParam: ByteArray?
+    private val pinUvAuthProtocol: PinProtocolVersion?
 
-    // initialized in Step7
+    private var shouldPerformUv = false
+    private var shouldPerformUp = false
+
+    //spec| Step 3. Create a new authenticatorGetAssertion response structure and initialize both its "uv" bit and "up" bit as false.
+    private var uvResult = false
+    private var upResult = false
+
+    private lateinit var protocol: PinUvAuthProtocol
+    // Step 6.2: result of performBuiltInUv(). When true (success), Step 8 sets UP from the UV
+    // evidence and Step 9 (explicit UP test) is skipped.
+    private var uvState = false
+
+    // Step 11.2: set to true when allowList is present (numberOfCredentials is deleted from response).
+    private var suppressNumberOfCredentials = false
+    // Step 12.2.3.4: set to true when user selects a credential via authenticator display.
+    private var userSelected = false
+
+    // initialized in Step 7
     private lateinit var credentials: List<Credential>
 
-    // initialized in Step10
+    // initialized in Step 10
     private lateinit var assertionObjects: List<GetAssertionSession.AssertionObject>
 
-    // initialized in Step11And12
+    // initialized in Step 11/12
     private lateinit var onGoingGetAssertionSession: GetAssertionSession
 
-    private var userVerificationPlan = false
-    private var userPresencePlan = false
-    private var userVerificationResult = false
-    private var userPresenceResult = false
-
+    private val isProtectedByUserVerification: Boolean
+        get() = ctapAuthenticatorSession.isClientPINReady ||
+                ctapAuthenticatorSession.userVerification == UserVerificationSetting.READY
 
     constructor(
         ctapAuthenticatorSession: CtapAuthenticatorSession,
@@ -88,15 +109,16 @@ internal class GetAssertionExecution :
 
         // command properties initialization and validation
         this.rpId = authenticatorGetAssertionRequest.rpId
-
         this.rpIdHash = MessageDigestUtil.createSHA256().digest(rpId.toByteArray())
         this.clientDataHash = authenticatorGetAssertionRequest.clientDataHash
         this.allowList = authenticatorGetAssertionRequest.allowList
-        this.authenticationExtensionsAuthenticatorInputs =
-            authenticatorGetAssertionRequest.extensions
+        this.authenticationExtensionsAuthenticatorInputs = authenticatorGetAssertionRequest.extensions
         this.options = authenticatorGetAssertionRequest.options
-        this.pinAuth = authenticatorGetAssertionRequest.pinAuth
-        this.pinProtocol = authenticatorGetAssertionRequest.pinProtocol
+        this.pinUvAuthParam = authenticatorGetAssertionRequest.pinUvAuthParam
+        this.pinUvAuthProtocol = authenticatorGetAssertionRequest.pinUvAuthProtocol
+        // Default to the highest version protocol (list is sorted by version descending).
+        // Overridden in Step 2 when pinUvAuthParam is present.
+        this.protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.first()
     }
 
     override suspend fun validate() {
@@ -104,15 +126,19 @@ internal class GetAssertionExecution :
     }
 
     override suspend fun doExecute(): AuthenticatorGetAssertionResponse {
-        // execStep1ZeroLengthPinUvAuthParam()     // TODO: CTAP 2.1
-        // execStep2ValidatePinUvAuthProtocol()     // TODO: CTAP 2.1
-        // execStep3InitializeResponseStructure()   // TODO: CTAP 2.1
+        ctapAuthenticatorSession.onGoingGetAssertionSession = null
+
+        execStep1ZeroLengthPinUvAuthParam()
+        execStep2ValidatePinUvAuthProtocol()
+        // TODO: Step 3: Create a new response structure. Currently represented by field declarations (upResult=false, uvResult=false).
         execStep4ProcessOptions()
-        // execStep5ProcessAlwaysUv()               // TODO: CTAP 2.1
+        execStep5ProcessAlwaysUv()
         execStep6ProcessUserVerification()
         execStep7LocateCredentials()
-        // execStep8SetUpFromBuiltInUv()            // TODO: CTAP 2.1
-        execStep9RequestUserConsent()
+        execStep8SetUserPresenceFromBuiltInUv()
+        if (!uvState) {
+            execStep9TestUserPresence()
+        }
         execStep10ProcessExtensions()
         execStep11And12SelectCredential()
         val response = execStep13Sign()
@@ -131,7 +157,6 @@ internal class GetAssertionExecution :
                     )
                 }
             }
-
         }
         val rpName =
             onGoingGetAssertionSession.assertionObjects.map { (it.credential as? UserCredential)?.rpName }
@@ -141,88 +166,291 @@ internal class GetAssertionExecution :
         return response
     }
 
-
     override fun createErrorResponse(statusCode: CtapStatusCode): AuthenticatorGetAssertionResponse {
         return AuthenticatorGetAssertionResponse(statusCode)
     }
 
-    //spec| Step 4
-    //spec| If the options parameter is present, process all option keys and values present in the parameter.
-    //spec| Treat any option keys that are not understood as absent.
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 1. If authenticator supports either pinUvAuthToken or clientPin features and the platform sends a
+    //spec| zero length pinUvAuthParam:
+    //spec|   1.1 Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|   1.2 If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   1.3 If evidence of user interaction is provided in this step then return either
+    //spec|   CTAP2_ERR_PIN_NOT_SET if PIN is not set or CTAP2_ERR_PIN_INVALID if PIN has been set.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private suspend fun execStep1ZeroLengthPinUvAuthParam() {
+        //spec| Step 1. If authenticator supports either pinUvAuthToken or clientPin features and the platform sends a zero length pinUvAuthParam:
+        if (pinUvAuthParam != null && pinUvAuthParam.isEmpty()) {
+            //spec| 1.1 Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+            //spec| 1.2 If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+            if (!performBuiltInUp()) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+            //spec| 1.3 If evidence of user interaction is provided in this step then return either
+            //spec| CTAP2_ERR_PIN_NOT_SET if PIN is not set or CTAP2_ERR_PIN_INVALID if PIN has been set.
+            if (ctapAuthenticatorSession.isClientPINReady) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+            } else {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
+            }
+        }
+    }
+
+    //spec| Step 2. If the pinUvAuthParam parameter is present:
+    //spec|   2.1 If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
+    //spec|   2.2 If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private fun execStep2ValidatePinUvAuthProtocol() {
+        //spec| Step 2. If the pinUvAuthParam parameter is present:
+        if (pinUvAuthParam != null) {
+            if (pinUvAuthProtocol != null) {
+                //spec| 2.1 If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
+                protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols
+                    .firstOrNull { it.version == pinUvAuthProtocol }
+                    ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+            } else {
+                //spec| 2.2 If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+            }
+        }
+    }
+
+    //spec| Step 4. If the options parameter is present, process all option keys and values present in the parameter. Treat any option keys that are not understood as absent.
+    //spec|   4.1 If the "uv" option is absent, let the "uv" option be treated as being present with the value false. (This is the default)
+    //spec|   4.2 If the pinUvAuthParam is present, let the "uv" option be treated as being present with the value false.
+    //spec|   4.3 If the "uv" option is present and true then:
+    //spec|     4.3.1 If the authenticator does not support a built-in user verification method end the operation by returning CTAP2_ERR_INVALID_OPTION.
+    //spec|     4.3.2 If the built-in user verification method has not yet been enabled, end the operation by returning CTAP2_ERR_INVALID_OPTION.
+    //spec|   4.4 If the "rk" option is present then:
+    //spec|     4.4.1 Return CTAP2_ERR_UNSUPPORTED_OPTION.
+    //spec|   4.5 If the "up" option is not present then:
+    //spec|     4.5.1 Let the "up" option be treated as being present with the value true. (This is the default)
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep4ProcessOptions() {
-        if (options != null) {
-            if (BooleanUtil.isTrue(options.uv)) {
-                userVerificationPlan = when (ctapAuthenticatorSession.userVerification) {
-                    UserVerificationSetting.READY -> true
-                    else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
+        val requestOptions = options
+
+        //spec| 4.1 If the "uv" option is absent, let the "uv" option be treated as being present with the value false. (This is the default)
+        var uv = requestOptions?.uv ?: false
+        //spec| 4.2 If the pinUvAuthParam is present, let the "uv" option be treated as being present with the value false.
+        if (pinUvAuthParam != null) {
+            uv = false
+        }
+        //spec| 4.3 If the "uv" option is present and true then:
+        if (uv) {
+            when (ctapAuthenticatorSession.userVerification) {
+                //spec| 4.3.1 If the authenticator does not support a built-in user verification method end the operation by returning CTAP2_ERR_INVALID_OPTION.
+                UserVerificationSetting.NOT_SUPPORTED -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+                //spec| 4.3.2 If the built-in user verification method has not yet been enabled, end the operation by returning CTAP2_ERR_INVALID_OPTION.
+                UserVerificationSetting.NOT_READY -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_INVALID_OPTION)
+                UserVerificationSetting.READY -> {}
+            }
+        }
+        shouldPerformUv = uv
+
+        //spec| 4.4 If the "rk" option is present then:
+        //spec|   4.4.1 Return CTAP2_ERR_UNSUPPORTED_OPTION.
+        if (requestOptions?.rk != null) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
+        }
+
+        //spec| 4.5 If the "up" option is not present then:
+        //spec|   4.5.1 Let the "up" option be treated as being present with the value true. (This is the default)
+        val up = requestOptions?.up ?: true
+        // Implementation-specific: reject up=true when the authenticator does not support user presence.
+        // The spec does not explicitly define this check, but an authenticator that cannot perform UP
+        // cannot fulfill the request.
+        if (up) {
+            shouldPerformUp = when (ctapAuthenticatorSession.userPresence) {
+                UserPresenceSetting.SUPPORTED -> true
+                else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
+            }
+        } else {
+            shouldPerformUp = false
+        }
+    }
+
+    //spec| Step 5. If the alwaysUv option ID is present and true and the "up" option is present and true then:
+    //spec|   5.1 If the authenticator is not protected by some form of user verification:
+    //spec|     5.1.1 If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false (clientPin is supported for the ga permission):
+    //spec|       5.1.1.1 End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|     5.1.2 Else (clientPin is not supported):
+    //spec|       5.1.2.1 End the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   5.2 If the pinUvAuthParam is present then go to Step 6.
+    //spec|   5.3 If the "uv" option is true then go to Step 6.
+    //spec|   5.4 If the "uv" option is false and the authenticator supports a built-in user verification method, and the user verification method is enabled then:
+    //spec|     5.4.1 Let the "uv" option be treated as being present with the value true.
+    //spec|     5.4.2 Go To Step 6.
+    //spec|   5.5 If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false, then:
+    //spec|     5.5.1 End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|   5.6 Else (clientPin is not supported):
+    //spec|     5.6.1 End the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private fun execStep5ProcessAlwaysUv() {
+        //spec| Step 5. If the alwaysUv option ID is present and true and the "up" option is present and true then:
+        if (ctapAuthenticatorSession.alwaysUv == AlwaysUvSetting.ENABLED && shouldPerformUp) {
+            //spec| 5.1 If the authenticator is not protected by some form of user verification:
+            if (!isProtectedByUserVerification) {
+                //spec| 5.1.1 If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false (clientPin is supported for the ga permission):
+                // TODO: noMcGaPermissionsWithClientPin not yet implemented; always treated as absent
+                if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
+                    //spec| 5.1.1.1 End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+                }
+                //spec| 5.1.2 Else (clientPin is not supported):
+                else {
+                    //spec| 5.1.2.1 End the operation by returning CTAP2_ERR_OPERATION_DENIED.
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
                 }
             }
-            if (options.up != false) {
-                userPresencePlan = when (ctapAuthenticatorSession.userPresence) {
-                    UserPresenceSetting.SUPPORTED -> true
-                    else -> throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_UNSUPPORTED_OPTION)
+
+            //spec| 5.2 If the pinUvAuthParam is present then go to Step 6.
+            if (pinUvAuthParam != null) {
+                return
+            }
+
+            //spec| 5.3 If the "uv" option is true then go to Step 6.
+            if (shouldPerformUv) {
+                return
+            }
+
+            //spec| 5.4 If the "uv" option is false and the authenticator supports a built-in user verification method, and the user verification method is enabled then:
+            if (!shouldPerformUv && ctapAuthenticatorSession.userVerification == UserVerificationSetting.READY) {
+                //spec| 5.4.1 Let the "uv" option be treated as being present with the value true.
+                shouldPerformUv = true
+                //spec| 5.4.2 Go To Step 6.
+                return
+            }
+
+            //spec| 5.5 If the clientPin option ID is present and noMcGaPermissionsWithClientPin option ID is absent or false, then:
+            // TODO: noMcGaPermissionsWithClientPin not yet implemented; always treated as absent
+            if (ctapAuthenticatorSession.clientPIN == ClientPINSetting.ENABLED) {
+                //spec| 5.5.1 End the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+            }
+            //spec| 5.6 Else (clientPin is not supported):
+            else {
+                //spec| 5.6.1 End the operation by returning CTAP2_ERR_OPERATION_DENIED.
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+            }
+        }
+    }
+
+    //spec| Step 6. If the authenticator is protected by some form of user verification, then:
+    //spec|   6.1 If pinUvAuthParam parameter is present (implying the "uv" option is treated as false, see Step 4):
+    //spec|     6.1.1 Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+    //spec|       6.1.1.1 If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
+    //spec|       6.1.1.2 If the verification returns success, set the "uv" bit to true in the response.
+    //spec|     6.1.2 Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
+    //spec|     6.1.3 If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     6.1.4 Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     6.1.5 If the pinUvAuthToken has a permissions RP ID associated:
+    //spec|       6.1.5.1 If the permissions RP ID does not match the rpId in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
+    //spec|     6.1.6 If the pinUvAuthToken does not have a permissions RP ID associated:
+    //spec|       6.1.6.1 Associate the request's rpId parameter value with the pinUvAuthToken as its permissions RP ID.
+    //spec|     6.1.7 Go to Step 7.
+    //spec|   6.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
+    //spec|   and that the authenticator supports an enabled built-in user verification method, see Step 4):
+    //spec|     6.2.1 Let internalRetry be true.
+    //spec|     6.2.2 Let uvState be the result of calling performBuiltInUv(internalRetry)
+    //spec|     6.2.3 If uvState is error:
+    //spec|       6.2.3.1 If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+    //spec|       6.2.3.2 If the ClientPin option ID is true and the noMcGaPermissionsWithClientPin option ID is absent or false, end the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+    //spec|       6.2.3.3 If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
+    //spec|       6.2.3.4 Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|     6.2.4 If uvState is success:
+    //spec|       6.2.4.1 Set the "uv" bit to true in the response.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private suspend fun execStep6ProcessUserVerification() {
+        //spec| Step 6. If the authenticator is protected by some form of user verification, then:
+        if (isProtectedByUserVerification) {
+            //spec| 6.1 If pinUvAuthParam parameter is present (implying the "uv" option is treated as false, see Step 4):
+            if (pinUvAuthParam != null) {
+                //spec| 6.1.1 Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
+                if (!protocol.verify(protocol.pinUvAuthToken, clientDataHash, pinUvAuthParam)) {
+                    //spec| 6.1.1.1 If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                }
+                //spec| 6.1.1.2 If the verification returns success, set the "uv" bit to true in the response.
+                uvResult = true
+
+                //spec| 6.1.2 Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
+                val userVerifiedFlagValue = protocol.tokenState.getUserVerifiedFlagValue()
+                //spec| 6.1.3 If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
+                if (!userVerifiedFlagValue) {
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                }
+
+                //spec| 6.1.4 Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
+                if (!protocol.tokenState.hasPermission(PinUvAuthTokenPermission.GA)) {
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                }
+
+                //spec| 6.1.5 If the pinUvAuthToken has a permissions RP ID associated:
+                //spec|   6.1.5.1 If the permissions RP ID does not match the rpId in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
+                val tokenRpId = protocol.tokenState.permissionsRpId
+                if (tokenRpId != null && tokenRpId != rpId) {
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+                }
+
+                //spec| 6.1.6 If the pinUvAuthToken does not have a permissions RP ID associated:
+                //spec|   6.1.6.1 Associate the request's rpId parameter value with the pinUvAuthToken as its permissions RP ID.
+                if (protocol.tokenState.permissionsRpId == null) {
+                    protocol.tokenState.permissionsRpId = rpId
+                }
+
+                // Record token usage to prevent expiration by initial usage time limit (§6.5.2.1)
+                protocol.tokenState.recordTokenUsage()
+                //spec| 6.1.7 Go to Step 7.
+                return
+            }
+
+            //spec| 6.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
+            //spec| and that the authenticator supports an enabled built-in user verification method, see Step 4):
+            if (shouldPerformUv) {
+                //spec| 6.2.1 Let internalRetry be true.
+                //spec| 6.2.2 Let uvState be the result of calling performBuiltInUv(internalRetry)
+                uvState = performBuiltInUv()
+                if (!uvState) {
+                    //spec| 6.2.3 If uvState is error:
+                    //spec|   6.2.3.1 If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+                    //spec|   6.2.3.2 If the ClientPin option ID is true and the noMcGaPermissionsWithClientPin option ID is absent or false, end the operation by returning CTAP2_ERR_PUAT_REQUIRED.
+                    //spec|   6.2.3.3 If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
+                    //spec|   6.2.3.4 Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+                    // Simplified: performBuiltInUv() returns a boolean; detailed error reasons
+                    // (timeout, blocked, PUAT) are not yet distinguished.
+                    throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+                } else {
+                    //spec| 6.2.4 If uvState is success:
+                    //spec|   6.2.4.1 Set the "uv" bit to true in the response.
+                    uvResult = true
                 }
             }
         }
     }
 
-    //spec| Step 6
-    //spec| If the authenticator is protected by some form of user verification, then:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
-    private fun execStep6ProcessUserVerification() {
-        // If pinUvAuthParam parameter is present and pinProtocol is supported,
-        // verify it and set the "uv" bit to true in the response.
-        if (pinAuth != null && pinProtocol != null) {
-            //spec| Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
-            //spec| If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
-            val matchedProtocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.firstOrNull { protocol ->
-                val calculatedPinAuth = protocol.authenticate(protocol.pinUvAuthToken, clientDataHash)
-                Arrays.equals(calculatedPinAuth, pinAuth)
-            } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-
-            //spec| Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
-            if (matchedProtocol.tokenState.isInUse() && !matchedProtocol.tokenState.hasPermission(PinUvAuthTokenPermission.GA)) {
-                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-            }
-            //spec| If the pinUvAuthToken has a permissions RP ID associated:
-            //spec| If the permissions RP ID does not match the rpId in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
-            val tokenRpId = matchedProtocol.tokenState.permissionsRpId
-            if (tokenRpId != null && tokenRpId != rpId) {
-                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
-            }
-
-            if (matchedProtocol.tokenState.isInUse()) {
-                matchedProtocol.tokenState.recordPlatformUsage()
-            }
-
-            userVerificationResult = true
-            return
-        }
-        // If pinUvAuthParam parameter is not present and clientPin has been set on the authenticator,
-        // set the "uv" bit to false in the response.
-        if (pinAuth == null && ctapAuthenticatorSession.isClientPINReady) {
-            userVerificationResult = false
-        }
-    }
-
-    //spec| Step 7
-    //spec| Locate all credentials that are eligible for retrieval under the specified criteria:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 7. Locate all credentials that are eligible for retrieval under the specified criteria:
+    //spec|   7.1 If the allowList parameter is present and is non-empty, locate all denoted credentials created by this authenticator and bound to the specified rpId.
+    //spec|   7.2 If an allowList is not present, locate all discoverable credentials that are created by this authenticator and bound to the specified rpId.
+    //spec|   7.3 Create an applicable credentials list populated with the located credentials.
+    //spec|   7.4 Iterate through the applicable credentials list, and if credential protection for a credential is marked as userVerificationRequired, and the "uv" bit is false in the response, remove that credential from the applicable credentials list.
+    //spec|   7.5 Iterate through the applicable credentials list, and if credential protection for a credential is marked as userVerificationOptionalWithCredentialIDList and there is no allowList passed by the client and the "uv" bit is false in the response, remove that credential from the applicable credentials list.
+    //spec|   7.6 If the applicable credentials list is empty, return CTAP2_ERR_NO_CREDENTIALS.
+    //spec|   7.7 Let numberOfCredentials be the number of applicable credentials found.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep7LocateCredentials() {
-        val rpId = rpId
-
-        //spec| If the allowList parameter is present and is non-empty, locate all
-        //spec| denoted credentials created by this authenticator and bound to the specified rpId.
-        //spec| If an allowList is not present, locate all discoverable credentials that are
-        //spec| created by this authenticator and bound to the specified rpId.
+        //spec| 7.1 If the allowList parameter is present and is non-empty, locate all denoted credentials created by this authenticator and bound to the specified rpId.
+        //spec| 7.2 If an allowList is not present, locate all discoverable credentials that are created by this authenticator and bound to the specified rpId.
+        //spec| 7.3 Create an applicable credentials list populated with the located credentials.
         credentials = if (allowList != null && allowList.isNotEmpty()) {
             val storedCredentials = authenticatorPropertyStore.loadUserCredentials(rpId)
                 .filter {
                     allowList.any { allowed: PublicKeyCredentialDescriptor ->
-                        it.credentialId.contentEquals(
-                            allowed.id
-                        )
+                        it.credentialId.contentEquals(allowed.id)
                     }
                 }.filter { it.rpIdHash.contentEquals(rpIdHash) }
             val derivedCredentials = allowList.mapNotNull(this::deriveCredential)
@@ -231,17 +459,20 @@ internal class GetAssertionExecution :
             result.addAll(derivedCredentials)
             result
         } else {
-            ArrayList<Credential>(
-                authenticatorPropertyStore.loadUserCredentials(
-                    rpId
-                )
-            )
+            ArrayList<Credential>(authenticatorPropertyStore.loadUserCredentials(rpId))
         }
 
-        //spec| If the applicable credentials list is empty, return CTAP2_ERR_NO_CREDENTIALS.
+        //spec| 7.4 Iterate through the applicable credentials list, and if credential protection for a credential is marked as userVerificationRequired, and the "uv" bit is false in the response, remove that credential from the applicable credentials list.
+        // TODO: credProtect filtering (userVerificationRequired) not yet implemented.
+        //spec| 7.5 Iterate through the applicable credentials list, and if credential protection for a credential is marked as userVerificationOptionalWithCredentialIDList and there is no allowList passed by the client and the "uv" bit is false in the response, remove that credential from the applicable credentials list.
+        // TODO: credProtect filtering (userVerificationOptionalWithCredentialIDList) not yet implemented.
+
+        //spec| 7.6 If the applicable credentials list is empty, return CTAP2_ERR_NO_CREDENTIALS.
         if (credentials.isEmpty()) {
             throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
         }
+
+        //spec| 7.7 Let numberOfCredentials be the number of applicable credentials found.
     }
 
     private fun deriveCredential(descriptor: PublicKeyCredentialDescriptor): Credential? {
@@ -309,41 +540,113 @@ internal class GetAssertionExecution :
         return null
     }
 
-    //spec| Step 9
-    //spec| If the "up" option is set to true or not present:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
-    private suspend fun execStep9RequestUserConsent() {
-        val options = GetAssertionConsentRequest(rpId, userPresencePlan, userVerificationPlan)
-        val consent = ctapAuthenticatorSession.withUserPresenceWait {
-            ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(options)
-        }
-        if (consent) {
-            if (userVerificationPlan) {
-                userVerificationResult = true
-            }
-            if (userPresencePlan) {
-                userPresenceResult = true
-            }
-        } else {
-            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+    //spec| Step 8. If evidence of user interaction was provided as part of Step 6.2 (i.e., by invoking performBuiltInUv()):
+    //spec|   8.1 Set the "up" bit to true in the response.
+    //spec|   8.2 Go to Step 10
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private fun execStep8SetUserPresenceFromBuiltInUv() {
+        //spec| Step 8. If evidence of user interaction was provided as part of Step 6.2 (i.e., by invoking performBuiltInUv()):
+        if (uvState) {
+            //spec| 8.1 Set the "up" bit to true in the response.
+            upResult = true
+            //spec| 8.2 Go to Step 10
         }
     }
 
-    //spec| Step 10
-    //spec| If the extensions parameter is present:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 9. If the "up" option is set to true or not present:
+    //spec|   9.1 If the pinUvAuthParam parameter is present then:
+    //spec|     9.1.1 Let userPresentFlagValue be the result of calling getUserPresentFlagValue().
+    //spec|     9.1.2 If userPresentFlagValue is false:
+    //spec|       9.1.2.1 Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|       If the authenticator has a display, show the rpId parameter value to the user,
+    //spec|       and request permission to create an assertion.
+    //spec|       9.1.2.2 If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   9.2 Else (implying the pinUvAuthParam parameter is not present):
+    //spec|     9.2.1 If the "up" bit is false in the response:
+    //spec|       9.2.1.1 Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+    //spec|       If the authenticator has a display, show the rpId parameter value to the user,
+    //spec|       and request permission to create an assertion.
+    //spec|       9.2.1.2 If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|   9.3 Set the "up" bit to true in the response.
+    //spec|   9.4 Call clearUserPresentFlag(), clearUserVerifiedFlag(), and clearPinUvAuthTokenPermissionsExceptLbw().
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
+    private suspend fun execStep9TestUserPresence() {
+        //spec| Step 9. If the "up" option is set to true or not present:
+        if (shouldPerformUp) {
+            //spec| 9.1 If the pinUvAuthParam parameter is present then:
+            if (pinUvAuthParam != null) {
+                //spec| 9.1.1 Let userPresentFlagValue be the result of calling getUserPresentFlagValue().
+                val userPresentFlagValue = protocol.tokenState.getUserPresentFlagValue()
+                //spec| 9.1.2 If userPresentFlagValue is false:
+                if (!userPresentFlagValue) {
+                    //spec| 9.1.2.1 Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+                    //spec| If the authenticator has a display, show the rpId parameter value to the user,
+                    //spec| and request permission to create an assertion.
+                    //spec| 9.1.2.2 If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+                    if (!performBuiltInUp()) {
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+                    }
+                }
+            } else {
+                //spec| 9.2 Else (implying the pinUvAuthParam parameter is not present):
+                //spec|   9.2.1 If the "up" bit is false in the response:
+                if (!upResult) {
+                    //spec| 9.2.1.1 Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
+                    //spec| If the authenticator has a display, show the rpId parameter value to the user,
+                    //spec| and request permission to create an assertion.
+                    //spec| 9.2.1.2 If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+                    if (!performBuiltInUp()) {
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+                    }
+                }
+            }
+
+            //spec| 9.3 Set the "up" bit to true in the response.
+            upResult = true
+
+            //spec| 9.4 Call clearUserPresentFlag(), clearUserVerifiedFlag(), and clearPinUvAuthTokenPermissionsExceptLbw().
+            protocol.tokenState.clearUserPresentFlag()
+            protocol.tokenState.clearUserVerifiedFlag()
+            protocol.tokenState.clearPinUvAuthTokenPermissionsExceptLbw()
+        }
+    }
+
+    private suspend fun performBuiltInUv(): Boolean {
+        val request = GetAssertionConsentRequest(rpId, isUserPresence = true, isUserVerification = true)
+        return ctapAuthenticatorSession.withUserPresenceWait {
+            ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(request)
+        }
+    }
+
+    private suspend fun performBuiltInUp(): Boolean {
+        val request = GetAssertionConsentRequest(rpId, isUserPresence = true, isUserVerification = false)
+        return ctapAuthenticatorSession.withUserPresenceWait {
+            ctapAuthenticatorSession.userVerificationHandler.onGetAssertionConsentRequested(request)
+        }
+    }
+
+    //spec| Step 10. If the extensions parameter is present:
+    //spec|   10.1 Process any extensions that this authenticator supports, ignoring any that it does not support.
+    //spec|   10.2 Authenticator extension outputs generated by the authenticator extension processing
+    //spec|   are returned in the authenticator data. The set of keys in the authenticator extension outputs map MUST be equal to,
+    //spec|   or a subset of, the keys of the authenticator extension inputs map.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep10ProcessExtensions() {
         val inputs = this.authenticationExtensionsAuthenticatorInputs
         assertionObjects = credentials.map { credential ->
             val outputsBuilder =
                 AuthenticationExtensionsAuthenticatorOutputs.BuilderForAuthentication()
             if (inputs != null) {
+                //spec| 10.1 Process any extensions that this authenticator supports, ignoring any that it does not support.
                 val context = AuthenticationExtensionContext(
                     ctapAuthenticatorSession,
                     authenticatorGetAssertionRequest,
                     credential,
-                    userVerificationPlan,
-                    userPresencePlan
+                    shouldPerformUv,
+                    shouldPerformUp
                 )
                 ctapAuthenticatorSession.extensionProcessors.filterIsInstance<AuthenticationExtensionProcessor>()
                     .forEach { processor ->
@@ -352,62 +655,129 @@ internal class GetAssertionExecution :
                         }
                     }
             }
+            //spec| 10.2 Authenticator extension outputs generated by the authenticator extension processing
+            //spec| are returned in the authenticator data. The set of keys in the authenticator extension outputs map MUST be equal to,
+            //spec| or a subset of, the keys of the authenticator extension inputs map.
             GetAssertionSession.AssertionObject(credential, false, outputsBuilder.build(), 0)
         }
     }
 
-    //spec| Step 11
-    //spec| If the allowList parameter is present:
-    //spec| Step 12
-    //spec| If allowList is not present:
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 11. If the allowList parameter is present:
+    //spec|   11.1 Select any credential from the applicable credentials list.
+    //spec|   11.2 Delete the numberOfCredentials member.
+    //spec|   11.3 Go to Step 13.
+    //spec| Step 12. If allowList is not present:
+    //spec|   12.1 If numberOfCredentials is one:
+    //spec|     12.1.1 Select that credential.
+    //spec|   12.2 If numberOfCredentials is more than one:
+    //spec|     12.2.1 Order the credentials in the applicable credentials list by the time when they were created in reverse order.
+    //spec|     (I.e. the first credential is the most recently created.)
+    //spec|     12.2.2 If the authenticator does not have a display, or the authenticator does have a display and the "uv" and "up" options are false:
+    //spec|       12.2.2.1 Remember the authenticatorGetAssertion parameters.
+    //spec|       12.2.2.2 Create a credential counter (credentialCounter) and set it to 1.
+    //spec|       This counter signifies the next credential to be returned by the authenticator, assuming zero-based indexing.
+    //spec|       12.2.2.3 Start a timer. This is used during authenticatorGetNextAssertion command. This step is OPTIONAL if transport is done over NFC.
+    //spec|       12.2.2.4 Select the first credential.
+    //spec|     12.2.3 If the authenticator has a display and at least one of the "uv" and "up" options is true:
+    //spec|       12.2.3.1 Display all the credentials in the applicable credentials list to the user, using their friendly name along with other stored account information.
+    //spec|       12.2.3.2 Also, display the rpId of the requester (specified in the request) and ask the user to select a credential.
+    //spec|       12.2.3.3 If the user declines to select a credential or takes too long (as determined by the authenticator), terminate this procedure and return the CTAP2_ERR_OPERATION_DENIED error.
+    //spec|       12.2.3.4 Update the response to set the userSelected member to true and to delete the numberOfCredentials member.
+    //spec|       12.2.3.5 Select the credential indicated by the user.
+    //spec|   12.3 Update the response to include the selected credential's publicKeyCredentialUserEntity information.
+    //spec|   User identifiable information (name, DisplayName, icon) inside the publicKeyCredentialUserEntity MUST NOT be returned if user verification is not done by the authenticator.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private suspend fun execStep11And12SelectCredential() {
-        // Sort credentials by creation time in reverse order (most recent first)
-        assertionObjects = assertionObjects.sortedByDescending { it.credential.createdAt.epochSecond }
-
-        // Mask user identifiable information if user verification was not performed
-        if (!(userVerificationPlan || authenticatorGetAssertionRequest.pinAuth != null)) {
-            assertionObjects.map {
-                it.maskUserIdentifiableInfo = true
-            }
-        }
-
-        // Build authenticator data flags
+        // Build authenticator data flags from uv/up results
         var flags: Byte = 0
-        if (userVerificationResult) {
+        if (uvResult) {
             flags = flags or AuthenticatorData.BIT_UV
         }
-        if (userPresenceResult) {
+        if (upResult) {
             flags = flags or AuthenticatorData.BIT_UP
         }
-
         assertionObjects.forEach { assertionObject ->
             assertionObject.flags = flags
             if (assertionObject.extensions.keys.isNotEmpty()) {
                 assertionObject.flags = assertionObject.flags or AuthenticatorData.BIT_ED
             }
         }
-        onGoingGetAssertionSession = GetAssertionSession(assertionObjects, clientDataHash)
-        ctapAuthenticatorSession.onGoingGetAssertionSession = onGoingGetAssertionSession
 
-        // If authenticator has a display, let user select a credential
-        if (ctapAuthenticatorSession.credentialSelector == CredentialSelectorSetting.AUTHENTICATOR) {
-            val selectedCredential: Credential =
-                ctapAuthenticatorSession.credentialSelectionHandler.onSelect(credentials)
-            val selectedAssertionObject =
-                assertionObjects.find { it.credential.credentialId.contentEquals(selectedCredential.credentialId) }
-                    ?: throw IllegalStateException("Selected Credential is not found in AssertionObject list")
-            onGoingGetAssertionSession =
-                onGoingGetAssertionSession.withAssertionObjects(listOf(selectedAssertionObject))
+        //spec| Step 11. If the allowList parameter is present:
+        if (allowList != null && allowList.isNotEmpty()) {
+            //spec| 11.1 Select any credential from the applicable credentials list.
+            onGoingGetAssertionSession = GetAssertionSession(assertionObjects, clientDataHash)
             ctapAuthenticatorSession.onGoingGetAssertionSession = onGoingGetAssertionSession
+            //spec| 11.2 Delete the numberOfCredentials member.
+            suppressNumberOfCredentials = true
+            //spec| 11.3 Go to Step 13.
+        }
+        //spec| Step 12. If allowList is not present:
+        else {
+            val numberOfCredentials = assertionObjects.size
+            //spec| 12.1 If numberOfCredentials is one:
+            if (numberOfCredentials == 1) {
+                //spec| 12.1.1 Select that credential.
+                onGoingGetAssertionSession = GetAssertionSession(assertionObjects, clientDataHash)
+                ctapAuthenticatorSession.onGoingGetAssertionSession = onGoingGetAssertionSession
+            }
+            //spec| 12.2 If numberOfCredentials is more than one:
+            else if (numberOfCredentials > 1) {
+                //spec| 12.2.1 Order the credentials in the applicable credentials list by the time when they were created in reverse order.
+                //spec| (I.e. the first credential is the most recently created.)
+                assertionObjects = assertionObjects.sortedByDescending { it.credential.createdAt.epochSecond }
+
+                //spec| 12.2.2 If the authenticator does not have a display, or the authenticator does have a display and the "uv" and "up" options are false:
+                if (ctapAuthenticatorSession.credentialSelector != CredentialSelectorSetting.AUTHENTICATOR || (!shouldPerformUv && !shouldPerformUp)) {
+                    //spec| 12.2.2.1 Remember the authenticatorGetAssertion parameters.
+                    //spec| 12.2.2.2 Create a credential counter (credentialCounter) and set it to 1.
+                    //spec| This counter signifies the next credential to be returned by the authenticator, assuming zero-based indexing.
+                    //spec| 12.2.2.3 Start a timer. This is used during authenticatorGetNextAssertion command. This step is OPTIONAL if transport is done over NFC.
+                    //spec| 12.2.2.4 Select the first credential.
+                    onGoingGetAssertionSession = GetAssertionSession(assertionObjects, clientDataHash)
+                    ctapAuthenticatorSession.onGoingGetAssertionSession = onGoingGetAssertionSession
+                }
+                //spec| 12.2.3 If the authenticator has a display and at least one of the "uv" and "up" options is true:
+                else {
+                    //spec| 12.2.3.1 Display all the credentials in the applicable credentials list to the user, using their friendly name along with other stored account information.
+                    //spec| 12.2.3.2 Also, display the rpId of the requester (specified in the request) and ask the user to select a credential.
+                    //spec| 12.2.3.3 If the user declines to select a credential or takes too long (as determined by the authenticator), terminate this procedure and return the CTAP2_ERR_OPERATION_DENIED error.
+                    val selectedCredential: Credential
+                    try {
+                        selectedCredential = ctapAuthenticatorSession.credentialSelectionHandler.onSelect(credentials)
+                    } catch (e: CredentialSelectionCanceledException) {
+                        throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED, e)
+                    }
+                    val selectedAssertionObject =
+                        assertionObjects.find { it.credential.credentialId.contentEquals(selectedCredential.credentialId) }
+                            ?: throw IllegalStateException("Selected Credential is not found in AssertionObject list")
+                    //spec| 12.2.3.4 Update the response to set the userSelected member to true and to delete the numberOfCredentials member.
+                    userSelected = true
+                    suppressNumberOfCredentials = true
+                    //spec| 12.2.3.5 Select the credential indicated by the user.
+                    onGoingGetAssertionSession = GetAssertionSession(listOf(selectedAssertionObject), clientDataHash)
+                    ctapAuthenticatorSession.onGoingGetAssertionSession = onGoingGetAssertionSession
+                }
+            }
+
+            //spec| 12.3 Update the response to include the selected credential's publicKeyCredentialUserEntity information.
+            //spec| User identifiable information (name, DisplayName, icon) inside the publicKeyCredentialUserEntity MUST NOT be returned if user verification is not done by the authenticator.
+            if (!uvResult) {
+                onGoingGetAssertionSession.assertionObjects.forEach {
+                    it.maskUserIdentifiableInfo = true
+                }
+            }
         }
     }
 
-    //spec| Step 13
-    //spec| Sign the clientDataHash along with authData with the selected credential, using the structure specified in [WebAuthn].
-    //spec| @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg">6.2.2. authenticatorGetAssertion Algorithm</a>
+    //spec| Step 13. Sign the clientDataHash along with authData with the selected credential, using the structure specified in [WebAuthn].
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-getAssert-authnr-alg
     private fun execStep13Sign(): AuthenticatorGetAssertionResponse {
-        val assertionObject = onGoingGetAssertionSession.nextAssertionObject()
+        //spec| Step 13. Sign the clientDataHash along with authData with the selected credential, using the structure specified in [WebAuthn].
+        val assertionObject = onGoingGetAssertionSession.currentAssertionObject()
+        onGoingGetAssertionSession.incrementCredentialCounter()
         val credential = assertionObject.credential
         val descriptor = PublicKeyCredentialDescriptor(
             PublicKeyCredentialType.PUBLIC_KEY,
@@ -423,10 +793,6 @@ internal class GetAssertionExecution :
         )
         val authData = ctapAuthenticatorSession.authenticatorDataConverter.convert(authenticatorDataObject)
 
-        // Let signature be the assertion signature of the concatenation authenticatorData || hash using
-        // the privateKey of selectedCredential as shown in Figure 2, below. A simple, un-delimited concatenation is
-        // safe to use here because the authenticator data describes its own length.
-        // The hash of the serialized client data (which potentially has a variable length) is always the last element.
         val clientDataHash = onGoingGetAssertionSession.clientDataHash
         val signedData = ByteBuffer.allocate(authData.size + clientDataHash.size).put(authData)
             .put(clientDataHash).array()
@@ -452,15 +818,15 @@ internal class GetAssertionExecution :
             }
             else -> null
         }
-        val numberOfCredentials = onGoingGetAssertionSession.numberOfAssertionObjects
+        val numberOfCredentials = if (suppressNumberOfCredentials) null else onGoingGetAssertionSession.numberOfAssertionObjects
 
-        //spec| On success, the authenticator returns an attestation object in its response as defined in [WebAuthn]:
         val responseData = AuthenticatorGetAssertionResponseData(
             descriptor,
             authData,
             signature,
             user,
-            numberOfCredentials
+            numberOfCredentials,
+            if (userSelected) true else null
         )
 
         // update counter

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetNextAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetNextAssertionExecution.kt
@@ -1,9 +1,10 @@
 package com.webauthn4j.ctap.authenticator.execution
 
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
-import com.webauthn4j.ctap.authenticator.GetAssertionSession
 import com.webauthn4j.ctap.authenticator.SignatureCalculator.calculate
+import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.data.credential.UserCredential
+import com.webauthn4j.ctap.authenticator.store.StoreFullException
 import com.webauthn4j.ctap.core.data.AuthenticatorGetNextAssertionRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorGetNextAssertionResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorGetNextAssertionResponseData
@@ -12,15 +13,13 @@ import com.webauthn4j.ctap.core.data.CtapStatusCode
 import com.webauthn4j.data.PublicKeyCredentialDescriptor
 import com.webauthn4j.data.PublicKeyCredentialType
 import com.webauthn4j.data.attestation.authenticator.AuthenticatorData
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
-// @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorGetNextAssertion">5.3. authenticatorGetNextAssertion</a>
-//spec| This method is used to obtain the next per-credential signature for a given
-//spec| authenticatorGetAssertion request.
-//spec| This method takes no arguments as it is always follows a call to
-//spec| authenticatorGetAssertion or authenticatorGetNextAssertion.
+/**
+ * GetNextAssertion command execution
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetNextAssertion">CTAP 2.3 §6.3 authenticatorGetNextAssertion</a>
+ */
 internal class GetNextAssertionExecution(
     private val ctapAuthenticatorSession: CtapAuthenticatorSession,
     authenticatorGetNextAssertionRequest: AuthenticatorGetNextAssertionRequest
@@ -29,62 +28,60 @@ internal class GetNextAssertionExecution(
     authenticatorGetNextAssertionRequest
 ) {
 
-    private val logger: Logger = LoggerFactory.getLogger(GetNextAssertionExecution::class.java)
     override val commandName: String = "GetNextAssertion"
 
     override suspend fun validate() {
         // nop
     }
 
+    //spec| When this command is received, the authenticator performs the following procedure:
+    //spec| Step 1. If the authenticator does not remember any authenticatorGetAssertion parameters, return CTAP2_ERR_NOT_ALLOWED.
+    //spec| Step 2. If the credentialCounter is equal to or greater than numberOfCredentials, return CTAP2_ERR_NOT_ALLOWED.
+    //spec| Step 3. If timer since the last call to authenticatorGetAssertion/authenticatorGetNextAssertion is greater than 30 seconds,
+    //spec| discard the current authenticatorGetAssertion state and return CTAP2_ERR_NOT_ALLOWED.
+    //spec| This step is OPTIONAL if transport is done over NFC.
+    //spec| Step 4. Select the credential indexed by credentialCounter. (I.e. credentials[n] assuming a zero-based array.)
+    //spec| Step 5. Update the response to include the selected credential's publicKeyCredentialUserEntity information.
+    //spec| User identifiable information (name, DisplayName, icon) inside the publicKeyCredentialUserEntity MUST NOT be returned
+    //spec| if user verification was not done by the authenticator in the original authenticatorGetAssertion call.
+    //spec| Step 6. Sign the clientDataHash along with authData with the selected credential, using the structure specified in [WebAuthn].
+    //spec| Step 7. Reset the timer. This step is OPTIONAL if transport is done over NFC.
+    //spec| Step 8. Increment credentialCounter.
+    //
+    // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetNextAssertion
     override suspend fun doExecute(): AuthenticatorGetNextAssertionResponse {
 
-        //spec| Step1
-        //spec| If authenticator does not remember any authenticatorGetAssertion parameters, return CTAP2_ERR_NOT_ALLOWED.
-        val getAssertionSession = ctapAuthenticatorSession.onGoingGetAssertionSession?: return AuthenticatorGetNextAssertionResponse(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+        //spec| Step 1. If the authenticator does not remember any authenticatorGetAssertion parameters, return CTAP2_ERR_NOT_ALLOWED.
+        val getAssertionSession = ctapAuthenticatorSession.onGoingGetAssertionSession
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
 
-        //spec| Step2
-        //spec| If the credentialCounter is equal to or greater than numberOfCredentials, return CTAP2_ERR_NOT_ALLOWED.
+        //spec| Step 2. If the credentialCounter is equal to or greater than numberOfCredentials, return CTAP2_ERR_NOT_ALLOWED.
         if (!getAssertionSession.hasNext()) {
-            return AuthenticatorGetNextAssertionResponse(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
         }
 
-        //spec| Step3
-        //spec| If timer since the last call to authenticatorGetAssertion/authenticatorGetNextAssertion is greater than 30 seconds,
+        //spec| Step 3. If timer since the last call to authenticatorGetAssertion/authenticatorGetNextAssertion is greater than 30 seconds,
         //spec| discard the current authenticatorGetAssertion state and return CTAP2_ERR_NOT_ALLOWED.
-        //spec| This step is optional if transport is done over NFC.
+        //spec| This step is OPTIONAL if transport is done over NFC.
         if (getAssertionSession.isExpired()) {
             ctapAuthenticatorSession.onGoingGetAssertionSession = null
-            return AuthenticatorGetNextAssertionResponse(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
         }
 
-        //spec| Step4
-        //spec| Sign the clientDataHash along with authData with the credential
-        //spec| using credentialCounter as index (e.g., credentials[n] assuming 0-based array), using the structure specified in [WebAuthn].
-        val assertionObject = getAssertionSession.nextAssertionObject()
+        //spec| Step 4. Select the credential indexed by credentialCounter. (I.e. credentials[n] assuming a zero-based array.)
+        val assertionObject = getAssertionSession.currentAssertionObject()
         val credential = assertionObject.credential
         val descriptor = PublicKeyCredentialDescriptor(
             PublicKeyCredentialType.PUBLIC_KEY,
             credential.credentialId,
             ctapAuthenticatorSession.transports
         )
-        val counter = credential.counter
-        val authenticatorDataObject = AuthenticatorData(
-            assertionObject.credential.rpIdHash,
-            assertionObject.flags,
-            counter,
-            assertionObject.extensions
-        )
-        val authData = ctapAuthenticatorSession.authenticatorDataConverter.convert(authenticatorDataObject)
-        val clientDataHash = getAssertionSession.clientDataHash
-        val signedData = ByteBuffer.allocate(authData.size + clientDataHash.size).put(authData)
-            .put(clientDataHash).array()
-        val signature = calculate(
-            credential.credentialKey.alg!!,
-            credential.credentialKey.keyPair!!.private,
-            signedData
-        )
+
+        //spec| Step 5. Update the response to include the selected credential's publicKeyCredentialUserEntity information.
+        //spec| User identifiable information (name, DisplayName, icon) inside the publicKeyCredentialUserEntity MUST NOT be returned
+        //spec| if user verification was not done by the authenticator in the original authenticatorGetAssertion call.
         val user = when (credential) {
-            is UserCredential -> when(assertionObject.maskUserIdentifiableInfo){
+            is UserCredential -> when (assertionObject.maskUserIdentifiableInfo) {
                 true -> CtapPublicKeyCredentialUserEntity(
                     credential.userHandle,
                     null,
@@ -101,13 +98,40 @@ internal class GetNextAssertionExecution(
             else -> null
         }
 
-        //spec| Step5
-        //spec| Reset the timer. This step is optional if transport is done over NFC.
+        //spec| Step 6. Sign the clientDataHash along with authData with the selected credential, using the structure specified in [WebAuthn].
+        val counter = credential.counter
+        val authenticatorDataObject = AuthenticatorData(
+            assertionObject.credential.rpIdHash,
+            assertionObject.flags,
+            counter,
+            assertionObject.extensions
+        )
+        val authData = ctapAuthenticatorSession.authenticatorDataConverter.convert(authenticatorDataObject)
+        val clientDataHash = getAssertionSession.clientDataHash
+        val signedData = ByteBuffer.allocate(authData.size + clientDataHash.size).put(authData)
+            .put(clientDataHash).array()
+        val signature = calculate(
+            credential.credentialKey.alg!!,
+            credential.credentialKey.keyPair!!.private,
+            signedData
+        )
+
+        // Update credential counter (same as GetAssertionExecution Step 13)
+        if (credential is ResidentUserCredential) {
+            credential.counter = counter + 1
+            try {
+                ctapAuthenticatorSession.authenticatorPropertyStore.saveUserCredential(credential)
+            } catch (e: StoreFullException) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_KEY_STORE_FULL, e)
+            }
+        }
+
+        //spec| Step 7. Reset the timer. This step is OPTIONAL if transport is done over NFC.
         getAssertionSession.resetTimer()
 
-        //spec| Step6
-        //spec| Increment credentialCounter.
-        // This is done in `getAssertionSession.nextUserCredential();`
+        //spec| Step 8. Increment credentialCounter.
+        getAssertionSession.incrementCredentialCounter()
+
         val responseData =
             AuthenticatorGetNextAssertionResponseData(descriptor, authData, signature, user)
         return AuthenticatorGetNextAssertionResponse(CtapStatusCode.CTAP2_OK, responseData)

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -111,9 +111,6 @@ internal class MakeCredentialExecution :
         get() = ctapAuthenticatorSession.isClientPINReady ||
                 ctapAuthenticatorSession.userVerification == UserVerificationSetting.READY
 
-    private fun isSupportedPinProtocol(version: PinProtocolVersion): Boolean =
-        version in ctapAuthenticatorSession.pinProtocols
-
     constructor(
         ctapAuthenticatorSession: CtapAuthenticatorSession,
         authenticatorMakeCredentialCommand: AuthenticatorMakeCredentialRequest
@@ -132,8 +129,8 @@ internal class MakeCredentialExecution :
         this.excludeList = authenticatorMakeCredentialCommand.excludeList
         this.registrationExtensionAuthenticatorInputs = authenticatorMakeCredentialCommand.extensions
         this.options = authenticatorMakeCredentialCommand.options
-        this.pinUvAuthParam = authenticatorMakeCredentialCommand.pinAuth
-        this.pinUvAuthProtocol = authenticatorMakeCredentialCommand.pinProtocol
+        this.pinUvAuthParam = authenticatorMakeCredentialCommand.pinUvAuthParam
+        this.pinUvAuthProtocol = authenticatorMakeCredentialCommand.pinUvAuthProtocol
         // Default to the highest version protocol (list is sorted by version descending).
         // Overridden in Step 2 when pinUvAuthParam is present.
         this.protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols.first()
@@ -162,7 +159,7 @@ internal class MakeCredentialExecution :
         execStep1ZeroLengthPinUvAuthParam()
         execStep2ValidatePinUvAuthProtocol()
         execStep3ValidatePubKeyCredParams()
-        // Step 4: response structure initialized via field declarations (upResult=false, uvResult=false)
+        // TODO: Step 4: Create a new response structure. Currently represented by field declarations (upResult=false, uvResult=false).
         execStep5ProcessOptions()
         // Initialize from authenticator setting; Step 6.1 may override to false when alwaysUv is enabled.
         makeCredUvNotRqd = ctapAuthenticatorSession.makeCredUvNotRqd == MakeCredUvNotRqdSetting.ENABLED
@@ -211,9 +208,8 @@ internal class MakeCredentialExecution :
         //spec| Step 1. If authenticator supports either pinUvAuthToken or clientPin features and the platform sends a zero length pinUvAuthParam:
         if (pinUvAuthParam != null && pinUvAuthParam.isEmpty()) {
             //spec| 1.1 Request evidence of user interaction in an authenticator-specific way (e.g., flash the LED light).
-            val consent = performBuiltInUp()
             //spec| 1.2 If the user declines permission, or the operation times out, then end the operation by returning CTAP2_ERR_OPERATION_DENIED.
-            if (!consent) {
+            if (!performBuiltInUp()) {
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
             }
             //spec| 1.3 If evidence of user interaction is provided in this step then return either
@@ -236,11 +232,9 @@ internal class MakeCredentialExecution :
         if (pinUvAuthParam != null) {
             if (pinUvAuthProtocol != null) {
                 //spec| 2.1 If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
-                if (!isSupportedPinProtocol(pinUvAuthProtocol)) {
-                    throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
-                }
                 protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols
-                    .first { it.version == pinUvAuthProtocol }
+                    .firstOrNull { it.version == pinUvAuthProtocol }
+                    ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
             } else {
                 //spec| 2.2 If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
                 throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
@@ -498,14 +492,14 @@ internal class MakeCredentialExecution :
     //spec|     11.1.8 Go to Step 12.
     //spec|   11.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
     //spec|   and that the authenticator supports an enabled built-in user verification method, see Step 5):
-    //spec|     Let internalRetry be true.
-    //spec|     Let uvState be the result of calling performBuiltInUv(internalRetry)
-    //spec|     If uvState is error:
-    //spec|       If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
-    //spec|       If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
-    //spec|       Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
-    //spec|     If uvState is success:
-    //spec|       Set the "uv" bit to true in the response.
+    //spec|     11.2.1 Let internalRetry be true.
+    //spec|     11.2.2 Let uvState be the result of calling performBuiltInUv(internalRetry)
+    //spec|     11.2.3 If uvState is error:
+    //spec|       11.2.3.1 If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+    //spec|       11.2.3.2 If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
+    //spec|       11.2.3.3 Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+    //spec|     11.2.4 If uvState is success:
+    //spec|       11.2.4.1 Set the "uv" bit to true in the response.
     //
     // @see https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-makeCred-authnr-alg
     private suspend fun execStep11ProcessUserVerification() {
@@ -513,7 +507,6 @@ internal class MakeCredentialExecution :
         if (isProtectedByUserVerification) {
             //spec| 11.1 If pinUvAuthParam parameter is present (implying the "uv" option is false (see Step 5)):
             if (pinUvAuthParam != null) {
-                val protocol = protocol
                 //spec| 11.1.1 Call verify(pinUvAuthToken, clientDataHash, pinUvAuthParam).
                 //spec| If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
                 if (!protocol.verify(protocol.pinUvAuthToken, clientDataHash, pinUvAuthParam)) {
@@ -549,7 +542,8 @@ internal class MakeCredentialExecution :
                     protocol.tokenState.permissionsRpId = rpId
                 }
 
-                protocol.tokenState.recordPlatformUsage()
+                // Record token usage to prevent expiration by initial usage time limit (§6.5.2.1)
+                protocol.tokenState.recordTokenUsage()
                 //spec| 11.1.8 Go to Step 12.
                 return
             }
@@ -557,11 +551,16 @@ internal class MakeCredentialExecution :
             //spec| 11.2 If the "uv" option is present and set to true (implying the pinUvAuthParam parameter is not present,
             //spec| and that the authenticator supports an enabled built-in user verification method, see Step 5):
             if (shouldPerformUv) {
+                //spec| 11.2.1 Let internalRetry be true.
                 //spec| 11.2.2 Let uvState be the result of calling performBuiltInUv(internalRetry)
                 uvState = performBuiltInUv()
                 if (!uvState) {
                     //spec| 11.2.3 If uvState is error:
-                    //spec|   11.2.3.4 Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+                    //spec|   11.2.3.1 If the error reason is a user action timeout, then return CTAP2_ERR_USER_ACTION_TIMEOUT.
+                    //spec|   11.2.3.2 If the uvRetries counter is 0, return CTAP2_ERR_PIN_BLOCKED.
+                    //spec|   11.2.3.3 Otherwise, end the operation by returning CTAP2_ERR_OPERATION_DENIED.
+                    // Simplified: performBuiltInUv() returns a boolean; detailed error reasons
+                    // (timeout, blocked) are not yet distinguished.
                     throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
                 }
                 else{

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
@@ -51,16 +51,16 @@ internal class CtapClientTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             RP_ID,
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_OK)
@@ -92,8 +92,8 @@ internal class CtapClientTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -102,8 +102,8 @@ internal class CtapClientTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         return try {
             connection.makeCredential(command)

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
@@ -55,16 +55,16 @@ internal class GetAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_OK)
@@ -91,16 +91,16 @@ internal class GetAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
@@ -116,16 +116,16 @@ internal class GetAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
@@ -141,16 +141,16 @@ internal class GetAssertionExecutionTest {
         val allowList: List<PublicKeyCredentialDescriptor> = emptyList()
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             null,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_OK)
@@ -180,16 +180,16 @@ internal class GetAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_ERR_KEY_STORE_FULL)
@@ -223,16 +223,16 @@ internal class GetAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = up, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(statusCode)
@@ -243,8 +243,8 @@ internal class GetAssertionExecutionTest {
     @CsvSource(
         value = [
             "true, READY, CTAP2_OK",
-            "true, NOT_READY, CTAP2_ERR_UNSUPPORTED_OPTION",
-            "true, NOT_SUPPORTED, CTAP2_ERR_UNSUPPORTED_OPTION",
+            "true, NOT_READY, CTAP2_ERR_INVALID_OPTION",
+            "true, NOT_SUPPORTED, CTAP2_ERR_INVALID_OPTION",
             "false, READY, CTAP2_OK",
             "false, NOT_READY, CTAP2_OK",
             "false, NOT_SUPPORTED, CTAP2_OK",
@@ -270,16 +270,16 @@ internal class GetAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = uv)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response: AuthenticatorGetAssertionResponse = connection.getAssertion(command)
         Assertions.assertThat(response.statusCode).isEqualTo(statusCode)
@@ -305,8 +305,8 @@ internal class GetAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = rk, uv = uv)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -315,8 +315,8 @@ internal class GetAssertionExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response = ctapAuthenticatorSession.makeCredential(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_OK)

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
@@ -52,16 +52,16 @@ class GetNextAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         connection.getAssertion(command)
         val response = connection.getNextAssertion()
@@ -93,16 +93,16 @@ class GetNextAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
         val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorGetAssertionRequest(
             "example.com",
             clientDataHash,
             allowList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         connection.getAssertion(command) // fetch 1st credential
         connection.getNextAssertion(AuthenticatorGetNextAssertionRequest()) // fetch 2nd credential
@@ -130,16 +130,16 @@ class GetNextAssertionExecutionTest {
             val extensions =
                 AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>()
             val options = AuthenticatorGetAssertionRequest.Options(up = true, uv = true)
-            val pinAuth: ByteArray? = null
-            val pinProtocol: PinProtocolVersion? = null
+            val pinUvAuthParam: ByteArray? = null
+            val pinUvAuthProtocol: PinProtocolVersion? = null
             val command = AuthenticatorGetAssertionRequest(
                 "example.com",
                 clientDataHash,
                 allowList,
                 extensions,
                 options,
-                pinAuth,
-                pinProtocol
+                pinUvAuthParam,
+                pinUvAuthProtocol
             )
 
             it.`when`<Instant>(Instant::now)
@@ -177,8 +177,8 @@ class GetNextAssertionExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = rk, uv = uv)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -187,8 +187,8 @@ class GetNextAssertionExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response = ctapAuthenticatorSession.makeCredential(command)
         Assertions.assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_OK)

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
@@ -53,8 +53,8 @@ internal class MakeCredentialExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -63,8 +63,8 @@ internal class MakeCredentialExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response = connection.makeCredential(command)
         assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_OK)
@@ -99,8 +99,8 @@ internal class MakeCredentialExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -109,8 +109,8 @@ internal class MakeCredentialExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
         val response = connection.makeCredential(command)
         assertThat(response.statusCode).isEqualTo(CtapStatusCode.CTAP2_ERR_KEY_STORE_FULL)
@@ -141,8 +141,8 @@ internal class MakeCredentialExecutionTest {
         val excludeList: List<PublicKeyCredentialDescriptor> = emptyList()
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -151,8 +151,8 @@ internal class MakeCredentialExecutionTest {
             excludeList,
             extensions,
             null,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
 
         val ctapAuthenticator = CtapAuthenticator()
@@ -198,8 +198,8 @@ internal class MakeCredentialExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = rk, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -208,8 +208,8 @@ internal class MakeCredentialExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
 
         val ctapAuthenticator = CtapAuthenticator()
@@ -253,8 +253,8 @@ internal class MakeCredentialExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = uv)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -263,8 +263,8 @@ internal class MakeCredentialExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
 
         val ctapAuthenticator = CtapAuthenticator()
@@ -299,8 +299,8 @@ internal class MakeCredentialExecutionTest {
             val extensions =
                 AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
             val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = false)
-            val pinAuth: ByteArray? = null
-            val pinProtocol: PinProtocolVersion? = null
+            val pinUvAuthParam: ByteArray? = null
+            val pinUvAuthProtocol: PinProtocolVersion? = null
             val command = AuthenticatorMakeCredentialRequest(
                 clientDataHash,
                 rp,
@@ -309,8 +309,8 @@ internal class MakeCredentialExecutionTest {
                 excludeList,
                 extensions,
                 options,
-                pinAuth,
-                pinProtocol
+                pinUvAuthParam,
+                pinUvAuthProtocol
             )
 
             val ctapAuthenticator = CtapAuthenticator()
@@ -339,8 +339,8 @@ internal class MakeCredentialExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -349,8 +349,8 @@ internal class MakeCredentialExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
 
         val ctapAuthenticator = CtapAuthenticator()
@@ -381,8 +381,8 @@ internal class MakeCredentialExecutionTest {
         val extensions =
             AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
         val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = true)
-        val pinAuth: ByteArray? = null
-        val pinProtocol: PinProtocolVersion? = null
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
         val command = AuthenticatorMakeCredentialRequest(
             clientDataHash,
             rp,
@@ -391,8 +391,8 @@ internal class MakeCredentialExecutionTest {
             excludeList,
             extensions,
             options,
-            pinAuth,
-            pinProtocol
+            pinUvAuthParam,
+            pinUvAuthProtocol
         )
 
         val ctapAuthenticator = CtapAuthenticator()

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetAssertionRequestSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetAssertionRequestSerializer.kt
@@ -10,7 +10,7 @@ class AuthenticatorGetAssertionRequestSerializer :
             FieldSerializationRule(3, AuthenticatorGetAssertionRequest::allowList),
             FieldSerializationRule(4, AuthenticatorGetAssertionRequest::extensions),
             FieldSerializationRule(5, AuthenticatorGetAssertionRequest::options),
-            FieldSerializationRule(6, AuthenticatorGetAssertionRequest::pinAuth),
-            FieldSerializationRule(7, AuthenticatorGetAssertionRequest::pinProtocol)
+            FieldSerializationRule(6, AuthenticatorGetAssertionRequest::pinUvAuthParam),
+            FieldSerializationRule(7, AuthenticatorGetAssertionRequest::pinUvAuthProtocol)
         )
     )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorMakeCredentialRequestSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorMakeCredentialRequestSerializer.kt
@@ -12,7 +12,7 @@ class AuthenticatorMakeCredentialRequestSerializer :
             FieldSerializationRule(5, AuthenticatorMakeCredentialRequest::excludeList),
             FieldSerializationRule(6, AuthenticatorMakeCredentialRequest::extensions),
             FieldSerializationRule(7, AuthenticatorMakeCredentialRequest::options),
-            FieldSerializationRule(8, AuthenticatorMakeCredentialRequest::pinAuth),
-            FieldSerializationRule(9, AuthenticatorMakeCredentialRequest::pinProtocol)
+            FieldSerializationRule(8, AuthenticatorMakeCredentialRequest::pinUvAuthParam),
+            FieldSerializationRule(9, AuthenticatorMakeCredentialRequest::pinUvAuthProtocol)
         )
     )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetAssertionRequest.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetAssertionRequest.kt
@@ -16,8 +16,8 @@ class AuthenticatorGetAssertionRequest(
     @JsonProperty("3") allowList: List<PublicKeyCredentialDescriptor>?,
     @JsonProperty("4") extensions: AuthenticationExtensionsAuthenticatorInputs<AuthenticationExtensionAuthenticatorInput>?,
     @JsonProperty("5") options: Options?,
-    @JsonProperty("6") pinAuth: ByteArray?,
-    @JsonProperty("7") pinProtocol: PinProtocolVersion?
+    @JsonProperty("6") pinUvAuthParam: ByteArray?,
+    @JsonProperty("7") pinUvAuthProtocol: PinProtocolVersion?
 ) : CtapRequest {
 
     override val command: CtapCommand = CtapCommand.GET_ASSERTION
@@ -28,9 +28,9 @@ class AuthenticatorGetAssertionRequest(
     val allowList = allowList?.toList()
     val extensions = extensions
     val options = options
-    val pinAuth: ByteArray? = ArrayUtil.clone(pinAuth)
+    val pinUvAuthParam: ByteArray? = ArrayUtil.clone(pinUvAuthParam)
         get() = ArrayUtil.clone(field)
-    val pinProtocol = pinProtocol
+    val pinUvAuthProtocol = pinUvAuthProtocol
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -42,7 +42,7 @@ class AuthenticatorGetAssertionRequest(
         if (allowList != other.allowList) return false
         if (extensions != other.extensions) return false
         if (options != other.options) return false
-        if (pinProtocol != other.pinProtocol) return false
+        if (pinUvAuthProtocol != other.pinUvAuthProtocol) return false
 
         return true
     }
@@ -52,7 +52,7 @@ class AuthenticatorGetAssertionRequest(
         result = 31 * result + (allowList?.hashCode() ?: 0)
         result = 31 * result + (extensions?.hashCode() ?: 0)
         result = 31 * result + (options?.hashCode() ?: 0)
-        result = 31 * result + (pinProtocol?.hashCode() ?: 0)
+        result = 31 * result + (pinUvAuthProtocol?.hashCode() ?: 0)
         return result
     }
 
@@ -61,18 +61,23 @@ class AuthenticatorGetAssertionRequest(
             HexUtil.encodeToString(
                 clientDataHash
             )
-        }, allowList=$allowList, extensions=$extensions, options=$options, pinAuth=${
+        }, allowList=$allowList, extensions=$extensions, options=$options, pinUvAuthParam=${
             HexUtil.encodeToString(
-                pinAuth
+                pinUvAuthParam
             )
-        }, pinProtocol=$pinProtocol)"
+        }, pinUvAuthProtocol=$pinUvAuthProtocol)"
     }
 
 
     class Options @JsonCreator constructor(
+        @param:JsonProperty("rk") rk: Boolean?,
         @param:JsonProperty("up") val up: Boolean?,
         @param:JsonProperty("uv") val uv: Boolean?
     ) {
+        // Not a valid GetAssertion option; detected for Step 4.4 rejection (CTAP2_ERR_UNSUPPORTED_OPTION).
+        val rk: Boolean? = rk
+
+        constructor(up: Boolean?, uv: Boolean?) : this(null, up, uv)
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetAssertionResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetAssertionResponseData.kt
@@ -12,8 +12,21 @@ class AuthenticatorGetAssertionResponseData @JsonCreator constructor(
     @JsonProperty("2") authData: ByteArray,
     @JsonProperty("3") signature: ByteArray,
     @JsonProperty("4") user: CtapPublicKeyCredentialUserEntity?,
-    @JsonProperty("5") numberOfCredentials: Int?
+    @JsonProperty("5") numberOfCredentials: Int?,
+    @JsonProperty("6") userSelected: Boolean?
+    // TODO: largeBlobKey (0x07) - "The contents of the associated largeBlobKey if present for the asserted credential,
+    //  and if largeBlobKey was true in the extensions input."
+    // TODO: unsignedExtensionOutputs (0x08) - "A map, keyed by extension identifiers, to unsigned outputs of extensions, if any.
+    //  Authenticators SHOULD omit this field if no processed extensions define unsigned outputs."
 ) : CtapResponseData {
+
+    constructor(
+        credential: PublicKeyCredentialDescriptor?,
+        authData: ByteArray,
+        signature: ByteArray,
+        user: CtapPublicKeyCredentialUserEntity?,
+        numberOfCredentials: Int?
+    ) : this(credential, authData, signature, user, numberOfCredentials, null)
 
     val credential: PublicKeyCredentialDescriptor? = credential
     val authData: ByteArray = ArrayUtil.clone(authData)
@@ -22,6 +35,7 @@ class AuthenticatorGetAssertionResponseData @JsonCreator constructor(
         get() = ArrayUtil.clone(field)
     val user: CtapPublicKeyCredentialUserEntity? = user
     val numberOfCredentials: Int? = numberOfCredentials
+    val userSelected: Boolean? = userSelected
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -32,6 +46,7 @@ class AuthenticatorGetAssertionResponseData @JsonCreator constructor(
         if (credential != other.credential) return false
         if (user != other.user) return false
         if (numberOfCredentials != other.numberOfCredentials) return false
+        if (userSelected != other.userSelected) return false
 
         return true
     }
@@ -40,6 +55,7 @@ class AuthenticatorGetAssertionResponseData @JsonCreator constructor(
         var result = credential?.hashCode() ?: 0
         result = 31 * result + (user?.hashCode() ?: 0)
         result = 31 * result + (numberOfCredentials ?: 0)
+        result = 31 * result + (userSelected?.hashCode() ?: 0)
         return result
     }
 
@@ -48,7 +64,7 @@ class AuthenticatorGetAssertionResponseData @JsonCreator constructor(
             HexUtil.encodeToString(
                 authData
             )
-        }, signature=${HexUtil.encodeToString(signature)}, user=$user, numberOfCredentials=$numberOfCredentials)"
+        }, signature=${HexUtil.encodeToString(signature)}, user=$user, numberOfCredentials=$numberOfCredentials, userSelected=$userSelected)"
     }
 
 

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorMakeCredentialRequest.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorMakeCredentialRequest.kt
@@ -19,8 +19,10 @@ class AuthenticatorMakeCredentialRequest @JsonCreator constructor(
     @JsonProperty("5") excludeList: List<PublicKeyCredentialDescriptor>?,
     @JsonProperty("6") extensions: AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>?,
     @JsonProperty("7") options: Options?,
-    @JsonProperty("8") pinAuth: ByteArray?,
-    @JsonProperty("9") pinProtocol: PinProtocolVersion?
+    @JsonProperty("8") pinUvAuthParam: ByteArray?,
+    @JsonProperty("9") pinUvAuthProtocol: PinProtocolVersion?
+    // TODO: enterpriseAttestation (0x0A) - §6.1 "This is an unsigned integer or absent."
+    // TODO: attestationFormatsPreference (0x0B) - §6.1 "An ordered list of preferred attestation statement formats."
 ) : CtapRequest {
 
     override val command: CtapCommand = CtapCommand.MAKE_CREDENTIAL
@@ -36,9 +38,9 @@ class AuthenticatorMakeCredentialRequest @JsonCreator constructor(
     val extensions: AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>? =
         extensions
     val options: Options? = options
-    val pinAuth: ByteArray? = ArrayUtil.clone(pinAuth)
+    val pinUvAuthParam: ByteArray? = ArrayUtil.clone(pinUvAuthParam)
         get() = ArrayUtil.clone(field)
-    val pinProtocol: PinProtocolVersion? = pinProtocol
+    val pinUvAuthProtocol: PinProtocolVersion? = pinUvAuthProtocol
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -50,7 +52,7 @@ class AuthenticatorMakeCredentialRequest @JsonCreator constructor(
         if (user != other.user) return false
         if (extensions != other.extensions) return false
         if (options != other.options) return false
-        if (pinProtocol != other.pinProtocol) return false
+        if (pinUvAuthProtocol != other.pinUvAuthProtocol) return false
 
         return true
     }
@@ -60,7 +62,7 @@ class AuthenticatorMakeCredentialRequest @JsonCreator constructor(
         result = 31 * result + user.hashCode()
         result = 31 * result + (extensions?.hashCode() ?: 0)
         result = 31 * result + (options?.hashCode() ?: 0)
-        result = 31 * result + (pinProtocol?.hashCode() ?: 0)
+        result = 31 * result + (pinUvAuthProtocol?.hashCode() ?: 0)
         return result
     }
 
@@ -69,16 +71,16 @@ class AuthenticatorMakeCredentialRequest @JsonCreator constructor(
             HexUtil.encodeToString(
                 clientDataHash
             )
-        }, rp=$rp, user=$user, pubKeyCredParams=$pubKeyCredParams, excludeList=$excludeList, extensions=$extensions, options=$options, pinAuth=${
+        }, rp=$rp, user=$user, pubKeyCredParams=$pubKeyCredParams, excludeList=$excludeList, extensions=$extensions, options=$options, pinUvAuthParam=${
             HexUtil.encodeToString(
-                pinAuth
+                pinUvAuthParam
             )
-        }, pinProtocol=$pinProtocol)"
+        }, pinUvAuthProtocol=$pinUvAuthProtocol)"
     }
 
     class Options @JsonCreator constructor(
         @param:JsonProperty("rk") val rk: Boolean?,
-        @param:JsonProperty("up") val up: Boolean?, //This is a known but invalid option, and should return CTAP2_ERR_INVALID_OPTION if present
+        @param:JsonProperty("up") val up: Boolean?,
         @param:JsonProperty("uv") val uv: Boolean?
     ) {
 

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorMakeCredentialResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorMakeCredentialResponseData.kt
@@ -24,6 +24,9 @@ class AuthenticatorMakeCredentialResponseData : CtapResponseData {
     constructor(
         @JsonProperty("2") authenticatorData: AuthenticatorData<RegistrationExtensionAuthenticatorOutput>,
         @JsonProperty("3") attestationStatement: AttestationStatement
+        // TODO: epAtt (0x04) - §6.1 "true if an enterprise attestation was returned"
+        // TODO: largeBlobKey (0x05) - §6.1 "The largeBlobKey for the credential"
+        // TODO: unsignedExtensionOutputs (0x06) - §6.1 "A map, keyed by extension identifiers, to unsigned outputs of extensions"
     ) {
         this.authenticatorData = authenticatorData
         this.attestationStatement = attestationStatement

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorGetAssertionRequestValidator.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorGetAssertionRequestValidator.kt
@@ -6,7 +6,7 @@ import com.webauthn4j.data.PinProtocolVersion
 class AuthenticatorGetAssertionRequestValidator {
 
     fun validate(value: AuthenticatorGetAssertionRequest) {
-        require(value.pinAuth == null || value.pinAuth?.size == 16) { "pinAuth must be 16 bytes length" }
-        require(value.pinProtocol == null || value.pinProtocol == PinProtocolVersion.VERSION_1) { "Only PIN Protocol version 1 is supported" }
+        require(value.pinUvAuthParam == null || value.pinUvAuthParam?.size == 16) { "pinUvAuthParam must be 16 bytes length" }
+        require(value.pinUvAuthProtocol == null || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_1) { "Only PIN Protocol version 1 is supported" }
     }
 }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorMakeCredentialRequestValidator.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorMakeCredentialRequestValidator.kt
@@ -6,7 +6,7 @@ import com.webauthn4j.data.PinProtocolVersion
 class AuthenticatorMakeCredentialRequestValidator {
 
     fun validate(value: AuthenticatorMakeCredentialRequest) {
-        require(value.pinAuth == null || value.pinAuth?.isEmpty() == true || value.pinAuth?.size == 16) { "pinAuth must be empty or 16 bytes length" }
-        require(value.pinProtocol == null || value.pinProtocol == PinProtocolVersion.VERSION_1) { "Only PIN Protocol version 1 is supported" }
+        require(value.pinUvAuthParam == null || value.pinUvAuthParam?.isEmpty() == true || value.pinUvAuthParam?.size == 16) { "pinUvAuthParam must be empty or 16 bytes length" }
+        require(value.pinUvAuthProtocol == null || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_1) { "Only PIN Protocol version 1 is supported" }
     }
 }


### PR DESCRIPTION
Rewrite GetAssertionExecution and GetNextAssertionExecution to align with CTAP 2.3 §6.2.2 / §6.3.

- Implement Steps 1-2 (zero-length pinUvAuthParam, pinUvAuthProtocol validation)
- Implement Step 4 (options processing: uv/rk/up per spec 4.1-4.5, rk option rejection with CTAP2_ERR_UNSUPPORTED_OPTION)
- Implement Step 5 (alwaysUv enforcement with up=true)
- Rewrite Step 6 (pinUvAuthToken verify with getUserVerifiedFlagValue, permissions RP ID binding, built-in UV via performBuiltInUv)
- Implement Step 8 (UP from built-in UV evidence)
- Rewrite Step 9 (UP test with getUserPresentFlagValue, clearUserPresentFlag/clearUserVerifiedFlag/clearPinUvAuthTokenPermissionsExceptLbw)
- Rewrite Steps 11/12 with spec-aligned if/else structure (allowList present: suppress numberOfCredentials; allowList absent: credential ordering, display-based selection with CredentialSelectionCanceledException, userSelected response member)
- Fix GetNextAssertionExecution: throw CtapCommandExecutionException instead of returning error responses, add credential counter update, split nextAssertionObject into currentAssertionObject/incrementCredentialCounter for spec step ordering
- Add rk field to GetAssertion Options for Step 4.4 detection (not in equals/hashCode; spec defines only up/uv for GetAssertion)
- Add userSelected (0x06) to GetAssertion response, add rk to GetAssertion request Options
- Rename pinAuth/pinProtocol to pinUvAuthParam/pinUvAuthProtocol in both MakeCredential and GetAssertion request classes, serializers, validators, and tests
- Remove incorrect comment on MakeCredential Options.up ("known but invalid option")
- Rename recordPlatformUsage to recordTokenUsage in PinUvAuthTokenState
- Consolidate isSupportedPinProtocol into firstOrNull lookup in both MakeCredential and GetAssertion
- Add TODO comments with spec references for unimplemented response fields (largeBlobKey, unsignedExtensionOutputs, epAtt, enterpriseAttestation, attestationFormatsPreference)
- All spec comments (//spec|) are verbatim quotes placed inline within method bodies