### PR TITLE
Move validate() inside try-catch in CtapCommandExecutionBase

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/CtapCommandExecutionBase.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/CtapCommandExecutionBase.kt
@@ -17,9 +17,8 @@ abstract class CtapCommandExecutionBase<TC : CtapRequest, TR : CtapResponse>(pri
     suspend fun execute(): TR {
         logger.info("CTAP Command {}", ctapCommand.toString())
 
-        validate()
-
         val ctapResponse = try {
+            validate()
             doExecute()
         } catch (e: CancellationException) {
             throw e


### PR DESCRIPTION
The validate() call in CtapCommandExecutionBase.execute() was outside the try-catch block, so exceptions thrown during validation (e.g. IllegalArgumentException) propagated uncaught instead of being converted to a proper CTAP error response. This moves validate() inside the existing try-catch block so validation failures are handled consistently with other runtime errors.