### PR TITLE
Refactor transaction management and KEEPALIVE architecture

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -20,10 +20,12 @@ import com.webauthn4j.ctap.core.data.*
 import com.webauthn4j.data.AuthenticatorTransport
 import com.webauthn4j.data.attestation.authenticator.AAGUID
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.coroutineContext
 import org.slf4j.LoggerFactory
 
 /**
@@ -86,8 +88,10 @@ class CtapAuthenticatorSession internal constructor(
 
     var onGoingGetAssertionSession: GetAssertionSession? = null
 
+    // The Job of the currently executing command, used by cancelOnGoingTransaction() to cancel it.
+    // Set after mutex acquisition to avoid race conditions; cleared in finally.
     @Volatile
-    private var onGoingJob: Job? = null
+    private var activeTransaction: Job? = null
 
     @Volatile
     var isWaitingForUserPresence: Boolean = false
@@ -102,94 +106,100 @@ class CtapAuthenticatorSession internal constructor(
         }
     }
 
-    suspend fun <TC : AuthenticatorRequest, TR : AuthenticatorResponse?> invokeCommand(request: TC): TR {
-        onGoingJob = coroutineContext[Job]
-        try {
-            val response = when (request) {
-                is AuthenticatorMakeCredentialRequest -> makeCredential(request)
-                is AuthenticatorGetAssertionRequest -> getAssertion(request)
-                is AuthenticatorGetNextAssertionRequest -> getNextAssertion(request)
-                is AuthenticatorGetInfoRequest -> getInfo(request)
-                is AuthenticatorClientPINRequest -> clientPIN(request)
-                is AuthenticatorResetRequest -> reset(request)
-                is U2FRegistrationRequest -> u2fRegister(request)
-                is U2FAuthenticationRequest -> u2fSign(request)
-                else -> throw IllegalStateException(
-                    String.format(
-                        "unknown command %s is invoked.",
-                        request::class.java.toString()
-                    )
-                )
-            }
-            @Suppress("UNCHECKED_CAST")
-            return response as TR
-        } finally {
-            onGoingJob = null
-        }
+    @Suppress("UNCHECKED_CAST")
+    suspend fun <TC : AuthenticatorRequest, TR : AuthenticatorResponse?> invokeCommand(
+        request: TC
+    ): TR {
+        return when (request) {
+            is AuthenticatorMakeCredentialRequest -> makeCredential(request)
+            is AuthenticatorGetAssertionRequest -> getAssertion(request)
+            is AuthenticatorGetNextAssertionRequest -> getNextAssertion(request)
+            is AuthenticatorGetInfoRequest -> getInfo(request)
+            is AuthenticatorClientPINRequest -> clientPIN(request)
+            is AuthenticatorResetRequest -> reset(request)
+            is U2FRegistrationRequest -> u2fRegister(request)
+            is U2FAuthenticationRequest -> u2fSign(request)
+            else -> throw IllegalStateException("unknown command ${request::class.java}")
+        } as TR
     }
 
     suspend fun makeCredential(authenticatorMakeCredentialCommand: AuthenticatorMakeCredentialRequest): AuthenticatorMakeCredentialResponse {
-        mutex.withLock {
-            return MakeCredentialExecution(this, authenticatorMakeCredentialCommand).execute()
+        return withTransaction {
+            MakeCredentialExecution(this, authenticatorMakeCredentialCommand).execute()
         }
     }
 
     suspend fun getAssertion(authenticatorGetAssertionCommand: AuthenticatorGetAssertionRequest): AuthenticatorGetAssertionResponse {
-        mutex.withLock {
-            return GetAssertionExecution(this, authenticatorGetAssertionCommand).execute()
+        return withTransaction {
+            GetAssertionExecution(this, authenticatorGetAssertionCommand).execute()
         }
     }
 
     @JvmOverloads
     suspend fun getNextAssertion(authenticatorGetNextAssertionCommand: AuthenticatorGetNextAssertionRequest = AuthenticatorGetNextAssertionRequest()): AuthenticatorGetNextAssertionResponse {
-        mutex.withLock {
-            return GetNextAssertionExecution(this, authenticatorGetNextAssertionCommand).execute()
+        return withTransaction {
+            GetNextAssertionExecution(this, authenticatorGetNextAssertionCommand).execute()
         }
     }
 
     @JvmOverloads
     suspend fun getInfo(authenticatorGetInfoCommand: AuthenticatorGetInfoRequest = AuthenticatorGetInfoRequest()): AuthenticatorGetInfoResponse {
-        mutex.withLock {
-            return GetInfoExecution(this, authenticatorGetInfoCommand).execute()
+        return withTransaction {
+            GetInfoExecution(this, authenticatorGetInfoCommand).execute()
         }
     }
 
     suspend fun clientPIN(authenticatorClientPINCommand: AuthenticatorClientPINRequest): AuthenticatorClientPINResponse {
-        mutex.withLock {
-            return ClientPINExecution(this, authenticatorClientPINCommand).execute()
+        return withTransaction {
+            ClientPINExecution(this, authenticatorClientPINCommand).execute()
         }
     }
 
     @JvmOverloads
     suspend fun reset(authenticatorResetCommand: AuthenticatorResetRequest = AuthenticatorResetRequest()): AuthenticatorResetResponse {
-        mutex.withLock {
-            return ResetExecution(this, authenticatorResetCommand).execute()
+        return withTransaction {
+            ResetExecution(this, authenticatorResetCommand).execute()
         }
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
     suspend fun u2fRegister(u2fRegistrationRequest: U2FRegistrationRequest): U2FRegistrationResponse {
-        mutex.withLock {
-            return U2FRegisterExecution(this, u2fRegistrationRequest).execute()
+        return withTransaction {
+            U2FRegisterExecution(this, u2fRegistrationRequest).execute()
         }
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
     suspend fun u2fSign(u2fAuthenticationRequest: U2FAuthenticationRequest): U2FAuthenticationResponse {
-        mutex.withLock {
-            return U2FAuthenticationExecution(this, u2fAuthenticationRequest).execute()
+        return withTransaction {
+            U2FAuthenticationExecution(this, u2fAuthenticationRequest).execute()
         }
     }
 
     suspend fun wink() {
-        mutex.withLock {
-            winkHandler.onWink()
+        withTransaction { winkHandler.onWink() }
+    }
+
+    // Serializes command execution with mutex and tracks the active Job for cancellation.
+    // Uses async(LAZY) so that activeTransaction is set before the command starts.
+    private suspend fun <T> withTransaction(block: suspend () -> T): T {
+        return mutex.withLock {
+            coroutineScope {
+                val commandJob = async(start = CoroutineStart.LAZY) { block() }
+                activeTransaction = commandJob
+                commandJob.start()
+                try {
+                    commandJob.await()
+                } finally {
+                    activeTransaction = null
+                }
+            }
         }
     }
 
-    fun cancelOnGoingTransaction() {
+    suspend fun cancelOnGoingTransaction() {
         logger.debug("Cancel ongoing transaction requested")
-        onGoingJob?.cancel()
+        activeTransaction?.cancelAndJoin()
         onGoingGetAssertionSession = null
     }
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDChannel.kt
@@ -1,21 +1,21 @@
 package com.webauthn4j.ctap.authenticator.transport.hid
 
+import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
 import com.webauthn4j.ctap.authenticator.transport.hid.handler.*
 import com.webauthn4j.ctap.core.data.hid.*
 import com.webauthn4j.ctap.core.data.hid.HIDMessage.Companion.DEFAULT_PACKET_SIZE
-import kotlinx.coroutines.CloseableCoroutineDispatcher
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
-import java.io.Closeable
 
 class HIDChannel(
     private val channelId: HIDChannelId,
     private val scope: CoroutineScope,
     private val packetSize: Int = DEFAULT_PACKET_SIZE,
-    private val keepAliveWorker: CloseableCoroutineDispatcher,
     private val activeTransactionChannelIdSetter: (HIDChannelId?) -> Unit,
     private val commandTimeSetter: (Long) -> Unit,
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession,
     private val initHandler: HIDInitCommandHandler,
     private val cborHandler: HIDCborCommandHandler,
     private val msgHandler: HIDMsgCommandHandler,
@@ -23,11 +23,14 @@ class HIDChannel(
     private val cancelHandler: HIDCancelCommandHandler,
     private val winkHandler: HIDWinkCommandHandler,
     private val lockHandler: HIDLockCommandHandler
-) : Closeable {
+) {
 
     private val logger = LoggerFactory.getLogger(HIDChannel::class.java)
     private val hidRequestMessageBuilder = HIDRequestMessageBuilder(packetSize)
-    private var cborCompletion: CompletableDeferred<Unit>? = null
+
+    // The coroutine Job running the current CBOR command (keepalive + command execution + response sending).
+    // Used by cancel() to await full completion before the channel is reused or replaced.
+    private var activeCborJob: Job? = null
 
     suspend fun handlePacket(
         hidPacket: HIDPacket,
@@ -89,17 +92,18 @@ class HIDChannel(
             }
             HIDCommand.CTAPHID_CBOR -> {
                 commandTimeSetter(System.currentTimeMillis())
-                cborCompletion = cborHandler.handle(scope, hidMessage as HIDCBORRequestMessage,
-                    responseCallback = {
-                        logger.debug("CTAP Response HID Message: {}", it)
-                        responseCallback(it)
-                    },
-                    onComplete = {
+                activeCborJob = scope.launch {
+                    try {
+                        cborHandler.handle(hidMessage as HIDCBORRequestMessage) {
+                            logger.debug("CTAP Response HID Message: {}", it)
+                            responseCallback(it)
+                        }
+                    } finally {
                         commandTimeSetter(0)
                         activeTransactionChannelIdSetter(null)
-                        cborCompletion = null
+                        activeCborJob = null
                     }
-                )
+                }
             }
             HIDCommand.CTAPHID_CANCEL -> {
                 //spec| Cancel any outstanding requests on this CID. If there is an outstanding request that can be
@@ -108,7 +112,6 @@ class HIDChannel(
                 //spec| Whether a request was cancelled or not, the authenticator MUST NOT reply to the CTAPHID_CANCEL
                 //spec| message itself.
                 cancelHandler.handle()
-                cborCompletion?.await()
             }
             HIDCommand.CTAPHID_INIT -> {
                 val response = initHandler.handle(hidMessage as HIDINITRequestMessage)
@@ -141,13 +144,8 @@ class HIDChannel(
         }
     }
 
-    suspend fun cancelAndAwaitCbor() {
-        val completion = cborCompletion ?: return
-        cancelHandler.handle()
-        completion.await()
-    }
-
-    override fun close() {
-        keepAliveWorker.close()
+    suspend fun cancel() {
+        ctapAuthenticatorSession.cancelOnGoingTransaction()
+        activeCborJob?.join()
     }
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/HIDTransport.kt
@@ -36,6 +36,7 @@ class HIDTransport(
     private var u2fAPDUProcessor = createU2FAPDUProcessor()
 
     private val hidPacketConverter = HIDPacketConverter()
+    // Allocated logical channels, keyed by channel ID. Access is serialized by consumerDispatcher.
     private val hidChannels: MutableMap<HIDChannelId, HIDChannel> = HashMap()
     private val secureRandom = SecureRandom()
 
@@ -68,8 +69,7 @@ class HIDTransport(
         }
         override suspend fun resyncChannel(channelId: HIDChannelId) {
             val old = hidChannels.remove(channelId)
-            old?.cancelAndAwaitCbor()
-            old?.close()
+            old?.cancel()
             hidChannels[channelId] = createChannel(channelId)
         }
     })
@@ -90,7 +90,6 @@ class HIDTransport(
     override fun close() {
         incomingPackets.close()
         consumerJob?.cancel()
-        hidChannels.values.forEach { it.close() }
         hidChannels.clear()
     }
 
@@ -99,7 +98,6 @@ class HIDTransport(
         u2fAPDUProcessor = createU2FAPDUProcessor()
         cancelHandler = HIDCancelCommandHandler(ctapAuthenticatorSession)
         winkHandler = HIDWinkCommandHandler(ctapAuthenticatorSession)
-        hidChannels.values.forEach { it.close() }
         hidChannels.clear()
     }
 
@@ -140,7 +138,7 @@ class HIDTransport(
                     val activeChannel = activeTransactionChannelId
                     if (activeChannel != null) {
                         logger.debug("Cancelling ongoing CBOR on channel {} before processing broadcast INIT", activeChannel)
-                        hidChannels[activeChannel]?.cancelAndAwaitCbor()
+                        hidChannels[activeChannel]?.cancel()
                     }
                     val tempChannel = createChannel(channelId)
                     tempChannel.handlePacket(hidPacket) { responsePacket ->
@@ -223,23 +221,20 @@ class HIDTransport(
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     private fun createChannel(channelId: HIDChannelId): HIDChannel {
-        val keepAliveWorker = newSingleThreadContext("hid-keepalive-worker-" + HexUtil.encodeToString(channelId.value))
         val msgHandler = HIDMsgCommandHandler(u2fAPDUProcessor, u2fConfirmationWorker)
         val perChannelCborHandler = HIDCborCommandHandler(
             CtapRequestConverter(ctapAuthenticatorSession.objectConverter),
             CtapResponseConverter(ctapAuthenticatorSession.objectConverter),
             ctapAuthenticatorSession,
-            keepAliveWorker
         )
         return HIDChannel(
             channelId = channelId,
             scope = scope,
             packetSize = packetSize,
-            keepAliveWorker = keepAliveWorker,
             activeTransactionChannelIdSetter = { activeTransactionChannelId = it },
             commandTimeSetter = { currentCommandStartTimeMs = it },
+            ctapAuthenticatorSession = ctapAuthenticatorSession,
             initHandler = initHandler,
             cborHandler = perChannelCborHandler,
             msgHandler = msgHandler,

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCancelCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCancelCommandHandler.kt
@@ -12,7 +12,7 @@ class HIDCancelCommandHandler(
     private val ctapAuthenticatorSession: CtapAuthenticatorSession
 ) {
 
-    fun handle() {
+    suspend fun handle() {
         ctapAuthenticatorSession.cancelOnGoingTransaction()
     }
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDCborCommandHandler.kt
@@ -9,17 +9,15 @@ import com.webauthn4j.ctap.core.data.CtapStatusCode
 import com.webauthn4j.ctap.core.data.hid.HIDCBORRequestMessage
 import com.webauthn4j.ctap.core.data.hid.HIDCBORResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDKEEPALIVEResponseMessage
+import com.webauthn4j.ctap.core.data.hid.HIDChannelId
 import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
 import com.webauthn4j.ctap.core.data.hid.HIDStatusCode
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlin.coroutines.CoroutineContext
+import org.slf4j.LoggerFactory
 
 // @see <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-hid-cbor">8.1.9.1.2. CTAPHID_CBOR</a>
 //spec| This command sends an encapsulated CTAP CBOR encoded message. The semantics of the data
@@ -29,56 +27,45 @@ class HIDCborCommandHandler(
     private val ctapRequestConverter: CtapRequestConverter,
     private val ctapResponseConverter: CtapResponseConverter,
     private val ctapAuthenticatorSession: CtapAuthenticatorSession,
-    private val keepAliveWorker: CoroutineContext
 ) {
 
     companion object {
-        //spec| This command code is sent while processing a CTAPHID_MSG. It should be sent at least
-        //spec| every 100ms and whenever the status changes.
         private const val KEEPALIVE_INTERVAL = 100L
     }
 
-    fun handle(
-        scope: CoroutineScope,
+    private val logger = LoggerFactory.getLogger(HIDCborCommandHandler::class.java)
+
+    suspend fun handle(
         hidMessage: HIDCBORRequestMessage,
         responseCallback: (HIDResponseMessage) -> Unit,
-        onComplete: () -> Unit
-    ): CompletableDeferred<Unit> {
-        val completion = CompletableDeferred<Unit>()
-        scope.launch(Dispatchers.Default) {
-            try {
-                coroutineScope {
-                    val keepAliveJob = launch(keepAliveWorker) {
-                        while (true) {
-                            //spec| STATUS_PROCESSING 1 The authenticator is still processing the current request.
-                            //spec| STATUS_UPNEEDED 2 The authenticator is waiting for user presence.
-                            val statusCode = if (ctapAuthenticatorSession.isWaitingForUserPresence) {
-                                HIDStatusCode.UPNEEDED
-                            } else {
-                                HIDStatusCode.PROCESSING
-                            }
-                            responseCallback(HIDKEEPALIVEResponseMessage(hidMessage.channelId, statusCode))
-                            delay(KEEPALIVE_INTERVAL)
-                        }
-                    }
-                    val ctapCommand = ctapRequestConverter.convert(hidMessage.data)
-                    val ctapResponse: CtapResponse = ctapAuthenticatorSession.invokeCommand(ctapCommand)
-                    val cbor = ctapResponseConverter.convertToResponseDataBytes(ctapResponse)
-                    val responseMessage = HIDCBORResponseMessage(hidMessage.channelId, ctapResponse.statusCode, cbor)
-                    keepAliveJob.cancelAndJoin()
-                    responseCallback(responseMessage)
-                }
-            } catch (_: CancellationException) {
-                responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP2_ERR_KEEPALIVE_CANCEL, ByteArray(0)))
-            } catch (e: CtapCommandExecutionException) {
-                responseCallback(HIDCBORResponseMessage(hidMessage.channelId, e.statusCode, ByteArray(0)))
-            } catch (_: Exception) {
-                responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP1_ERR_OTHER, ByteArray(0)))
-            } finally {
-                onComplete()
-                completion.complete(Unit)
+    ) {
+        val ctapCommand = ctapRequestConverter.convert(hidMessage.data)
+        try {
+            coroutineScope {
+                startKeepAlive(hidMessage.channelId, responseCallback)
+                val response: CtapResponse = ctapAuthenticatorSession.invokeCommand(ctapCommand)
+                val cbor = ctapResponseConverter.convertToResponseDataBytes(response)
+                responseCallback(HIDCBORResponseMessage(hidMessage.channelId, response.statusCode, cbor))
+            }
+        } catch (_: CancellationException) {
+            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP2_ERR_KEEPALIVE_CANCEL, ByteArray(0)))
+        } catch (e: CtapCommandExecutionException) {
+            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, e.statusCode, ByteArray(0)))
+        } catch (e: Exception) {
+            logger.error("Unexpected exception while processing CTAP CBOR command", e)
+            responseCallback(HIDCBORResponseMessage(hidMessage.channelId, CtapStatusCode.CTAP1_ERR_OTHER, ByteArray(0)))
+        }
+    }
+
+    // Launches a child coroutine that sends CTAPHID_KEEPALIVE every 100ms until the parent scope completes.
+    private fun CoroutineScope.startKeepAlive(channelId: HIDChannelId, responseCallback: (HIDResponseMessage) -> Unit) {
+        launch {
+            while (true) {
+                delay(KEEPALIVE_INTERVAL)
+                val status = if (ctapAuthenticatorSession.isWaitingForUserPresence)
+                    HIDStatusCode.UPNEEDED else HIDStatusCode.PROCESSING
+                responseCallback(HIDKEEPALIVEResponseMessage(channelId, status))
             }
         }
-        return completion
     }
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDLockCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDLockCommandHandler.kt
@@ -19,7 +19,7 @@ class HIDLockCommandHandler(
         private const val MAX_LOCK_SECONDS = 10
     }
 
-    fun handle(hidMessage: HIDLOCKRequestMessage, channelId: HIDChannelId): HIDLOCKResponseMessage {
+    suspend fun handle(hidMessage: HIDLOCKRequestMessage, channelId: HIDChannelId): HIDLOCKResponseMessage {
         val seconds = hidMessage.seconds.toInt().coerceIn(0, MAX_LOCK_SECONDS)
         if (seconds == 0) {
             lockState.ownerChannelId = null

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDPingCommandHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/transport/hid/handler/HIDPingCommandHandler.kt
@@ -9,7 +9,7 @@ import com.webauthn4j.ctap.core.data.hid.HIDResponseMessage
 //spec| is defined to be a uniform function for debugging, latency and performance measurements.
 class HIDPingCommandHandler {
 
-    fun handle(hidMessage: HIDPINGRequestMessage): HIDResponseMessage {
+    suspend fun handle(hidMessage: HIDPINGRequestMessage): HIDResponseMessage {
         return HIDPINGResponseMessage(hidMessage.channelId, hidMessage.data)
     }
 }


### PR DESCRIPTION
- Introduce `CtapTransaction` (Job wrapper) and `withTransaction` for centralized mutex, KEEPALIVE, and active transaction tracking
- Extract `KeepAliveHandler`/`KeepAliveStatus` as transport-agnostic types shared between HID and BLE
- Simplify `HIDCborCommandHandler` to use suspend `invokeCommand` with `KeepAliveHandler` callback instead of managing keepAlive coroutine directly
- Remove per-channel `keepAliveWorker` thread and `CompletableDeferred` from `HIDChannel`/`HIDCborCommandHandler`
- Fix `_activeTransaction` race condition by setting it after mutex acquisition and clearing in finally block