### PR TITLE
Fix PinUvAuthTokenPermissions CBOR deserialization

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
@@ -2,6 +2,7 @@ package com.webauthn4j.ctap.core.converter.jackson
 
 import tools.jackson.databind.module.SimpleModule
 import com.webauthn4j.ctap.core.converter.jackson.deserializer.CoercionLessByteArrayDeserializer
+import com.webauthn4j.ctap.core.converter.jackson.deserializer.PinUvAuthTokenPermissionsDeserializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorClientPINRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorClientPINResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorGetAssertionRequestOptionsSerializer
@@ -17,6 +18,7 @@ import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorMakeCr
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorMakeCredentialResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorResetRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorResetResponseDataSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.PinUvAuthTokenPermissionsSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialRpEntitySerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialUserEntitySerializer
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINRequest
@@ -33,6 +35,7 @@ import com.webauthn4j.ctap.core.data.AuthenticatorResetRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorResetResponseData
 import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialRpEntity
 import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialUserEntity
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
 
 class CtapCBORModule : SimpleModule("CtapCBORModule") {
     init {
@@ -105,6 +108,9 @@ class CtapCBORModule : SimpleModule("CtapCBORModule") {
             CtapPublicKeyCredentialUserEntitySerializer()
         )
 
+        this.addSerializer(PinUvAuthTokenPermissions::class.java, PinUvAuthTokenPermissionsSerializer())
+
         this.addDeserializer(ByteArray::class.java, CoercionLessByteArrayDeserializer())
+        this.addDeserializer(PinUvAuthTokenPermissions::class.java, PinUvAuthTokenPermissionsDeserializer())
     }
 }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/deserializer/PinUvAuthTokenPermissionsDeserializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/deserializer/PinUvAuthTokenPermissionsDeserializer.kt
