### PR TITLE
Fix GetInfo options CBOR canonical sort order

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetInfoResponseDataOptionsSerializer.kt
@@ -2,28 +2,29 @@ package com.webauthn4j.ctap.core.converter.jackson.serializer
 
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
 
+// CTAP2 canonical CBOR: string keys sorted by length first, then lexicographic
 class AuthenticatorGetInfoResponseDataOptionsSerializer :
     AbstractCtapCanonicalCborSerializer<AuthenticatorGetInfoResponseData.Options>(
         AuthenticatorGetInfoResponseData.Options::class.java,
         listOf(
+            FieldSerializationRule("ep") { it.ep?.value },
             FieldSerializationRule("rk") { it.rk?.value },
             FieldSerializationRule("up") { it.up?.value },
             FieldSerializationRule("uv") { it.uv?.value },
             FieldSerializationRule("plat") { it.plat?.value },
-            FieldSerializationRule("clientPin") { it.clientPin?.value },
-            FieldSerializationRule("pinUvAuthToken") { it.pinUvAuthToken?.value },
-            FieldSerializationRule("noMcGaPermissionsWithClientPin") { it.noMcGaPermissionsWithClientPin?.value },
-            FieldSerializationRule("largeBlobs") { it.largeBlobs?.value },
-            FieldSerializationRule("ep") { it.ep?.value },
-            FieldSerializationRule("bioEnroll") { it.bioEnroll?.value },
-            FieldSerializationRule("userVerificationMgmtPreview") { it.userVerificationMgmtPreview?.value },
-            FieldSerializationRule("uvBioEnroll") { it.uvBioEnroll?.value },
-            FieldSerializationRule("authnrCfg") { it.authnrCfg?.value },
             FieldSerializationRule("uvAcfg") { it.uvAcfg?.value },
+            FieldSerializationRule("alwaysUv") { it.alwaysUv?.value },
             FieldSerializationRule("credMgmt") { it.credMgmt?.value },
+            FieldSerializationRule("authnrCfg") { it.authnrCfg?.value },
+            FieldSerializationRule("bioEnroll") { it.bioEnroll?.value },
+            FieldSerializationRule("clientPin") { it.clientPin?.value },
+            FieldSerializationRule("largeBlobs") { it.largeBlobs?.value },
+            FieldSerializationRule("uvBioEnroll") { it.uvBioEnroll?.value },
             FieldSerializationRule("perCredMgmtRO") { it.perCredMgmtRO?.value },
-            FieldSerializationRule("credentialMgmtPreview") { it.credentialMgmtPreview?.value },
+            FieldSerializationRule("pinUvAuthToken") { it.pinUvAuthToken?.value },
             FieldSerializationRule("setMinPINLength") { it.setMinPINLength?.value },
             FieldSerializationRule("makeCredUvNotRqd") { it.makeCredUvNotRqd?.value },
-            FieldSerializationRule("alwaysUv") { it.alwaysUv?.value }
+            FieldSerializationRule("credentialMgmtPreview") { it.credentialMgmtPreview?.value },
+            FieldSerializationRule("userVerificationMgmtPreview") { it.userVerificationMgmtPreview?.value },
+            FieldSerializationRule("noMcGaPermissionsWithClientPin") { it.noMcGaPermissionsWithClientPin?.value }
         ))


### PR DESCRIPTION
Sort options keys by length first, then lexicographic, as required by CTAP2 canonical CBOR encoding.