### PR TITLE
Introduce typed CtapVersion enum for version management

### DIFF
--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
@@ -125,7 +125,7 @@ class GenerateMetadataStatement : Runnable {
     companion object {
         private fun toMetadataGetInfo(getInfo: AuthenticatorGetInfoResponseData): AuthenticatorGetInfo {
             return AuthenticatorGetInfo(
-                getInfo.versions,
+                getInfo.versions.map { it.versionString },
                 getInfo.extensions ?: emptyList(),
                 getInfo.aaguid,
                 getInfo.options?.let { toMetadataOptions(it) },

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -1,6 +1,7 @@
 package com.webauthn4j.ctap.authenticator
 
 import tools.jackson.databind.json.JsonMapper
+import com.webauthn4j.ctap.core.data.CtapVersion
 import tools.jackson.dataformat.cbor.CBORMapper
 import tools.jackson.module.kotlin.KotlinModule
 import com.webauthn4j.converter.util.ObjectConverter
@@ -58,12 +59,9 @@ class CtapAuthenticator(
     companion object{
         @JvmField
         val AAGUID = AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8")
-        const val VERSION_U2F_V2 = "U2F_V2"
-        const val VERSION_FIDO_2_0 = "FIDO_2_0"
-        const val VERSION_FIDO_2_1_PRE = "FIDO_2_1_PRE"
-
         @JvmField
-        val VERSIONS = listOf(VERSION_U2F_V2, VERSION_FIDO_2_0)
+        val VERSIONS = listOf(CtapVersion.U2F_V2, CtapVersion.FIDO_2_0)
+
 
         private fun createObjectConverter(): ObjectConverter {
             val jsonMapper = JsonMapper()

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
@@ -17,7 +17,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
         @JvmStatic
         @JsonCreator
         fun createFromCbor(
-            @JsonProperty("1") versions: List<String>,
+            @JsonProperty("1") versions: List<CtapVersion>,
             @JsonProperty("2") extensions: List<String>?,
             @JsonProperty("3") aaguid: AAGUID,
             @JsonProperty("4") options: Options?,
@@ -86,7 +86,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
     }
 
     // §6.4 versions (0x01): Required
-    val versions: List<String>
+    val versions: List<CtapVersion>
     // §6.4 extensions (0x02): Optional
     val extensions: List<String>?
     // §6.4 aaguid (0x03): Required
@@ -149,7 +149,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
     val authenticatorConfigCommands: List<UInt>?
 
     constructor(
-        versions: List<String>,
+        versions: List<CtapVersion>,
         extensions: List<String>?,
         aaguid: AAGUID,
         options: Options?,

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
@@ -1,0 +1,26 @@
+package com.webauthn4j.ctap.core.data
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class CtapVersion(@get:JsonValue val versionString: String, val major: Int, val minor: Int) {
+
+    companion object {
+        val U2F_V2 = CtapVersion("U2F_V2", 1, 0)
+        val FIDO_2_0 = CtapVersion("FIDO_2_0", 1, 0)
+        val FIDO_2_1_PRE = CtapVersion("FIDO_2_1_PRE", 1, 0)
+        val FIDO_2_1 = CtapVersion("FIDO_2_1", 1, 1)
+
+        @JvmStatic
+        @JsonCreator
+        fun create(value: String): CtapVersion {
+            return when (value) {
+                U2F_V2.versionString -> U2F_V2
+                FIDO_2_0.versionString -> FIDO_2_0
+                FIDO_2_1_PRE.versionString -> FIDO_2_1_PRE
+                FIDO_2_1.versionString -> FIDO_2_1
+                else -> CtapVersion(value, 0, 0)
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverterTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverterTest.kt
@@ -8,6 +8,7 @@ import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.core.converter.jackson.CtapCBORModule
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
+import com.webauthn4j.ctap.core.data.CtapVersion
 import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialResponse
 import com.webauthn4j.ctap.core.data.CtapStatusCode
 import com.webauthn4j.data.PinProtocolVersion
@@ -37,7 +38,7 @@ internal class CtapResponseConverterTest {
     @Test
     fun convert_AuthenticatorGetInfoResponseData_test() {
         val responseData = AuthenticatorGetInfoResponseData(
-            listOf("FIDO_2_0"), emptyList(),
+            listOf(CtapVersion.FIDO_2_0), emptyList(),
             CtapAuthenticator.AAGUID,
             AuthenticatorGetInfoResponseData.Options(
                 PlatformOption.CROSS_PLATFORM,

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataSerializerTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataSerializerTest.kt
@@ -8,6 +8,7 @@ import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.core.converter.jackson.CtapCBORModule
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
+import com.webauthn4j.ctap.core.data.CtapVersion
 import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.core.data.options.ClientPINOption
 import com.webauthn4j.ctap.core.data.options.PlatformOption
@@ -32,7 +33,7 @@ internal class AuthenticatorGetInfoResponseDataSerializerTest {
     @Test
     fun integer_keys_should_be_encoded_as_cbor_unsigned_integer() {
         val original = AuthenticatorGetInfoResponseData(
-            listOf("FIDO_2_0"), null,
+            listOf(CtapVersion.FIDO_2_0), null,
             CtapAuthenticator.AAGUID,
             null, null, null, null, null, null
         )
@@ -46,7 +47,7 @@ internal class AuthenticatorGetInfoResponseDataSerializerTest {
     @Test
     fun test() {
         val original = AuthenticatorGetInfoResponseData(
-            listOf("FIDO_2_0"), emptyList(),
+            listOf(CtapVersion.FIDO_2_0), emptyList(),
             CtapAuthenticator.AAGUID,
             AuthenticatorGetInfoResponseData.Options(
                 PlatformOption.CROSS_PLATFORM,

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/data/hid/HIDMessageTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/data/hid/HIDMessageTest.kt
@@ -4,6 +4,7 @@ import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.ctap.authenticator.transport.hid.HIDResponseMessageBuilder
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
+import com.webauthn4j.ctap.core.data.CtapVersion
 import com.webauthn4j.ctap.core.data.CtapStatusCode.Companion.CTAP2_OK
 import com.webauthn4j.ctap.core.data.options.ClientPINOption
 import com.webauthn4j.ctap.core.data.options.PlatformOption
@@ -23,7 +24,7 @@ internal class HIDMessageTest {
             AuthenticatorGetInfoResponse(
                 CTAP2_OK,
                 AuthenticatorGetInfoResponseData(
-                    listOf("FIDO_2_0"),
+                    listOf(CtapVersion.FIDO_2_0),
                     listOf(),
                     AAGUID(UUID.randomUUID()),
                     AuthenticatorGetInfoResponseData.Options(


### PR DESCRIPTION
Move version definitions from raw String constants to a `CtapVersion` enum in ctap-core. Each entry carries the CTAP version string (for GetInfo CBOR serialization via `@JsonValue`) and UPV major/minor (for metadata generation). `AuthenticatorGetInfoResponseData.versions` is now `List<CtapVersion>` instead of `List<String>`.

Depends on #301.