### PR TITLE
Leverage JUnit 6 native suspend support to simplify test methods

### DIFF
--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
@@ -11,7 +11,6 @@ import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthen
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorInputs
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorInput
 import com.webauthn4j.util.exception.UnexpectedCheckedException
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.concurrent.ExecutionException
@@ -21,7 +20,7 @@ internal class CtapClientTest {
     private val connection = CtapAuthenticator().createSession()
 
     @Test
-    fun getInfo_test() = runTest {
+    suspend fun getInfo_test() {
         val response = connection.getInfo()
         Assertions.assertThat(response.responseData).isNotNull
         Assertions.assertThat(response.responseData!!.aaguid).isEqualTo(CtapAuthenticator.AAGUID)
@@ -44,7 +43,7 @@ internal class CtapClientTest {
     }
 
     @Test
-    fun getAssertion_test() = runTest {
+    suspend fun getAssertion_test() {
         makeCredential()
         val clientDataHash = ByteArray(0)
         val allowList: List<PublicKeyCredentialDescriptor> = emptyList()
@@ -68,7 +67,7 @@ internal class CtapClientTest {
     }
 
     @Test
-    fun reset_test() = runTest {
+    suspend fun reset_test() {
         makeCredential()
         Assertions.assertThat(connection.authenticatorPropertyStore.loadUserCredentials(RP_ID))
             .hasSize(1)

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapRequestExecutionBaseTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapRequestExecutionBaseTest.kt
@@ -4,16 +4,13 @@ import com.webauthn4j.ctap.authenticator.execution.CtapCommandExecutionBase
 import com.webauthn4j.ctap.core.data.CtapRequest
 import com.webauthn4j.ctap.core.data.CtapResponse
 import com.webauthn4j.ctap.core.data.CtapStatusCode
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 
-@ExperimentalCoroutinesApi
 internal class CtapRequestExecutionBaseTest {
 
     @Test
-    fun unexpected_execution_error_test() = runTest {
+    suspend fun unexpected_execution_error_test() {
 
         val connection = CtapAuthenticator().createSession()
         val target = TestCtapCommandExecution(connection, mock(CtapRequest::class.java))

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
@@ -21,8 +21,6 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorInput
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorInputs
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorInput
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -30,7 +28,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.mockito.Mockito.mock
 
-@ExperimentalCoroutinesApi
 internal class GetAssertionExecutionTest {
 
     @Disabled
@@ -46,7 +43,7 @@ internal class GetAssertionExecutionTest {
     }
 
     @Test
-    fun getAssertion_test() = runTest {
+    suspend fun getAssertion_test() {
         val connection = CtapAuthenticator().createSession()
         makeCredential(connection)
 
@@ -72,7 +69,7 @@ internal class GetAssertionExecutionTest {
     }
 
     @Test
-    fun userConsent_false_test() = runTest {
+    suspend fun userConsent_false_test() {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.userVerificationHandler = object : UserVerificationHandler {
             override fun getUserVerificationOption(rpId: String?): UserVerificationOption? {
@@ -107,7 +104,7 @@ internal class GetAssertionExecutionTest {
     }
 
     @Test
-    fun no_credentials_test() = runTest {
+    suspend fun no_credentials_test() {
         val ctapAuthenticator = CtapAuthenticator()
         val connection = ctapAuthenticator.createSession()
 
@@ -132,7 +129,7 @@ internal class GetAssertionExecutionTest {
     }
 
     @Test
-    fun options_null_test() = runTest {
+    suspend fun options_null_test() {
         val ctapAuthenticator = CtapAuthenticator()
         val connection = ctapAuthenticator.createSession()
         makeCredential(connection)
@@ -158,7 +155,7 @@ internal class GetAssertionExecutionTest {
     }
 
     @Test
-    fun store_full_test() = runTest {
+    suspend fun store_full_test() {
         var isFull = false
         val authenticatorPropertyStoreSpy =
             object : InMemoryAuthenticatorPropertyStore() {
@@ -204,11 +201,11 @@ internal class GetAssertionExecutionTest {
             "false, NOT_SUPPORTED, CTAP2_OK",
         ]
     )
-    fun up_userVerification_matrix_test(
+    suspend fun up_userVerification_matrix_test(
         up: Boolean,
         userPresenceSetting: UserPresenceSetting,
         statusCode: CtapStatusCode
-    ) = runTest {
+    ) {
         // Create a credential with default settings first,
         // then switch to the target userPresence setting for the GetAssertion test.
         val ctapAuthenticator = CtapAuthenticator()
@@ -250,11 +247,11 @@ internal class GetAssertionExecutionTest {
             "false, NOT_SUPPORTED, CTAP2_OK",
         ]
     )
-    fun uv_userVerification_matrix_test(
+    suspend fun uv_userVerification_matrix_test(
         uv: Boolean,
         userVerificationSetting: UserVerificationSetting,
         statusCode: CtapStatusCode
-    ) = runTest {
+    ) {
         // Create a credential with default settings (userVerification=READY) first,
         // then switch to the target userVerification setting for the GetAssertion test.
         // This is needed because MakeCredential requires UV on a UV-protected authenticator (Step 8).

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
@@ -17,15 +17,12 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionAuthenticatorInput
 import com.webauthn4j.data.extension.authenticator.AuthenticationExtensionsAuthenticatorInputs
 import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorInput
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import java.time.Instant
 
-@ExperimentalCoroutinesApi
 class GetNextAssertionExecutionTest {
 
     @Test
@@ -40,7 +37,7 @@ class GetNextAssertionExecutionTest {
     }
 
     @Test
-    fun getNextAssertion_test() = runTest {
+    suspend fun getNextAssertion_test() {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         val connection = ctapAuthenticator.createSession()
@@ -70,7 +67,7 @@ class GetNextAssertionExecutionTest {
     }
 
     @Test
-    fun getNextAssertion_when_no_session_exist_test() = runTest {
+    suspend fun getNextAssertion_when_no_session_exist_test() {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         val connection = ctapAuthenticator.createSession()
@@ -81,7 +78,7 @@ class GetNextAssertionExecutionTest {
     }
 
     @Test
-    fun getNextAssertion_when_next_credential_does_not_exist_test() = runTest {
+    suspend fun getNextAssertion_when_next_credential_does_not_exist_test() {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         val connection = ctapAuthenticator.createSession()
@@ -113,7 +110,7 @@ class GetNextAssertionExecutionTest {
 
     @Disabled("Mockito.mockStatic doesn't work with JDK 21")
     @Test
-    fun expiration_test() = runTest {
+    suspend fun expiration_test() {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         val connection = ctapAuthenticator.createSession()

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
@@ -36,7 +36,7 @@ import org.mockito.kotlin.spy
 internal class MakeCredentialExecutionTest {
 
     @Test
-    fun test() = runTest {
+    suspend fun test() {
         val ctapAuthenticator = CtapAuthenticator()
         val connection = ctapAuthenticator.createSession()
 
@@ -74,7 +74,7 @@ internal class MakeCredentialExecutionTest {
     }
 
     @Test
-    fun store_full_test() = runTest {
+    suspend fun store_full_test() {
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.authenticatorPropertyStore = spy<InMemoryAuthenticatorPropertyStore> {
             onGeneric {
@@ -124,11 +124,11 @@ internal class MakeCredentialExecutionTest {
             "NEVER, CTAP2_OK, 0",
         ]
     )
-    fun options_null_residentKey_variation_test(
+    suspend fun options_null_residentKey_variation_test(
         residentKeySetting: ResidentKeySetting,
         statusCode: CtapStatusCode,
         createdResidentKeyCount: Int
-    ) = runTest {
+    ) {
         val clientDataHash = ByteArray(0)
         val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
         val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
@@ -179,12 +179,12 @@ internal class MakeCredentialExecutionTest {
             "false, NEVER, CTAP2_ERR_UNSUPPORTED_OPTION, 0",
         ]
     )
-    fun rk_and_residentKey_matrix_test(
+    suspend fun rk_and_residentKey_matrix_test(
         rk: Boolean,
         residentKeySetting: ResidentKeySetting,
         statusCode: CtapStatusCode,
         createdResidentKeyCount: Int
-    ) = runTest {
+    ) {
         val clientDataHash = ByteArray(0)
         val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
         val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
@@ -235,11 +235,11 @@ internal class MakeCredentialExecutionTest {
             "false, NOT_SUPPORTED, CTAP2_OK",
         ]
     )
-    fun uv_and_userVerification_test(
+    suspend fun uv_and_userVerification_test(
         uv: Boolean,
         userVerificationSetting: UserVerificationSetting,
         statusCode: CtapStatusCode
-    ) = runTest {
+    ) {
         val clientDataHash = ByteArray(0)
         val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
         val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
@@ -284,48 +284,47 @@ internal class MakeCredentialExecutionTest {
             "NOT_SUPPORTED, CTAP2_ERR_INVALID_OPTION",
         ]
     )
-    fun userPresence_test(userPresenceSetting: UserPresenceSetting, statusCode: CtapStatusCode) =
-        runTest {
-            val clientDataHash = ByteArray(0)
-            val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-            val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
-            val pubKeyCredParams = listOf(
-                PublicKeyCredentialParameters(
-                    PublicKeyCredentialType.PUBLIC_KEY,
-                    COSEAlgorithmIdentifier.ES256
-                )
+    suspend fun userPresence_test(userPresenceSetting: UserPresenceSetting, statusCode: CtapStatusCode) {
+        val clientDataHash = ByteArray(0)
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val pubKeyCredParams = listOf(
+            PublicKeyCredentialParameters(
+                PublicKeyCredentialType.PUBLIC_KEY,
+                COSEAlgorithmIdentifier.ES256
             )
-            val excludeList: List<PublicKeyCredentialDescriptor> = emptyList()
-            val extensions =
-                AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
-            val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = false)
-            val pinUvAuthParam: ByteArray? = null
-            val pinUvAuthProtocol: PinProtocolVersion? = null
-            val command = AuthenticatorMakeCredentialRequest(
-                clientDataHash,
-                rp,
-                user,
-                pubKeyCredParams,
-                excludeList,
-                extensions,
-                options,
-                pinUvAuthParam,
-                pinUvAuthProtocol
-            )
+        )
+        val excludeList: List<PublicKeyCredentialDescriptor> = emptyList()
+        val extensions =
+            AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>()
+        val options = AuthenticatorMakeCredentialRequest.Options(rk = true, uv = false)
+        val pinUvAuthParam: ByteArray? = null
+        val pinUvAuthProtocol: PinProtocolVersion? = null
+        val command = AuthenticatorMakeCredentialRequest(
+            clientDataHash,
+            rp,
+            user,
+            pubKeyCredParams,
+            excludeList,
+            extensions,
+            options,
+            pinUvAuthParam,
+            pinUvAuthProtocol
+        )
 
-            val ctapAuthenticator = CtapAuthenticator()
-            ctapAuthenticator.userPresence = userPresenceSetting
-            ctapAuthenticator.userVerification = UserVerificationSetting.NOT_SUPPORTED
-            ctapAuthenticator.clientPIN = ClientPINSetting.DISABLED
-            val connection = ctapAuthenticator.createSession()
+        val ctapAuthenticator = CtapAuthenticator()
+        ctapAuthenticator.userPresence = userPresenceSetting
+        ctapAuthenticator.userVerification = UserVerificationSetting.NOT_SUPPORTED
+        ctapAuthenticator.clientPIN = ClientPINSetting.DISABLED
+        val connection = ctapAuthenticator.createSession()
 
-            val response = connection.makeCredential(command)
-            assertThat(response).isInstanceOf(AuthenticatorMakeCredentialResponse::class.java)
-            assertThat(response.statusCode).isEqualTo(statusCode)
-        }
+        val response = connection.makeCredential(command)
+        assertThat(response).isInstanceOf(AuthenticatorMakeCredentialResponse::class.java)
+        assertThat(response.statusCode).isEqualTo(statusCode)
+    }
 
     @Test
-    fun userConsent_false_test() = runTest {
+    suspend fun userConsent_false_test() {
         val clientDataHash = ByteArray(0)
         val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
         val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
@@ -367,7 +366,7 @@ internal class MakeCredentialExecutionTest {
     }
 
     @Test
-    fun unsupported_alg_test() = runTest {
+    suspend fun unsupported_alg_test() {
         val clientDataHash = ByteArray(0)
         val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
         val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/nfc/NFCTransportTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/nfc/NFCTransportTest.kt
@@ -4,8 +4,6 @@ import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.UserVerificationHandler
 import com.webauthn4j.ctap.core.data.nfc.CommandAPDU
 import com.webauthn4j.util.Base64UrlUtil
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 
@@ -15,9 +13,8 @@ internal class NFCTransportTest {
         mock(UserVerificationHandler::class.java)
     )
 
-    @ExperimentalCoroutinesApi
     @Test
-    fun processApduCommand_test() = runTest {
+    suspend fun processApduCommand_test() {
         val apdu = Base64UrlUtil.decode("gBAAAAEEAA")
         target.onCommandAPDUReceived(CommandAPDU.parse(apdu))
     }

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/nfc/apdu/CtapAPDUProcessorTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/nfc/apdu/CtapAPDUProcessorTest.kt
@@ -5,7 +5,6 @@ import com.webauthn4j.ctap.authenticator.UserVerificationHandler
 import com.webauthn4j.ctap.authenticator.transport.nfc.NFCTransport
 import com.webauthn4j.ctap.core.data.nfc.CommandAPDU
 import com.webauthn4j.util.Base64UrlUtil
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -19,7 +18,7 @@ internal class CtapAPDUProcessorTest {
     @Disabled
     @Suppress("EXPERIMENTAL_API_USAGE")
     @Test
-    fun processCtapFinalCommand_test() = runTest {
+    suspend fun processCtapFinalCommand_test() {
         val command = CommandAPDU.parse(Base64UrlUtil.decode("gBAAAAEEAA"))
         target.process(command)
     }

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/nfc/apdu/SelectCommandAPDUProcessorTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/transport/nfc/apdu/SelectCommandAPDUProcessorTest.kt
@@ -8,8 +8,6 @@ import com.webauthn4j.ctap.authenticator.UserVerificationHandler
 import com.webauthn4j.ctap.authenticator.transport.nfc.NFCTransport
 import com.webauthn4j.ctap.core.data.nfc.CommandAPDU
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -30,9 +28,8 @@ internal class SelectCommandAPDUProcessorTest {
     }
 
     @Disabled
-    @ExperimentalCoroutinesApi
     @Test
-    fun process_test() = runTest {
+    suspend fun process_test() {
         val apdu = ByteArrayUtil.hexStringToByteArray("00A4040000A0000006472F0001")
         val commandAPDU = CommandAPDU.parse(apdu)
         target.process(commandAPDU)

--- a/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
+++ b/webauthn4j-ctap-client/src/test/kotlin/com/webauthn4j/ctap/client/CtapServiceTest.kt
@@ -10,8 +10,6 @@ import com.webauthn4j.ctap.client.transport.InProcessAdaptor
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
 import com.webauthn4j.util.MessageDigestUtil
 import com.webauthn4j.data.AuthenticatorAttachment
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.charset.StandardCharsets
@@ -37,10 +35,9 @@ internal class CtapServiceTest {
         })))
     private val target = CtapService(ctapClient)
 
-    @ExperimentalCoroutinesApi
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun setPIN_test() = runTest {
+    suspend fun setPIN_test() {
         target.reset()
         target.setPIN("newPIN")
         assertThat(connection.authenticatorPropertyStore.loadClientPIN()).isEqualTo(
@@ -48,10 +45,9 @@ internal class CtapServiceTest {
         )
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun changePIN_test() = runTest {
+    suspend fun changePIN_test() {
         target.reset()
         target.setPIN("currentPIN")
         assertThat(connection.authenticatorPropertyStore.loadClientPIN()).isEqualTo(
@@ -70,10 +66,9 @@ internal class CtapServiceTest {
     }
 
     /*ignore exception*/
-    @ExperimentalCoroutinesApi
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun getRetries_test() = runTest {
+    suspend fun getRetries_test() {
         assertThat(target.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES)
         try {
             target.changePIN("wrongPIN", "newPIN")
@@ -84,10 +79,9 @@ internal class CtapServiceTest {
         assertThat(target.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun reset_test() = runTest {
+    suspend fun reset_test() {
         target.reset()
     }
 }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AAGUIDTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AAGUIDTest.kt
@@ -2,8 +2,6 @@ package integration.setting.authenticator
 
 import com.webauthn4j.data.attestation.authenticator.AAGUID
 import integration.usecase.testcase.PasswordlessTestCase
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -13,10 +11,9 @@ import java.util.concurrent.ExecutionException
 class AAGUIDTest {
     private val passwordlessTestCase = PasswordlessTestCase()
 
-    @ExperimentalCoroutinesApi
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun aaguid_custom_test() = runTest {
+    suspend fun aaguid_custom_test() {
         val aaguid = AAGUID(UUID.randomUUID())
         passwordlessTestCase.authenticator.aaguid = aaguid
         passwordlessTestCase.step1_createCredential()

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AlgorithmsTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AlgorithmsTest.kt
@@ -31,7 +31,7 @@ class AlgorithmsTest {
         }
 
         @Test
-        fun authenticator_supports_ES256_test() = runTest {
+        suspend fun authenticator_supports_ES256_test() {
             passwordlessTestCase.authenticator.algorithms = setOf(COSEAlgorithmIdentifier.ES256)
             passwordlessTestCase.step1_createCredential()
             val registrationData = passwordlessTestCase.step2_validateCredentialForRegistration()
@@ -78,7 +78,7 @@ class AlgorithmsTest {
         }
 
         @Test
-        fun authenticator_supports_RS256_test() = runTest {
+        suspend fun authenticator_supports_RS256_test() {
             passwordlessTestCase.authenticator.algorithms = setOf(COSEAlgorithmIdentifier.RS256)
             passwordlessTestCase.step1_createCredential()
             val registrationData = passwordlessTestCase.step2_validateCredentialForRegistration()
@@ -103,7 +103,7 @@ class AlgorithmsTest {
         }
 
         @Test
-        fun authenticator_supports_RS1_test() = runTest {
+        suspend fun authenticator_supports_RS1_test() {
             passwordlessTestCase.authenticator.algorithms = setOf(COSEAlgorithmIdentifier.RS1)
             passwordlessTestCase.step1_createCredential()
             val registrationData = passwordlessTestCase.step2_validateCredentialForRegistration()

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AttachmentSettingTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AttachmentSettingTest.kt
@@ -25,7 +25,7 @@ class AttachmentSettingTest {
 
         @Test
         @Throws(ExecutionException::class, InterruptedException::class)
-        fun platform_platform_test() = runTest {
+        suspend fun platform_platform_test() {
             passwordlessTestCase.authenticator.platformSetting = AttachmentSetting.PLATFORM
             passwordlessTestCase.run()
         }
@@ -63,7 +63,7 @@ class AttachmentSettingTest {
 
         @Test
         @Throws(ExecutionException::class, InterruptedException::class)
-        fun platform_cross_platform_test() = runTest {
+        suspend fun platform_cross_platform_test() {
             passwordlessTestCase.authenticator.platformSetting = AttachmentSetting.CROSS_PLATFORM
             passwordlessTestCase.run()
         }
@@ -79,14 +79,14 @@ class AttachmentSettingTest {
 
         @Test
         @Throws(ExecutionException::class, InterruptedException::class)
-        fun platform_platform_test() = runTest {
+        suspend fun platform_platform_test() {
             passwordlessTestCase.authenticator.platformSetting = AttachmentSetting.PLATFORM
             passwordlessTestCase.run()
         }
 
         @Test
         @Throws(ExecutionException::class, InterruptedException::class)
-        fun platform_cross_platform_test() = runTest {
+        suspend fun platform_cross_platform_test() {
             passwordlessTestCase.authenticator.platformSetting = AttachmentSetting.CROSS_PLATFORM
             passwordlessTestCase.run()
         }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AttestationStatementProviderTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/AttestationStatementProviderTest.kt
@@ -9,7 +9,6 @@ import com.webauthn4j.data.attestation.statement.NoneAttestationStatement
 import com.webauthn4j.data.attestation.statement.PackedAttestationStatement
 import com.webauthn4j.test.TestAttestationUtil
 import integration.usecase.testcase.PasswordlessTestCase
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.concurrent.ExecutionException
@@ -21,7 +20,7 @@ class AttestationStatementProviderTest {
 
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun attestationStatementGenerator_packed_test() = runTest {
+    suspend fun attestationStatementGenerator_packed_test() {
         passwordlessTestCase.authenticator.attestationStatementGenerator =
             PackedBasicAttestationStatementProvider.createWithDemoAttestationKey()
         passwordlessTestCase.step1_createCredential()
@@ -34,7 +33,7 @@ class AttestationStatementProviderTest {
 
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun attestationStatementGenerator_fido_u2f_test() = runTest {
+    suspend fun attestationStatementGenerator_fido_u2f_test() {
         val privateKey = TestAttestationUtil.load2tierTestAuthenticatorAttestationPrivateKey()
         val attestationCertificate =
             TestAttestationUtil.load2tierTestAuthenticatorAttestationCertificate()
@@ -51,7 +50,7 @@ class AttestationStatementProviderTest {
 
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
-    fun attestationStatementGenerator_none_test() = runTest {
+    suspend fun attestationStatementGenerator_none_test() {
         passwordlessTestCase.authenticator.attestationStatementGenerator =
             NoneAttestationStatementProvider()
         passwordlessTestCase.authenticator.aaguid = AAGUID.ZERO

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINAndUserVerificationTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINAndUserVerificationTest.kt
@@ -23,14 +23,14 @@ class ClientPINAndUserVerificationTest {
         }
 
         @Test
-        fun userVerification_ready_test() = runTest {
+        suspend fun userVerification_ready_test() {
             passwordlessTestCase.authenticator.userVerificationSetting =
                 UserVerificationSetting.READY
             passwordlessTestCase.run()
         }
 
         @Test
-        fun userVerification_not_ready_test() = runTest {
+        suspend fun userVerification_not_ready_test() {
             passwordlessTestCase.authenticator.userVerificationSetting =
                 UserVerificationSetting.NOT_READY
             passwordlessTestCase.run()
@@ -46,7 +46,7 @@ class ClientPINAndUserVerificationTest {
         }
 
         @Test
-        fun userVerification_ready_test() = runTest {
+        suspend fun userVerification_ready_test() {
             passwordlessTestCase.authenticator.userVerificationSetting = UserVerificationSetting.READY
             passwordlessTestCase.run()
         }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ClientPINTest.kt
@@ -33,14 +33,14 @@ class ClientPINTest {
         }
 
         @Test
-        fun pin_not_already_set_test() = runTest {
+        suspend fun pin_not_already_set_test() {
             clientPINTestCase.clientPlatform.ctapService.reset()
             clientPINTestCase.clientPlatform.ctapService.setPIN("new-PIN")
         }
     }
 
     @Test
-    fun changePIN_test() = runTest {
+    suspend fun changePIN_test() {
         clientPINTestCase.clientPlatform.ctapService.changePIN("clientPIN", "new-PIN")
     }
 
@@ -89,7 +89,7 @@ class ClientPINTest {
 
 
     @Test
-    fun getRetries_test() = runTest {
+    suspend fun getRetries_test() {
         assertThat(clientPINTestCase.clientPlatform.ctapService.getRetries()).isEqualTo(PinUvAuthManager.MAX_PIN_RETRIES)
         try {
             clientPINTestCase.clientPlatform.ctapService.changePIN("invalid-PIN", "invalid-PIN")
@@ -100,7 +100,7 @@ class ClientPINTest {
 
     @Disabled
     @Test
-    fun clientPINSetting_DISABLED_test() = runTest {
+    suspend fun clientPINSetting_DISABLED_test() {
         clientPINTestCase.authenticator.clientPINSetting = ClientPINSetting.ENABLED
         clientPINTestCase.clientPlatform.ctapService.setPIN("dummy")
     }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/CredentialSelectorSettingTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/CredentialSelectorSettingTest.kt
@@ -9,7 +9,6 @@ import com.webauthn4j.data.PublicKeyCredential
 import com.webauthn4j.data.extension.client.RegistrationExtensionClientOutput
 import com.webauthn4j.verifier.exception.BadSignatureException
 import integration.usecase.testcase.PasswordlessTestCase
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,7 +21,7 @@ class CredentialSelectorSettingTest {
     @Nested
     inner class credentialSelector_authenticator {
         @Test
-        fun correct_selection_test() = runTest {
+        suspend fun correct_selection_test() {
             var publicKeyCredential: PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput>? =
                 null
 
@@ -42,7 +41,7 @@ class CredentialSelectorSettingTest {
         }
 
         @Test
-        fun incorrect_selection_test() = runTest {
+        suspend fun incorrect_selection_test() {
             var publicKeyCredential: PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput>? =
                 null
 
@@ -71,7 +70,7 @@ class CredentialSelectorSettingTest {
     inner class credentialSelector_client_platform {
 
         @Test
-        fun correct_selection_test() = runTest {
+        suspend fun correct_selection_test() {
 
             var publicKeyCredential: PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput>? =
                 null
@@ -90,7 +89,7 @@ class CredentialSelectorSettingTest {
         }
 
         @Test
-        fun incorrect_selection_test() = runTest {
+        suspend fun incorrect_selection_test() {
             var publicKeyCredential: PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput>? =
                 null
 

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ResetProtectionSettingTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ResetProtectionSettingTest.kt
@@ -25,7 +25,7 @@ internal class ResetProtectionSettingTest {
     }
 
     @Test
-    fun resetProtection_disabled_test() = runTest {
+    suspend fun resetProtection_disabled_test() {
         resetTestCase.authenticator.resetProtectionSetting = ResetProtectionSetting.DISABLED
         resetTestCase.run()
     }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ResidentKeySettingTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/ResidentKeySettingTest.kt
@@ -13,13 +13,13 @@ class ResidentKeySettingTest {
     private val passwordlessTestCase = PasswordlessTestCase()
 
     @Test
-    fun residentKey_always_test() = runTest {
+    suspend fun residentKey_always_test() {
         passwordlessTestCase.authenticator.residentKeySetting = ResidentKeySetting.ALWAYS
         passwordlessTestCase.run()
     }
 
     @Test
-    fun residentKey_if_required_test() = runTest {
+    suspend fun residentKey_if_required_test() {
         passwordlessTestCase.authenticator.residentKeySetting = ResidentKeySetting.IF_REQUIRED
         passwordlessTestCase.run()
     }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/UserPresenceSettingTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/authenticator/UserPresenceSettingTest.kt
@@ -12,7 +12,7 @@ class UserPresenceSettingTest {
     private val passwordlessTestCase = PasswordlessTestCase()
 
     @Test
-    fun userPresence_supported_test() = runTest {
+    suspend fun userPresence_supported_test() {
         passwordlessTestCase.authenticator.userPresenceSetting = UserPresenceSetting.SUPPORTED
         passwordlessTestCase.run()
     }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/relyingparty/AttestationTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/relyingparty/AttestationTest.kt
@@ -5,20 +5,17 @@ import com.webauthn4j.data.AttestationConveyancePreference
 import com.webauthn4j.data.attestation.statement.NoneAttestationStatement
 import com.webauthn4j.data.attestation.statement.PackedAttestationStatement
 import integration.usecase.testcase.PasswordlessTestCase
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
-@ExperimentalCoroutinesApi
 class AttestationTest {
 
     private val passwordlessTestCase = PasswordlessTestCase()
 
 
     @Test
-    fun attestation_none_test() = runTest {
+    suspend fun attestation_none_test() {
         passwordlessTestCase.relyingParty.registration.frontend.attestation =
             AttestationConveyancePreference.NONE
 
@@ -32,7 +29,7 @@ class AttestationTest {
 
     @Disabled
     @Test
-    fun attestation_indirect_test() = runTest {
+    suspend fun attestation_indirect_test() {
         passwordlessTestCase.relyingParty.registration.frontend.attestation =
             AttestationConveyancePreference.INDIRECT
 
@@ -45,7 +42,7 @@ class AttestationTest {
     }
 
     @Test
-    fun attestation_direct_test() = runTest {
+    suspend fun attestation_direct_test() {
         passwordlessTestCase.relyingParty.registration.frontend.attestation =
             AttestationConveyancePreference.DIRECT
 

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/relyingparty/ExcludeCredentialsTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/relyingparty/ExcludeCredentialsTest.kt
@@ -44,7 +44,7 @@ class ExcludeCredentialsTest {
     }
 
     @Test
-    fun excludeCredentials_other_authenticator_test() = runTest {
+    suspend fun excludeCredentials_other_authenticator_test() {
         var result: PublicKeyCredential<AuthenticatorAttestationResponse, RegistrationExtensionClientOutput>? =
             null
         passwordlessTestCase.authenticator.credentialSelectorSetting =

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/setting/relyingparty/RpIdTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/setting/relyingparty/RpIdTest.kt
@@ -24,13 +24,13 @@ class RpIdTest {
         }
 
         @Test
-        fun frontend_rpId_null_test() = runTest {
+        suspend fun frontend_rpId_null_test() {
             passwordlessTestCase.relyingParty.registration.frontend.rpId = null
             passwordlessTestCase.run()
         }
 
         @Test
-        fun frontend_backend_rpId_match_test() = runTest {
+        suspend fun frontend_backend_rpId_match_test() {
             passwordlessTestCase.relyingParty.registration.backend.rpId = "example.com"
             passwordlessTestCase.run()
         }
@@ -56,13 +56,13 @@ class RpIdTest {
         }
 
         @Test
-        fun frontend_rpId_null_test() = runTest {
+        suspend fun frontend_rpId_null_test() {
             passwordlessTestCase.relyingParty.authentication.frontend.rpId = null
             passwordlessTestCase.run()
         }
 
         @Test
-        fun frontend_backend_rpId_match_test() = runTest {
+        suspend fun frontend_backend_rpId_match_test() {
             passwordlessTestCase.relyingParty.authentication.backend.rpId = "example.com"
             passwordlessTestCase.run()
         }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorPasswordLessUseCaseTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorPasswordLessUseCaseTest.kt
@@ -1,14 +1,13 @@
 package integration.usecase
 
 import integration.usecase.testcase.PasswordlessTestCase
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 internal class AuthenticatorPasswordLessUseCaseTest {
 
     @Test
-    fun passwordless_test() = runTest {
+    suspend fun passwordless_test() {
         val passwordlessTestCase = PasswordlessTestCase()
         passwordlessTestCase.run()
     }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorResetUseCaseTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorResetUseCaseTest.kt
@@ -1,15 +1,12 @@
 package integration.usecase
 
 import integration.usecase.testcase.ResetTestCase
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
-@ExperimentalCoroutinesApi
 class AuthenticatorResetUseCaseTest {
 
     @Test
-    fun reset_test() = runTest {
+    suspend fun reset_test() {
         val resetTestCase = ResetTestCase()
         resetTestCase.run()
     }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorSecondFactorUseCaseTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/AuthenticatorSecondFactorUseCaseTest.kt
@@ -20,13 +20,13 @@ internal class AuthenticatorSecondFactorUseCaseTest {
     internal inner class residentKey_setting_test {
 
         @Test
-        fun residentKey_always_test() = runTest {
+        suspend fun residentKey_always_test() {
             secondFactorTestCase.authenticator.residentKeySetting = ResidentKeySetting.ALWAYS
             secondFactorTestCase.run()
         }
 
         @Test
-        fun residentKey_if_required_test() = runTest {
+        suspend fun residentKey_if_required_test() {
             secondFactorTestCase.authenticator.residentKeySetting = ResidentKeySetting.IF_REQUIRED
             secondFactorTestCase.run()
         }
@@ -37,7 +37,7 @@ internal class AuthenticatorSecondFactorUseCaseTest {
         //  this test should pass without throwing and the @Disabled can be removed.
         @Disabled
         @Test
-        fun residentKey_never_test() = runTest {
+        suspend fun residentKey_never_test() {
             secondFactorTestCase.authenticator.residentKeySetting = ResidentKeySetting.NEVER
             secondFactorTestCase.run()
         }
@@ -46,7 +46,7 @@ internal class AuthenticatorSecondFactorUseCaseTest {
     @Nested
     internal inner class clientPIN_userVerification_setting_correlation_test {
         @Test
-        fun clientPIN_enabled_userVerification_ready_test() = runTest {
+        suspend fun clientPIN_enabled_userVerification_ready_test() {
             secondFactorTestCase.authenticator.clientPINSetting = ClientPINSetting.ENABLED
             secondFactorTestCase.authenticator.userVerificationSetting =
                 UserVerificationSetting.READY
@@ -54,7 +54,7 @@ internal class AuthenticatorSecondFactorUseCaseTest {
         }
 
         @Test
-        fun clientPIN_enabled_userVerification_not_ready_test() = runTest {
+        suspend fun clientPIN_enabled_userVerification_not_ready_test() {
             secondFactorTestCase.authenticator.clientPINSetting = ClientPINSetting.ENABLED
             secondFactorTestCase.authenticator.userVerificationSetting =
                 UserVerificationSetting.NOT_READY
@@ -62,7 +62,7 @@ internal class AuthenticatorSecondFactorUseCaseTest {
         }
 
         @Test
-        fun clientPIN_disabled_userVerification_ready_test() = runTest {
+        suspend fun clientPIN_disabled_userVerification_ready_test() {
             secondFactorTestCase.authenticator.clientPINSetting = ClientPINSetting.DISABLED
             secondFactorTestCase.authenticator.userVerificationSetting =
                 UserVerificationSetting.READY
@@ -70,7 +70,7 @@ internal class AuthenticatorSecondFactorUseCaseTest {
         }
 
         @Test
-        fun clientPIN_disabled_userVerification_not_ready_test() = runTest {
+        suspend fun clientPIN_disabled_userVerification_not_ready_test() {
             secondFactorTestCase.authenticator.clientPINSetting = ClientPINSetting.DISABLED
             secondFactorTestCase.authenticator.userVerificationSetting =
                 UserVerificationSetting.NOT_READY
@@ -78,7 +78,7 @@ internal class AuthenticatorSecondFactorUseCaseTest {
         }
 
         @Test
-        fun clientPIN_disabled_userVerification_not_supported_test() = runTest {
+        suspend fun clientPIN_disabled_userVerification_not_supported_test() {
             secondFactorTestCase.authenticator.clientPINSetting = ClientPINSetting.DISABLED
             secondFactorTestCase.authenticator.userVerificationSetting =
                 UserVerificationSetting.NOT_SUPPORTED
@@ -89,7 +89,7 @@ internal class AuthenticatorSecondFactorUseCaseTest {
     @Nested
     internal inner class userPresence_setting_test {
         @Test
-        fun userPresence_supported_test() = runTest {
+        suspend fun userPresence_supported_test() {
             secondFactorTestCase.authenticator.userPresenceSetting = UserPresenceSetting.SUPPORTED
             secondFactorTestCase.run()
         }


### PR DESCRIPTION
- JUnit 6 natively supports `@Test suspend fun`, making `runTest` wrappers unnecessary for tests that don't use virtual time control or other kotlinx-coroutines-test features
- Replaced `fun test() = runTest { ... }` with `suspend fun test() { ... }` across 25 test files
- Removed `runTest` import and `@ExperimentalCoroutinesApi` from files that no longer need them
- Nested `runTest` calls inside `assertThatThrownBy` blocks are left as-is since those require a non-suspend coroutine bridge