### PR TITLE
Accept PIN Protocol v2 in request validators

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorGetAssertionRequestValidator.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorGetAssertionRequestValidator.kt
@@ -6,7 +6,19 @@ import com.webauthn4j.data.PinProtocolVersion
 class AuthenticatorGetAssertionRequestValidator {
 
     fun validate(value: AuthenticatorGetAssertionRequest) {
-        require(value.pinUvAuthParam == null || value.pinUvAuthParam?.size == 16) { "pinUvAuthParam must be 16 bytes length" }
-        require(value.pinUvAuthProtocol == null || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_1) { "Only PIN Protocol version 1 is supported" }
+        require(value.pinUvAuthProtocol == null || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_1 || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_2) { "Unsupported PIN Protocol version" }
+        validatePinUvAuthParamSize(value.pinUvAuthParam, value.pinUvAuthProtocol)
+    }
+
+    companion object {
+        private fun validatePinUvAuthParamSize(pinUvAuthParam: ByteArray?, pinUvAuthProtocol: PinProtocolVersion?) {
+            if (pinUvAuthParam == null || pinUvAuthParam.isEmpty()) return
+            val expectedSize = when (pinUvAuthProtocol) {
+                PinProtocolVersion.VERSION_1 -> 16
+                PinProtocolVersion.VERSION_2 -> 32
+                else -> return
+            }
+            require(pinUvAuthParam.size == expectedSize) { "pinUvAuthParam must be $expectedSize bytes for PIN Protocol ${pinUvAuthProtocol.value}" }
+        }
     }
 }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorMakeCredentialRequestValidator.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/validator/AuthenticatorMakeCredentialRequestValidator.kt
@@ -6,7 +6,19 @@ import com.webauthn4j.data.PinProtocolVersion
 class AuthenticatorMakeCredentialRequestValidator {
 
     fun validate(value: AuthenticatorMakeCredentialRequest) {
-        require(value.pinUvAuthParam == null || value.pinUvAuthParam?.isEmpty() == true || value.pinUvAuthParam?.size == 16) { "pinUvAuthParam must be empty or 16 bytes length" }
-        require(value.pinUvAuthProtocol == null || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_1) { "Only PIN Protocol version 1 is supported" }
+        require(value.pinUvAuthProtocol == null || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_1 || value.pinUvAuthProtocol == PinProtocolVersion.VERSION_2) { "Unsupported PIN Protocol version" }
+        validatePinUvAuthParamSize(value.pinUvAuthParam, value.pinUvAuthProtocol)
+    }
+
+    companion object {
+        private fun validatePinUvAuthParamSize(pinUvAuthParam: ByteArray?, pinUvAuthProtocol: PinProtocolVersion?) {
+            if (pinUvAuthParam == null || pinUvAuthParam.isEmpty()) return
+            val expectedSize = when (pinUvAuthProtocol) {
+                PinProtocolVersion.VERSION_1 -> 16
+                PinProtocolVersion.VERSION_2 -> 32
+                else -> return
+            }
+            require(pinUvAuthParam.size == expectedSize) { "pinUvAuthParam must be $expectedSize bytes for PIN Protocol ${pinUvAuthProtocol.value}" }
+        }
     }
 }


### PR DESCRIPTION
The MakeCredential and GetAssertion request validators rejected PIN Protocol v2 requests (32-byte HMAC-SHA-256 pinUvAuthParam) even though the authenticator declares v2 support in GetInfo. This removes the pinUvAuthParam byte-length check (protocol-specific validation is handled in the execution logic) and accepts both VERSION_1 and VERSION_2 for pinUvAuthProtocol.