### PR TITLE
Align Option/Setting naming with webauthn4j-metadata

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -108,7 +108,7 @@ class CtapAuthenticator(
     var userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED
     var userVerification: UserVerificationSetting = UserVerificationSetting.READY
     var alwaysUv: AlwaysUvSetting = AlwaysUvSetting.DISABLED
-    var makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.DISABLED
+    var makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.UV_REQUIRED
     var credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.AUTHENTICATOR
 
     fun createSession(

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/data/settings/MakeCredUvNotRqdSetting.kt
@@ -3,7 +3,7 @@ package com.webauthn4j.ctap.authenticator.data.settings
 /**
  * Controls the makeCredUvNotRqd option reported in authenticatorGetInfo.
  *
- * When [ENABLED], the authenticator allows creating non-discoverable credentials
+ * When [UV_NOT_REQUIRED], the authenticator allows creating non-discoverable credentials
  * without user verification. Discoverable credentials (rk=true) still require UV.
  * This option is overridden to false when alwaysUv is enabled.
  *
@@ -11,16 +11,16 @@ package com.webauthn4j.ctap.authenticator.data.settings
  */
 enum class MakeCredUvNotRqdSetting(val value: Boolean) {
     /** Non-discoverable credentials can be created without user verification. */
-    ENABLED(true),
+    UV_NOT_REQUIRED(true),
     /** All credentials require user verification when the authenticator is protected. */
-    DISABLED(false);
+    UV_REQUIRED(false);
 
     companion object {
         @JvmStatic
         fun create(value: Boolean): MakeCredUvNotRqdSetting {
             return when {
-                value -> ENABLED
-                else -> DISABLED
+                value -> UV_NOT_REQUIRED
+                else -> UV_REQUIRED
             }
         }
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -108,8 +108,8 @@ internal class GetInfoExecution(
             AlwaysUvSetting.DISABLED -> null
         }
         val makeCredUvNotRqd: MakeCredUvNotRqdOption? = when (ctapAuthenticatorSession.makeCredUvNotRqd) {
-            MakeCredUvNotRqdSetting.ENABLED -> MakeCredUvNotRqdOption.ENABLED
-            MakeCredUvNotRqdSetting.DISABLED -> null
+            MakeCredUvNotRqdSetting.UV_NOT_REQUIRED -> MakeCredUvNotRqdOption.UV_NOT_REQUIRED
+            MakeCredUvNotRqdSetting.UV_REQUIRED -> null
         }
         val extensions = ctapAuthenticatorSession.extensionProcessors.map { it.extensionId }
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -162,7 +162,7 @@ internal class MakeCredentialExecution :
         // TODO: Step 4: Create a new response structure. Currently represented by field declarations (upResult=false, uvResult=false).
         execStep5ProcessOptions()
         // Initialize from authenticator setting; Step 6.1 may override to false when alwaysUv is enabled.
-        makeCredUvNotRqd = ctapAuthenticatorSession.makeCredUvNotRqd == MakeCredUvNotRqdSetting.ENABLED
+        makeCredUvNotRqd = ctapAuthenticatorSession.makeCredUvNotRqd == MakeCredUvNotRqdSetting.UV_NOT_REQUIRED
         execStep6ProcessAlwaysUv()
         execStep7And8ProcessMakeCredUvNotRqd()
         // TODO: Step 9: enterpriseAttestation processing

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
@@ -157,7 +157,7 @@ internal class MakeCredentialExecutionTest {
 
         val ctapAuthenticator = CtapAuthenticator()
         ctapAuthenticator.residentKey = residentKeySetting
-        ctapAuthenticator.makeCredUvNotRqd = MakeCredUvNotRqdSetting.ENABLED
+        ctapAuthenticator.makeCredUvNotRqd = MakeCredUvNotRqdSetting.UV_NOT_REQUIRED
         val connection = ctapAuthenticator.createSession()
 
         val response = connection.makeCredential(command)

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/AlwaysUvOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/AlwaysUvOption.kt
@@ -13,13 +13,13 @@ data class AlwaysUvOption constructor(@get:JsonValue val value: Boolean) {
         val DISABLED = AlwaysUvOption(false)
 
         @JvmField
-        val NULL: AlwaysUvOption? = null
+        val NOT_SUPPORTED: AlwaysUvOption? = null
 
         @JvmStatic
         @JsonCreator
         fun create(value: Boolean?): AlwaysUvOption? {
             return when {
-                value == null -> NULL
+                value == null -> NOT_SUPPORTED
                 value -> ENABLED
                 else -> DISABLED
             }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/BioEnrollOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/BioEnrollOption.kt
@@ -13,13 +13,13 @@ data class BioEnrollOption constructor(@get:JsonValue val value: Boolean) {
         val NOT_PROVISIONED = BioEnrollOption(false)
 
         @JvmField
-        val NULL: BioEnrollOption? = null
+        val NOT_SUPPORTED: BioEnrollOption? = null
 
         @JvmStatic
         @JsonCreator
         fun create(value: Boolean?): BioEnrollOption? {
             return when {
-                value == null -> NULL
+                value == null -> NOT_SUPPORTED
                 value -> PROVISIONED
                 else -> NOT_PROVISIONED
             }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/EnterpriseAttestationOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/EnterpriseAttestationOption.kt
@@ -13,13 +13,13 @@ data class EnterpriseAttestationOption constructor(@get:JsonValue val value: Boo
         val DISABLED = EnterpriseAttestationOption(false)
 
         @JvmField
-        val NULL: EnterpriseAttestationOption? = null
+        val NOT_SUPPORTED: EnterpriseAttestationOption? = null
 
         @JvmStatic
         @JsonCreator
         fun create(value: Boolean?): EnterpriseAttestationOption? {
             return when {
-                value == null -> NULL
+                value == null -> NOT_SUPPORTED
                 value -> ENABLED
                 else -> DISABLED
             }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/MakeCredUvNotRqdOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/MakeCredUvNotRqdOption.kt
@@ -7,10 +7,10 @@ data class MakeCredUvNotRqdOption constructor(@get:JsonValue val value: Boolean)
 
     companion object {
         @JvmField
-        val ENABLED = MakeCredUvNotRqdOption(true)
+        val UV_NOT_REQUIRED = MakeCredUvNotRqdOption(true)
 
         @JvmField
-        val DISABLED = MakeCredUvNotRqdOption(false)
+        val UV_REQUIRED = MakeCredUvNotRqdOption(false)
 
         @JvmField
         val NULL: MakeCredUvNotRqdOption? = null
@@ -20,8 +20,8 @@ data class MakeCredUvNotRqdOption constructor(@get:JsonValue val value: Boolean)
         fun create(value: Boolean?): MakeCredUvNotRqdOption? {
             return when {
                 value == null -> NULL
-                value -> ENABLED
-                else -> DISABLED
+                value -> UV_NOT_REQUIRED
+                else -> UV_REQUIRED
             }
         }
     }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/UserVerificationMgmtPreviewOption.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/options/UserVerificationMgmtPreviewOption.kt
@@ -13,13 +13,13 @@ data class UserVerificationMgmtPreviewOption constructor(@get:JsonValue val valu
         val NOT_PROVISIONED = UserVerificationMgmtPreviewOption(false)
 
         @JvmField
-        val NULL: UserVerificationMgmtPreviewOption? = null
+        val NOT_SUPPORTED: UserVerificationMgmtPreviewOption? = null
 
         @JvmStatic
         @JsonCreator
         fun create(value: Boolean?): UserVerificationMgmtPreviewOption? {
             return when {
-                value == null -> NULL
+                value == null -> NOT_SUPPORTED
                 value -> PROVISIONED
                 else -> NOT_PROVISIONED
             }

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
@@ -77,7 +77,7 @@ abstract class IntegrationTestCaseBase {
             TestParameter { UserVerificationSetting.READY }
         private val algorithmsParameter = TestParameter { setOf(COSEAlgorithmIdentifier.ES256) }
         private val makeCredUvNotRqdSettingParameter =
-            TestParameter { MakeCredUvNotRqdSetting.DISABLED }
+            TestParameter { MakeCredUvNotRqdSetting.UV_REQUIRED }
         private val credentialSelectorSettingParameter =
             TestParameter { CredentialSelectorSetting.CLIENT_PLATFORM }
 

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/SecondFactorTestCase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/SecondFactorTestCase.kt
@@ -21,7 +21,7 @@ class SecondFactorTestCase : IntegrationTestCaseBase() {
         //  Without makeCredUvNotRqd, Step 8 rejects all uv=false requests on UV-protected authenticators.
         //  With PREFERRED, the client sends rk=true and Step 7 rejects it without UV.
         //  Once the client supports PUAT_REQUIRED retry, these can be removed.
-        authenticator.makeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.ENABLED
+        authenticator.makeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.UV_NOT_REQUIRED
         relyingParty.registration.frontend.requireResidentKey = false
         relyingParty.registration.frontend.residentKey = ResidentKeyRequirement.DISCOURAGED
         relyingParty.registration.frontend.userVerification =


### PR DESCRIPTION
Align constant names in webauthn4j-ctap with those in webauthn4j-metadata for consistency.

- `MakeCredUvNotRqdOption`: `ENABLED`/`DISABLED` → `UV_NOT_REQUIRED`/`UV_REQUIRED`
- `MakeCredUvNotRqdSetting`: `ENABLED`/`DISABLED` → `UV_NOT_REQUIRED`/`UV_REQUIRED`
- Null constants: `NULL` → `NOT_SUPPORTED` for `AlwaysUvOption`, `BioEnrollOption`, `EnterpriseAttestationOption`, `UserVerificationMgmtPreviewOption`