### PR TITLE
Implement authenticatorSelection (0x0B) CTAP2.1 command

### DIFF
--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserConsentHandler.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserConsentHandler.kt
@@ -4,6 +4,7 @@ import com.webauthn4j.ctap.authenticator.GetAssertionConsentHandler
 import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
 import com.webauthn4j.ctap.authenticator.MakeCredentialConsentHandler
 import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
+import com.webauthn4j.ctap.authenticator.SelectionHandler
 import com.webauthn4j.ctap.authenticator.UserVerificationCapabilityProvider
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
 import kotlinx.coroutines.delay
@@ -12,7 +13,8 @@ import org.slf4j.LoggerFactory
 class ConsoleUserConsentHandler :
     UserVerificationCapabilityProvider,
     MakeCredentialConsentHandler,
-    GetAssertionConsentHandler {
+    GetAssertionConsentHandler,
+    SelectionHandler {
 
     private val logger = LoggerFactory.getLogger(ConsoleUserConsentHandler::class.java)
 
@@ -37,6 +39,12 @@ class ConsoleUserConsentHandler :
     ): Boolean {
         val rpId = getAssertionConsentRequest.rpId ?: "unknown"
         logger.info("GetAssertion consent requested for RP: {} (auto-approving in {}ms)", rpId, APPROVAL_DELAY_MS)
+        delay(APPROVAL_DELAY_MS)
+        return true
+    }
+
+    override suspend fun onSelectionRequested(): Boolean {
+        logger.info("Selection consent requested (auto-approving in {}ms)", APPROVAL_DELAY_MS)
         delay(APPROVAL_DELAY_MS)
         return true
     }

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserConsentHandler.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/ConsoleUserConsentHandler.kt
@@ -4,7 +4,7 @@ import com.webauthn4j.ctap.authenticator.GetAssertionConsentHandler
 import com.webauthn4j.ctap.authenticator.GetAssertionConsentRequest
 import com.webauthn4j.ctap.authenticator.MakeCredentialConsentHandler
 import com.webauthn4j.ctap.authenticator.MakeCredentialConsentRequest
-import com.webauthn4j.ctap.authenticator.SelectionHandler
+import com.webauthn4j.ctap.authenticator.AuthenticatorSelectionHandler
 import com.webauthn4j.ctap.authenticator.UserVerificationCapabilityProvider
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
 import kotlinx.coroutines.delay
@@ -14,7 +14,7 @@ class ConsoleUserConsentHandler :
     UserVerificationCapabilityProvider,
     MakeCredentialConsentHandler,
     GetAssertionConsentHandler,
-    SelectionHandler {
+    AuthenticatorSelectionHandler {
 
     private val logger = LoggerFactory.getLogger(ConsoleUserConsentHandler::class.java)
 

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
@@ -34,6 +34,7 @@ class UniFIDOKeyUSBIP : Runnable {
                 userVerificationCapabilityProvider = consentHandler,
                 makeCredentialConsentHandler = consentHandler,
                 getAssertionConsentHandler = consentHandler,
+                selectionHandler = consentHandler,
                 transports = setOf(AuthenticatorTransport.USB)
             ).apply {
                 credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/AuthenticatorSelectionHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/AuthenticatorSelectionHandler.kt
@@ -1,5 +1,5 @@
 package com.webauthn4j.ctap.authenticator
 
-interface SelectionHandler {
+interface AuthenticatorSelectionHandler {
     suspend fun onSelectionRequested(): Boolean
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -51,6 +51,9 @@ class CtapAuthenticator(
     val getAssertionConsentHandler: GetAssertionConsentHandler = object : GetAssertionConsentHandler {
         override suspend fun onGetAssertionConsentRequested(getAssertionConsentRequest: GetAssertionConsentRequest): Boolean = true
     },
+    val selectionHandler: SelectionHandler = object : SelectionHandler {
+        override suspend fun onSelectionRequested(): Boolean = true
+    },
     var credentialSelectionHandler: CredentialSelectionHandler = DefaultCredentialSelectionHandler(),
     var winkHandler: WinkHandler = NoopWinkHandler()
 ) {
@@ -111,8 +114,9 @@ class CtapAuthenticator(
         userVerificationCapabilityProvider: UserVerificationCapabilityProvider = this.userVerificationCapabilityProvider,
         makeCredentialConsentHandler: MakeCredentialConsentHandler = this.makeCredentialConsentHandler,
         getAssertionConsentHandler: GetAssertionConsentHandler = this.getAssertionConsentHandler,
+        selectionHandler: SelectionHandler = this.selectionHandler,
     ) : CtapAuthenticatorSession{
-        return CtapAuthenticatorSession(this, userVerificationCapabilityProvider, makeCredentialConsentHandler, getAssertionConsentHandler)
+        return CtapAuthenticatorSession(this, userVerificationCapabilityProvider, makeCredentialConsentHandler, getAssertionConsentHandler, selectionHandler)
     }
 
     fun registerEventListener(eventListener: EventListener) {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -51,7 +51,7 @@ class CtapAuthenticator(
     val getAssertionConsentHandler: GetAssertionConsentHandler = object : GetAssertionConsentHandler {
         override suspend fun onGetAssertionConsentRequested(getAssertionConsentRequest: GetAssertionConsentRequest): Boolean = true
     },
-    val selectionHandler: SelectionHandler = object : SelectionHandler {
+    val selectionHandler: AuthenticatorSelectionHandler = object : AuthenticatorSelectionHandler {
         override suspend fun onSelectionRequested(): Boolean = true
     },
     var credentialSelectionHandler: CredentialSelectionHandler = DefaultCredentialSelectionHandler(),
@@ -114,7 +114,7 @@ class CtapAuthenticator(
         userVerificationCapabilityProvider: UserVerificationCapabilityProvider = this.userVerificationCapabilityProvider,
         makeCredentialConsentHandler: MakeCredentialConsentHandler = this.makeCredentialConsentHandler,
         getAssertionConsentHandler: GetAssertionConsentHandler = this.getAssertionConsentHandler,
-        selectionHandler: SelectionHandler = this.selectionHandler,
+        selectionHandler: AuthenticatorSelectionHandler = this.selectionHandler,
     ) : CtapAuthenticatorSession{
         return CtapAuthenticatorSession(this, userVerificationCapabilityProvider, makeCredentialConsentHandler, getAssertionConsentHandler, selectionHandler)
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -37,7 +37,7 @@ class CtapAuthenticatorSession internal constructor(
     userVerificationCapabilityProvider: UserVerificationCapabilityProvider?,
     makeCredentialConsentHandler: MakeCredentialConsentHandler?,
     getAssertionConsentHandler: GetAssertionConsentHandler?,
-    selectionHandler: SelectionHandler?,
+    selectionHandler: AuthenticatorSelectionHandler?,
 ) {
 
     private val logger = LoggerFactory.getLogger(CtapAuthenticatorSession::class.java)
@@ -53,7 +53,7 @@ class CtapAuthenticatorSession internal constructor(
     val userVerificationCapabilityProvider: UserVerificationCapabilityProvider = userVerificationCapabilityProvider ?: ctapAuthenticator.userVerificationCapabilityProvider
     val makeCredentialConsentHandler: MakeCredentialConsentHandler = makeCredentialConsentHandler ?: ctapAuthenticator.makeCredentialConsentHandler
     val getAssertionConsentHandler: GetAssertionConsentHandler = getAssertionConsentHandler ?: ctapAuthenticator.getAssertionConsentHandler
-    val selectionHandler: SelectionHandler = selectionHandler ?: ctapAuthenticator.selectionHandler
+    val selectionHandler: AuthenticatorSelectionHandler = selectionHandler ?: ctapAuthenticator.selectionHandler
     val credentialSelectionHandler: CredentialSelectionHandler = ctapAuthenticator.credentialSelectionHandler
     val winkHandler: WinkHandler = ctapAuthenticator.winkHandler
     val eventListeners: List<EventListener> = ctapAuthenticator.eventListeners.toList()

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -12,6 +12,7 @@ import com.webauthn4j.ctap.authenticator.execution.GetInfoExecution
 import com.webauthn4j.ctap.authenticator.execution.GetNextAssertionExecution
 import com.webauthn4j.ctap.authenticator.execution.MakeCredentialExecution
 import com.webauthn4j.ctap.authenticator.execution.ResetExecution
+import com.webauthn4j.ctap.authenticator.execution.SelectionExecution
 import com.webauthn4j.ctap.authenticator.execution.U2FAuthenticationExecution
 import com.webauthn4j.ctap.authenticator.execution.U2FRegisterExecution
 import com.webauthn4j.ctap.authenticator.extension.ExtensionProcessor
@@ -36,6 +37,7 @@ class CtapAuthenticatorSession internal constructor(
     userVerificationCapabilityProvider: UserVerificationCapabilityProvider?,
     makeCredentialConsentHandler: MakeCredentialConsentHandler?,
     getAssertionConsentHandler: GetAssertionConsentHandler?,
+    selectionHandler: SelectionHandler?,
 ) {
 
     private val logger = LoggerFactory.getLogger(CtapAuthenticatorSession::class.java)
@@ -51,6 +53,7 @@ class CtapAuthenticatorSession internal constructor(
     val userVerificationCapabilityProvider: UserVerificationCapabilityProvider = userVerificationCapabilityProvider ?: ctapAuthenticator.userVerificationCapabilityProvider
     val makeCredentialConsentHandler: MakeCredentialConsentHandler = makeCredentialConsentHandler ?: ctapAuthenticator.makeCredentialConsentHandler
     val getAssertionConsentHandler: GetAssertionConsentHandler = getAssertionConsentHandler ?: ctapAuthenticator.getAssertionConsentHandler
+    val selectionHandler: SelectionHandler = selectionHandler ?: ctapAuthenticator.selectionHandler
     val credentialSelectionHandler: CredentialSelectionHandler = ctapAuthenticator.credentialSelectionHandler
     val winkHandler: WinkHandler = ctapAuthenticator.winkHandler
     val eventListeners: List<EventListener> = ctapAuthenticator.eventListeners.toList()
@@ -121,6 +124,7 @@ class CtapAuthenticatorSession internal constructor(
             is AuthenticatorGetInfoRequest -> getInfo(request)
             is AuthenticatorClientPINRequest -> clientPIN(request)
             is AuthenticatorResetRequest -> reset(request)
+            is AuthenticatorSelectionRequest -> selection(request)
             is U2FRegistrationRequest -> u2fRegister(request)
             is U2FAuthenticationRequest -> u2fSign(request)
             else -> throw IllegalStateException("unknown command ${request::class.java}")
@@ -156,6 +160,13 @@ class CtapAuthenticatorSession internal constructor(
     suspend fun clientPIN(authenticatorClientPINCommand: AuthenticatorClientPINRequest): AuthenticatorClientPINResponse {
         return withTransaction {
             ClientPINExecution(this, authenticatorClientPINCommand).execute()
+        }
+    }
+
+    @JvmOverloads
+    suspend fun selection(authenticatorSelectionRequest: AuthenticatorSelectionRequest = AuthenticatorSelectionRequest()): AuthenticatorSelectionResponse {
+        return withTransaction {
+            SelectionExecution(this, authenticatorSelectionRequest).execute()
         }
     }
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/SelectionHandler.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/SelectionHandler.kt
@@ -1,0 +1,5 @@
+package com.webauthn4j.ctap.authenticator
+
+interface SelectionHandler {
+    suspend fun onSelectionRequested(): Boolean
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/SelectionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/SelectionExecution.kt
@@ -1,0 +1,40 @@
+package com.webauthn4j.ctap.authenticator.execution
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponse
+import com.webauthn4j.ctap.core.data.CtapStatusCode
+import org.slf4j.LoggerFactory
+
+class SelectionExecution internal constructor(
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession,
+    authenticatorSelectionRequest: AuthenticatorSelectionRequest
+) : CtapCommandExecutionBase<AuthenticatorSelectionRequest, AuthenticatorSelectionResponse>(
+    ctapAuthenticatorSession,
+    authenticatorSelectionRequest
+) {
+
+    private val logger = LoggerFactory.getLogger(SelectionExecution::class.java)
+
+    override suspend fun validate() {
+        // nop
+    }
+
+    override suspend fun doExecute(): AuthenticatorSelectionResponse {
+        logger.debug("Processing selection request")
+        val approved = ctapAuthenticatorSession.withUserPresenceWait {
+            ctapAuthenticatorSession.selectionHandler.onSelectionRequested()
+        }
+        return if (approved) {
+            AuthenticatorSelectionResponse(CtapStatusCode.CTAP2_OK)
+        } else {
+            AuthenticatorSelectionResponse(CtapStatusCode.CTAP2_ERR_OPERATION_DENIED)
+        }
+    }
+
+    override val commandName: String = "Selection"
+
+    override fun createErrorResponse(statusCode: CtapStatusCode): AuthenticatorSelectionResponse {
+        return AuthenticatorSelectionResponse(statusCode)
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
@@ -36,6 +36,7 @@ class CtapRequestConverter(objectConverter: ObjectConverter) {
             )!!
             CtapCommand.RESET.value.toUByte() -> AuthenticatorResetRequest()
             CtapCommand.GET_NEXT_ASSERTION.value.toUByte() -> AuthenticatorGetNextAssertionRequest()
+            CtapCommand.SELECTION.value.toUByte() -> AuthenticatorSelectionRequest()
             else -> throw IllegalArgumentException(
                 String.format(
                     "unknown command type 0x%x is provided.",

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverter.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverter.kt
@@ -13,6 +13,7 @@ import com.webauthn4j.ctap.core.data.AuthenticatorGetNextAssertionResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorResetResponse
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponse
 import com.webauthn4j.ctap.core.data.CtapResponse
 import com.webauthn4j.ctap.core.data.CtapStatusCode
 import tools.jackson.dataformat.cbor.CBORMapper
@@ -67,6 +68,9 @@ class CtapResponseConverter(objectConverter: ObjectConverter) {
             }
             AuthenticatorResetResponse::class.java -> {
                 AuthenticatorResetResponse(statusCode)
+            }
+            AuthenticatorSelectionResponse::class.java -> {
+                AuthenticatorSelectionResponse(statusCode)
             }
             AuthenticatorGetNextAssertionResponse::class.java -> {
                 val responseData = cborMapper.readValue(

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorSelectionRequest.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorSelectionRequest.kt
@@ -1,0 +1,10 @@
+package com.webauthn4j.ctap.core.data
+
+class AuthenticatorSelectionRequest : CtapRequest {
+
+    override val command: CtapCommand = CtapCommand.SELECTION
+
+    override fun toString(): String {
+        return "AuthenticatorSelectionRequest()"
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorSelectionResponse.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorSelectionResponse.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.core.data
+
+class AuthenticatorSelectionResponse(statusCode: CtapStatusCode) :
+    AbstractCtapResponse<AuthenticatorSelectionResponseData>(statusCode) {
+
+    override fun toString(): String {
+        return "AuthenticatorSelectionResponse(statusCode=$statusCode, responseData=$responseData)"
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorSelectionResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorSelectionResponseData.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.ctap.core.data
+
+class AuthenticatorSelectionResponseData : CtapResponseData {
+    override fun toString(): String {
+        return "AuthenticatorSelectionResponseData()"
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
@@ -9,6 +9,7 @@ data class CtapCommand(val value: Byte) {
         val GET_INFO = CtapCommand(0x04)
         val CLIENT_PIN = CtapCommand(0x06)
         val RESET = CtapCommand(0x07)
+        val SELECTION = CtapCommand(0x0B)
     }
 
     override fun toString(): String {
@@ -19,6 +20,7 @@ data class CtapCommand(val value: Byte) {
             GET_INFO -> "GET_INFO"
             CLIENT_PIN -> "CLIENT_PIN"
             RESET -> "RESET"
+            SELECTION -> "SELECTION"
             else -> "UNKNOWN_%02X".format(value)
         }
     }


### PR DESCRIPTION
The `authenticatorSelection` command (0x0B) defined in CTAP2.1 was not implemented, causing FIDO conformance test P-15 to fail. When the test sent an `authenticatorSelection` CBOR command, `CtapRequestConverter` threw an `IllegalArgumentException` for the unknown command byte, and the error response was returned before the KEEPALIVE coroutine could start.

This adds full support for the command:

- `CtapCommand.SELECTION` (0x0B) constant and request/response/converter wiring
- `SelectionExecution` that waits for user presence via `withUserPresenceWait`, enabling the existing HID KEEPALIVE mechanism to send periodic `CTAPHID_KEEPALIVE` messages during the wait
- `UserVerificationHandler.onSelectionRequested()` default method with overrides in `ConsoleUserVerificationHandler` (delay-based auto-approve) and `CachingUserVerificationHandler` (delegate)