@@ -1,0 +1,12 @@
+package com.webauthn4j.ctap.core.converter.jackson.deserializer
+
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.deser.std.StdDeserializer
+
+class PinUvAuthTokenPermissionsDeserializer : StdDeserializer<PinUvAuthTokenPermissions>(PinUvAuthTokenPermissions::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): PinUvAuthTokenPermissions {
+        return PinUvAuthTokenPermissions.fromBitfield(p.intValue)
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/PinUvAuthTokenPermissionsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/PinUvAuthTokenPermissionsSerializer.kt
@@ -1,0 +1,12 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ser.std.StdSerializer
+
+class PinUvAuthTokenPermissionsSerializer : StdSerializer<PinUvAuthTokenPermissions>(PinUvAuthTokenPermissions::class.java) {
+    override fun serialize(value: PinUvAuthTokenPermissions, gen: JsonGenerator, ctxt: SerializationContext) {
+        gen.writeNumber(value.toBitfield())
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermission.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermission.kt
@@ -14,12 +14,4 @@ enum class PinUvAuthTokenPermission(val value: Int) {
     BE(0x08),
     LBW(0x10),
     ACFG(0x20);
-
-    companion object {
-        fun fromBitfield(bitfield: Int): Set<PinUvAuthTokenPermission> =
-            entries.filter { bitfield and it.value != 0 }.toSet()
-
-        fun toBitfield(permissions: Set<PinUvAuthTokenPermission>): Int =
-            permissions.fold(0) { acc, p -> acc or p.value }
-    }
 }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermissions.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermissions.kt
@@ -1,24 +1,22 @@
 package com.webauthn4j.ctap.core.data
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonValue
-
-class PinUvAuthTokenPermissions : AbstractSet<PinUvAuthTokenPermission> {
-
+class PinUvAuthTokenPermissions private constructor(
     private val permissions: Set<PinUvAuthTokenPermission>
+) : AbstractSet<PinUvAuthTokenPermission>() {
 
-    @JsonCreator
-    constructor(bitfield: Int) {
-        permissions = PinUvAuthTokenPermission.fromBitfield(bitfield)
-    }
+    constructor(vararg perms: PinUvAuthTokenPermission) : this(perms.toSet())
 
-    constructor(vararg perms: PinUvAuthTokenPermission) {
-        permissions = perms.toSet()
-    }
-
-    @JsonValue
-    fun toBitfield(): Int = PinUvAuthTokenPermission.toBitfield(permissions)
+    fun toBitfield(): Int = permissions.fold(0) { acc, p -> acc or p.value }
 
     override val size: Int get() = permissions.size
     override fun iterator(): Iterator<PinUvAuthTokenPermission> = permissions.iterator()
+
+    companion object {
+        @JvmStatic
+        fun fromBitfield(bitfield: Int): PinUvAuthTokenPermissions {
+            return PinUvAuthTokenPermissions(
+                PinUvAuthTokenPermission.entries.filter { bitfield and it.value != 0 }.toSet()
+            )
+        }
+    }
 }

--- a/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermissionsTest.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/com/webauthn4j/ctap/core/data/PinUvAuthTokenPermissionsTest.kt
@@ -1,0 +1,71 @@
+package com.webauthn4j.ctap.core.data
+
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.ctap.core.converter.jackson.CtapCBORModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.dataformat.cbor.CBORMapper
+import tools.jackson.module.kotlin.KotlinModule
+
+internal class PinUvAuthTokenPermissionsTest {
+
+    private val cborMapper: CBORMapper
+
+    init {
+        val jsonMapper = JsonMapper()
+        val ctapCborMapper = CBORMapper.builder()
+            .addModule(CtapCBORModule())
+            .addModule(KotlinModule.Builder().build())
+            .build()
+        cborMapper = ObjectConverter(jsonMapper, ctapCborMapper).cborMapper
+    }
+
+    @Test
+    fun cbor_roundtrip_single_permission() {
+        val original = PinUvAuthTokenPermissions(PinUvAuthTokenPermission.MC)
+        val bytes = cborMapper.writeValueAsBytes(original)
+        val deserialized = cborMapper.readValue(bytes, PinUvAuthTokenPermissions::class.java)
+        assertThat(deserialized).containsExactlyInAnyOrderElementsOf(original)
+        assertThat(deserialized.toBitfield()).isEqualTo(original.toBitfield())
+    }
+
+    @Test
+    fun cbor_roundtrip_multiple_permissions() {
+        val original = PinUvAuthTokenPermissions(PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA)
+        val bytes = cborMapper.writeValueAsBytes(original)
+        val deserialized = cborMapper.readValue(bytes, PinUvAuthTokenPermissions::class.java)
+        assertThat(deserialized).containsExactlyInAnyOrderElementsOf(original)
+        assertThat(deserialized.toBitfield()).isEqualTo(0x03)
+    }
+
+    @Test
+    fun cbor_roundtrip_all_permissions() {
+        val original = PinUvAuthTokenPermissions(
+            PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA,
+            PinUvAuthTokenPermission.CM, PinUvAuthTokenPermission.BE,
+            PinUvAuthTokenPermission.LBW, PinUvAuthTokenPermission.ACFG
+        )
+        val bytes = cborMapper.writeValueAsBytes(original)
+        val deserialized = cborMapper.readValue(bytes, PinUvAuthTokenPermissions::class.java)
+        assertThat(deserialized).containsExactlyInAnyOrderElementsOf(original)
+        assertThat(deserialized.toBitfield()).isEqualTo(0x3F)
+    }
+
+    @Test
+    fun cbor_deserialize_from_integer() {
+        // Simulate CBOR integer 0x03 (MC | GA) as sent by a CTAP client
+        val bytes = cborMapper.writeValueAsBytes(0x03)
+        val deserialized = cborMapper.readValue(bytes, PinUvAuthTokenPermissions::class.java)
+        assertThat(deserialized).containsExactlyInAnyOrder(PinUvAuthTokenPermission.MC, PinUvAuthTokenPermission.GA)
+    }
+
+    @Test
+    fun toBitfield_and_constructor_consistency() {
+        val permissions = PinUvAuthTokenPermissions(PinUvAuthTokenPermission.GA, PinUvAuthTokenPermission.LBW)
+        val bitfield = permissions.toBitfield()
+        assertThat(bitfield).isEqualTo(0x12)
+        val fromBitfield = PinUvAuthTokenPermissions.fromBitfield(bitfield)
+        assertThat(fromBitfield).containsExactlyInAnyOrderElementsOf(permissions)
+    }
+}


### PR DESCRIPTION
Jackson treats AbstractSet subclasses as collections and ignores @JsonCreator on the constructor, causing `MismatchedInputException: no default no-arguments constructor found` when deserializing the `permissions` field in ClientPIN requests.

Add explicit serializer/deserializer pair registered in CtapCBORModule, and remove the Jackson annotations from the class since they are not effective on AbstractSet subclasses.