### PR TITLE
Fix authenticatorGetNextAssertion command code from 0x03 to 0x08

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
@@ -21,21 +21,21 @@ class CtapRequestConverter(objectConverter: ObjectConverter) {
         val commandType = source.first().toUByte()
         val commandParameters = source.copyOfRange(1, source.size)
         return when (commandType) {
-            0x01.toUByte() -> cborMapper.readValue(
+            CtapCommand.MAKE_CREDENTIAL.value.toUByte() -> cborMapper.readValue(
                 commandParameters,
                 AuthenticatorMakeCredentialRequest::class.java
             )!!
-            0x02.toUByte() -> cborMapper.readValue(
+            CtapCommand.GET_ASSERTION.value.toUByte() -> cborMapper.readValue(
                 commandParameters,
                 AuthenticatorGetAssertionRequest::class.java
             )!!
-            0x04.toUByte() -> AuthenticatorGetInfoRequest()
-            0x06.toUByte() -> cborMapper.readValue(
+            CtapCommand.GET_INFO.value.toUByte() -> AuthenticatorGetInfoRequest()
+            CtapCommand.CLIENT_PIN.value.toUByte() -> cborMapper.readValue(
                 commandParameters,
                 AuthenticatorClientPINRequest::class.java
             )!!
-            0x07.toUByte() -> AuthenticatorResetRequest()
-            0x08.toUByte() -> AuthenticatorGetNextAssertionRequest()
+            CtapCommand.RESET.value.toUByte() -> AuthenticatorResetRequest()
+            CtapCommand.GET_NEXT_ASSERTION.value.toUByte() -> AuthenticatorGetNextAssertionRequest()
             else -> throw IllegalArgumentException(
                 String.format(
                     "unknown command type 0x%x is provided.",

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
@@ -5,7 +5,7 @@ data class CtapCommand(val value: Byte) {
     companion object {
         val MAKE_CREDENTIAL = CtapCommand(0x01)
         val GET_ASSERTION = CtapCommand(0x02)
-        val GET_NEXT_ASSERTION = CtapCommand(0x03)
+        val GET_NEXT_ASSERTION = CtapCommand(0x08)
         val GET_INFO = CtapCommand(0x04)
         val CLIENT_PIN = CtapCommand(0x06)
         val RESET = CtapCommand(0x07)


### PR DESCRIPTION
The CTAP specification defines authenticatorGetNextAssertion as command code 0x08, not 0x03. The incorrect value in `CtapCommand.GET_NEXT_ASSERTION` had no runtime impact because `CtapRequestConverter` deserialized using a hardcoded 0x08 and in-process communication dispatched by Kotlin type, but it would cause wrong bytes on the wire if `convertToBytes` were ever called for this command.

Also replaces all hardcoded command code literals in `CtapRequestConverter` with `CtapCommand` constant references to prevent similar divergence.