### PR TITLE
Restore webauthn4j master-SNAPSHOT dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktor = "3.5.1"
 
 quarkus = "3.37.2"
 
-webauthn4j = "0.31.8.RELEASE"
+webauthn4j = "master-SNAPSHOT"
 
 slf4j = "2.0.18"
 


### PR DESCRIPTION
Dependabot PR #306 reverted webauthn4j from master-SNAPSHOT back to 0.31.8.RELEASE, losing the CBOR canonical serialization fix for PublicKeyCredentialParameters needed by FIDO Conformance Tools.