### PR TITLE
Declare FIDO 2.1 support and configure authenticator settings

### DIFF
--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
@@ -3,6 +3,7 @@ package com.webauthn4j.unifidokey.usbip
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.attestation.PackedBasicAttestationStatementProvider
 import com.webauthn4j.ctap.authenticator.data.settings.CredentialSelectorSetting
+import com.webauthn4j.data.AuthenticatorTransport
 import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDevice
 import com.webauthn4j.ctap.authenticator.transport.usbip.USBIPDeviceConfig
 import kotlinx.coroutines.CoroutineScope
@@ -29,7 +30,8 @@ class UniFIDOKeyUSBIP : Runnable {
         val config = USBIPDeviceConfig(host = host, port = port)
         val authenticator = CtapAuthenticator(
             attestationStatementProvider = PackedBasicAttestationStatementProvider.createWithDemoAttestationKey(),
-            userVerificationHandler = ConsoleUserVerificationHandler()
+            userVerificationHandler = ConsoleUserVerificationHandler(),
+            transports = setOf(AuthenticatorTransport.USB)
         ).apply {
             credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
         }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -60,8 +60,7 @@ class CtapAuthenticator(
         @JvmField
         val AAGUID = AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8")
         @JvmField
-        val VERSIONS = listOf(CtapVersion.U2F_V2, CtapVersion.FIDO_2_0)
-
+        val VERSIONS = listOf(CtapVersion.U2F_V2, CtapVersion.FIDO_2_0, CtapVersion.FIDO_2_1_PRE, CtapVersion.FIDO_2_1)
 
         private fun createObjectConverter(): ObjectConverter {
             val jsonMapper = JsonMapper()
@@ -106,7 +105,7 @@ class CtapAuthenticator(
     var userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED
     var userVerification: UserVerificationSetting = UserVerificationSetting.READY
     var alwaysUv: AlwaysUvSetting = AlwaysUvSetting.DISABLED
-    var makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.UV_REQUIRED
+    var makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.UV_NOT_REQUIRED
     var credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.AUTHENTICATOR
 
     fun createSession(


### PR DESCRIPTION
- Add `FIDO_2_1` and `FIDO_2_1_PRE` to supported versions in `CtapAuthenticator.VERSIONS`.
- Set `makeCredUvNotRqd` default to `UV_NOT_REQUIRED`, allowing non-discoverable credential creation without user verification when the RP does not explicitly require it.
- Set USB transport for unifidokey-usbip.

Depends on #299.