### PR TITLE
Upgrade webauthn4j to master-SNAPSHOT via JitPack

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktor = "3.5.1"
 
 quarkus = "3.37.2"
 
-webauthn4j = "0.31.8.RELEASE"
+webauthn4j = "master-SNAPSHOT"
 
 slf4j = "2.0.18"
 
@@ -44,9 +44,9 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
 
 # WebAuthn4J
-webauthn4j-core = { module = "com.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
-webauthn4j-metadata = { module = "com.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
-webauthn4j-test = { module = "com.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
+webauthn4j-core = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
+webauthn4j-metadata = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
+webauthn4j-test = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
 
 # Third-party libraries
 

--- a/unifidokey-usbip/build.gradle.kts
+++ b/unifidokey-usbip/build.gradle.kts
@@ -8,6 +8,7 @@ description = "Sample application demonstrating CTAP USB-IP server"
 repositories {
     mavenLocal()
     mavenCentral()
+    maven(url = "https://jitpack.io")
 }
 
 dependencies {

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
@@ -2,28 +2,29 @@ package com.webauthn4j.ctap.core.converter.jackson.serializer
 
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
 
+// CTAP2 canonical CBOR: string keys sorted by length first, then lexicographic
 class AuthenticatorGetInfoResponseDataOptionsSerializer :
     AbstractCtapCanonicalCborSerializer<AuthenticatorGetInfoResponseData.Options>(
         AuthenticatorGetInfoResponseData.Options::class.java,
         listOf(
+            FieldSerializationRule("ep") { it.ep?.value },
             FieldSerializationRule("rk") { it.rk?.value },
             FieldSerializationRule("up") { it.up?.value },
             FieldSerializationRule("uv") { it.uv?.value },
             FieldSerializationRule("plat") { it.plat?.value },
-            FieldSerializationRule("clientPin") { it.clientPin?.value },
-            FieldSerializationRule("pinUvAuthToken") { it.pinUvAuthToken?.value },
-            FieldSerializationRule("noMcGaPermissionsWithClientPin") { it.noMcGaPermissionsWithClientPin?.value },
-            FieldSerializationRule("largeBlobs") { it.largeBlobs?.value },
-            FieldSerializationRule("ep") { it.ep?.value },
-            FieldSerializationRule("bioEnroll") { it.bioEnroll?.value },
-            FieldSerializationRule("userVerificationMgmtPreview") { it.userVerificationMgmtPreview?.value },
-            FieldSerializationRule("uvBioEnroll") { it.uvBioEnroll?.value },
-            FieldSerializationRule("authnrCfg") { it.authnrCfg?.value },
             FieldSerializationRule("uvAcfg") { it.uvAcfg?.value },
+            FieldSerializationRule("alwaysUv") { it.alwaysUv?.value },
             FieldSerializationRule("credMgmt") { it.credMgmt?.value },
+            FieldSerializationRule("authnrCfg") { it.authnrCfg?.value },
+            FieldSerializationRule("bioEnroll") { it.bioEnroll?.value },
+            FieldSerializationRule("clientPin") { it.clientPin?.value },
+            FieldSerializationRule("largeBlobs") { it.largeBlobs?.value },
+            FieldSerializationRule("uvBioEnroll") { it.uvBioEnroll?.value },
             FieldSerializationRule("perCredMgmtRO") { it.perCredMgmtRO?.value },
-            FieldSerializationRule("credentialMgmtPreview") { it.credentialMgmtPreview?.value },
+            FieldSerializationRule("pinUvAuthToken") { it.pinUvAuthToken?.value },
             FieldSerializationRule("setMinPINLength") { it.setMinPINLength?.value },
             FieldSerializationRule("makeCredUvNotRqd") { it.makeCredUvNotRqd?.value },
-            FieldSerializationRule("alwaysUv") { it.alwaysUv?.value }
+            FieldSerializationRule("credentialMgmtPreview") { it.credentialMgmtPreview?.value },
+            FieldSerializationRule("userVerificationMgmtPreview") { it.userVerificationMgmtPreview?.value },
+            FieldSerializationRule("noMcGaPermissionsWithClientPin") { it.noMcGaPermissionsWithClientPin?.value }
         ))


### PR DESCRIPTION
- Switch webauthn4j dependency from `0.31.8.RELEASE` to `master-SNAPSHOT` via JitPack to pick up recent fixes (e.g., strict COSEAlgorithmIdentifier deserialization).
- Fix `AuthenticatorGetInfoResponseDataOptionsSerializer` to use CTAP2 canonical CBOR ordering (sorted by key length first, then lexicographic).