### PR TITLE
Fix USB-IP protocol compliance

### DIFF
--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/URBProcessor.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/URBProcessor.kt
@@ -52,15 +52,15 @@ class URBProcessor(private val session: USBIPSession) {
     private suspend fun processURBs(urbQueue: Channel<UrbRequest>) {
         while (true) {
             select {
+                if (pendingIns.isNotEmpty()) {
+                    session.interruptEndpoint.responses.onReceive { data ->
+                        completeInterruptIn(data)
+                    }
+                }
                 urbQueue.onReceive { urb ->
                     when (urb) {
                         is SubmitRequest -> handleSubmit(urb)
                         is UnlinkRequest -> handleUnlink(urb)
-                    }
-                }
-                if (pendingIns.isNotEmpty()) {
-                    session.interruptEndpoint.responses.onReceive { data ->
-                        completeInterruptIn(data)
                     }
                 }
             }

--- a/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/SubmitResponse.kt
+++ b/webauthn4j-ctap-authenticator-usbip/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/usbip/data/urb/SubmitResponse.kt
@@ -6,6 +6,9 @@ import java.nio.ByteOrder
 /** USBIP_RET_SUBMIT — server response after processing a submitted URB. */
 class SubmitResponse(
     val seqnum: Int,
+    val devid: Int,
+    val direction: TransferDirection,
+    val ep: Int,
     val status: UrbStatus,
     val actualLength: Int,
     val startFrame: Int,
@@ -13,9 +16,6 @@ class SubmitResponse(
     val errorCount: Int,
     val transferBuffer: ByteArray
 ) {
-    val devid: Int = 0
-    val direction: TransferDirection = TransferDirection.OUT
-    val ep: Int = 0
 
     companion object {
         const val COMMAND = 0x00000003
@@ -24,12 +24,14 @@ class SubmitResponse(
 
         fun ok(request: SubmitRequest, transferBuffer: ByteArray, actualLength: Int = transferBuffer.size): SubmitResponse = SubmitResponse(
             seqnum = request.seqnum,
+            devid = request.devid, direction = request.direction, ep = request.ep,
             status = UrbStatus.SUCCESS, actualLength = actualLength,
             startFrame = 0, numberOfPackets = 0, errorCount = 0, transferBuffer = transferBuffer
         )
 
         fun error(request: SubmitRequest, status: UrbStatus): SubmitResponse = SubmitResponse(
             seqnum = request.seqnum,
+            devid = request.devid, direction = request.direction, ep = request.ep,
             status = status, actualLength = 0,
             startFrame = 0, numberOfPackets = 0, errorCount = 0, transferBuffer = ByteArray(0)
         )


### PR DESCRIPTION
- Fix SubmitResponse to echo back `devid`, `direction`, and `ep` from the original request, as required by the USB-IP protocol (USBIP_RET_SUBMIT). These fields were previously hardcoded to `devid=0`, `direction=OUT`, `ep=0`.
- Prioritize response delivery over URB intake in URBProcessor's `select` block. Kotlin's `select` is biased toward the first clause, so placing `responses.onReceive` first ensures KEEPALIVE and CBOR responses are not starved when many IN requests are queued.