### PR TITLE
Add FIDO 2.3 version support

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -61,7 +61,7 @@ class CtapAuthenticator(
         @JvmField
         val AAGUID = AAGUID("33c1642b-b5e9-423d-9add-5a0119c2a8b8")
         @JvmField
-        val VERSIONS = listOf(CtapVersion.U2F_V2, CtapVersion.FIDO_2_0, CtapVersion.FIDO_2_1_PRE, CtapVersion.FIDO_2_1)
+        val VERSIONS = listOf(CtapVersion.U2F_V2, CtapVersion.FIDO_2_0, CtapVersion.FIDO_2_1_PRE, CtapVersion.FIDO_2_1, CtapVersion.FIDO_2_3)
 
         private fun createObjectConverter(): ObjectConverter {
             val jsonMapper = JsonMapper()

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
@@ -10,6 +10,7 @@ data class CtapVersion(@get:JsonValue val versionString: String, val major: Int,
         val FIDO_2_0 = CtapVersion("FIDO_2_0", 1, 0)
         val FIDO_2_1_PRE = CtapVersion("FIDO_2_1_PRE", 1, 0)
         val FIDO_2_1 = CtapVersion("FIDO_2_1", 1, 1)
+        val FIDO_2_3 = CtapVersion("FIDO_2_3", 1, 2)
 
         @JvmStatic
         @JsonCreator
@@ -19,6 +20,7 @@ data class CtapVersion(@get:JsonValue val versionString: String, val major: Int,
                 FIDO_2_0.versionString -> FIDO_2_0
                 FIDO_2_1_PRE.versionString -> FIDO_2_1_PRE
                 FIDO_2_1.versionString -> FIDO_2_1
+                FIDO_2_3.versionString -> FIDO_2_3
                 else -> CtapVersion(value, 0, 0)
             }
         }


### PR DESCRIPTION
Add the FIDO_2_3 constant to CtapVersion (version string "FIDO_2_3", CTAP 1.2) with its factory method entry, and include it in the authenticator's advertised VERSIONS list so it appears in GetInfo responses.