### PR TITLE
Make CtapAuthenticator properties immutable and add copy()

### DIFF
--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/UniFIDOKeyUSBIP.kt
@@ -35,10 +35,9 @@ class UniFIDOKeyUSBIP : Runnable {
                 makeCredentialConsentHandler = consentHandler,
                 getAssertionConsentHandler = consentHandler,
                 selectionHandler = consentHandler,
-                transports = setOf(AuthenticatorTransport.USB)
-            ).apply {
-                credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
-            }
+                transports = setOf(AuthenticatorTransport.USB),
+                credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM,
+            )
         }
     }
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -33,15 +33,13 @@ import org.slf4j.LoggerFactory
 
 class CtapAuthenticator(
     val objectConverter: ObjectConverter = createObjectConverter(),
-    // Core logic delegates
-    // These are final as it should not be updated on the fly for integrity. To update these, new instance should be created.
-    var attestationStatementProvider: AttestationStatementProvider = NoneAttestationStatementProvider(),
-    var fidoU2FBasicAttestationStatementGenerator: FIDOU2FAttestationStatementProvider = FIDOU2FBasicAttestationStatementProvider.createWithDemoAttestationKey(),
+    val attestationStatementProvider: AttestationStatementProvider = NoneAttestationStatementProvider(),
+    val fidoU2FBasicAttestationStatementGenerator: FIDOU2FAttestationStatementProvider = FIDOU2FBasicAttestationStatementProvider.createWithDemoAttestationKey(),
     transports: Set<AuthenticatorTransport> = setOf(),
     pinProtocols: Set<PinProtocolVersion> = setOf(PinProtocolVersion.VERSION_2, PinProtocolVersion.VERSION_1),
     val extensionProcessors: List<ExtensionProcessor> = listOf(CredProtectExtensionProcessor()),
+    val authenticatorPropertyStore: AuthenticatorPropertyStore = InMemoryAuthenticatorPropertyStore(),
     // Handlers
-    var authenticatorPropertyStore: AuthenticatorPropertyStore = InMemoryAuthenticatorPropertyStore(),
     val userVerificationCapabilityProvider: UserVerificationCapabilityProvider = object : UserVerificationCapabilityProvider {
         override fun getUserVerificationOption(rpId: String?): UserVerificationOption = UserVerificationOption.READY
     },
@@ -54,8 +52,22 @@ class CtapAuthenticator(
     val selectionHandler: AuthenticatorSelectionHandler = object : AuthenticatorSelectionHandler {
         override suspend fun onSelectionRequested(): Boolean = true
     },
-    var credentialSelectionHandler: CredentialSelectionHandler = DefaultCredentialSelectionHandler(),
-    var winkHandler: WinkHandler = NoopWinkHandler()
+    val credentialSelectionHandler: CredentialSelectionHandler = DefaultCredentialSelectionHandler(),
+    val winkHandler: WinkHandler = NoopWinkHandler(),
+    // Settings
+    val aaguid: AAGUID = AAGUID,
+    val platform: AttachmentSetting = AttachmentSetting.CROSS_PLATFORM,
+    val residentKey: ResidentKeySetting = ResidentKeySetting.ALWAYS,
+    val clientPIN: ClientPINSetting = ClientPINSetting.ENABLED,
+    val resetProtection: ResetProtectionSetting = ResetProtectionSetting.DISABLED,
+    val userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED,
+    val userVerification: UserVerificationSetting = UserVerificationSetting.READY,
+    val alwaysUv: AlwaysUvSetting = AlwaysUvSetting.DISABLED,
+    val makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.UV_NOT_REQUIRED,
+    val credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.AUTHENTICATOR,
+    // Observers
+    eventListeners: List<EventListener> = emptyList(),
+    exceptionReporters: List<ExceptionReporter> = emptyList(),
 ) {
 
     companion object{
@@ -95,20 +107,8 @@ class CtapAuthenticator(
 
     val transports: MutableSet<AuthenticatorTransport> = transports.toMutableSet()
     val pinProtocols: Set<PinProtocolVersion> = pinProtocols
-    internal val eventListeners: MutableList<EventListener> = mutableListOf()
-    internal val exceptionReporters: MutableList<ExceptionReporter> = mutableListOf()
-
-    var aaguid: AAGUID = AAGUID
-
-    var platform: AttachmentSetting = AttachmentSetting.CROSS_PLATFORM
-    var residentKey: ResidentKeySetting = ResidentKeySetting.ALWAYS
-    var clientPIN: ClientPINSetting = ClientPINSetting.ENABLED
-    var resetProtection: ResetProtectionSetting = ResetProtectionSetting.DISABLED
-    var userPresence: UserPresenceSetting = UserPresenceSetting.SUPPORTED
-    var userVerification: UserVerificationSetting = UserVerificationSetting.READY
-    var alwaysUv: AlwaysUvSetting = AlwaysUvSetting.DISABLED
-    var makeCredUvNotRqd: MakeCredUvNotRqdSetting = MakeCredUvNotRqdSetting.UV_NOT_REQUIRED
-    var credentialSelector: CredentialSelectorSetting = CredentialSelectorSetting.AUTHENTICATOR
+    internal val eventListeners: MutableList<EventListener> = eventListeners.toMutableList()
+    internal val exceptionReporters: MutableList<ExceptionReporter> = exceptionReporters.toMutableList()
 
     fun createSession(
         userVerificationCapabilityProvider: UserVerificationCapabilityProvider = this.userVerificationCapabilityProvider,
@@ -118,6 +118,60 @@ class CtapAuthenticator(
     ) : CtapAuthenticatorSession{
         return CtapAuthenticatorSession(this, userVerificationCapabilityProvider, makeCredentialConsentHandler, getAssertionConsentHandler, selectionHandler)
     }
+
+    fun copy(
+        objectConverter: ObjectConverter = this.objectConverter,
+        attestationStatementProvider: AttestationStatementProvider = this.attestationStatementProvider,
+        fidoU2FBasicAttestationStatementGenerator: FIDOU2FAttestationStatementProvider = this.fidoU2FBasicAttestationStatementGenerator,
+        transports: Set<AuthenticatorTransport> = this.transports,
+        pinProtocols: Set<PinProtocolVersion> = this.pinProtocols,
+        extensionProcessors: List<ExtensionProcessor> = this.extensionProcessors,
+        authenticatorPropertyStore: AuthenticatorPropertyStore = this.authenticatorPropertyStore,
+        userVerificationCapabilityProvider: UserVerificationCapabilityProvider = this.userVerificationCapabilityProvider,
+        makeCredentialConsentHandler: MakeCredentialConsentHandler = this.makeCredentialConsentHandler,
+        getAssertionConsentHandler: GetAssertionConsentHandler = this.getAssertionConsentHandler,
+        selectionHandler: AuthenticatorSelectionHandler = this.selectionHandler,
+        credentialSelectionHandler: CredentialSelectionHandler = this.credentialSelectionHandler,
+        winkHandler: WinkHandler = this.winkHandler,
+        aaguid: AAGUID = this.aaguid,
+        platform: AttachmentSetting = this.platform,
+        residentKey: ResidentKeySetting = this.residentKey,
+        clientPIN: ClientPINSetting = this.clientPIN,
+        resetProtection: ResetProtectionSetting = this.resetProtection,
+        userPresence: UserPresenceSetting = this.userPresence,
+        userVerification: UserVerificationSetting = this.userVerification,
+        alwaysUv: AlwaysUvSetting = this.alwaysUv,
+        makeCredUvNotRqd: MakeCredUvNotRqdSetting = this.makeCredUvNotRqd,
+        credentialSelector: CredentialSelectorSetting = this.credentialSelector,
+        eventListeners: List<EventListener> = this.eventListeners,
+        exceptionReporters: List<ExceptionReporter> = this.exceptionReporters,
+    ): CtapAuthenticator = CtapAuthenticator(
+        objectConverter = objectConverter,
+        attestationStatementProvider = attestationStatementProvider,
+        fidoU2FBasicAttestationStatementGenerator = fidoU2FBasicAttestationStatementGenerator,
+        transports = transports,
+        pinProtocols = pinProtocols,
+        extensionProcessors = extensionProcessors,
+        authenticatorPropertyStore = authenticatorPropertyStore,
+        userVerificationCapabilityProvider = userVerificationCapabilityProvider,
+        makeCredentialConsentHandler = makeCredentialConsentHandler,
+        getAssertionConsentHandler = getAssertionConsentHandler,
+        selectionHandler = selectionHandler,
+        credentialSelectionHandler = credentialSelectionHandler,
+        winkHandler = winkHandler,
+        aaguid = aaguid,
+        platform = platform,
+        residentKey = residentKey,
+        clientPIN = clientPIN,
+        resetProtection = resetProtection,
+        userPresence = userPresence,
+        userVerification = userVerification,
+        alwaysUv = alwaysUv,
+        makeCredUvNotRqd = makeCredUvNotRqd,
+        credentialSelector = credentialSelector,
+        eventListeners = eventListeners,
+        exceptionReporters = exceptionReporters,
+    )
 
     fun registerEventListener(eventListener: EventListener) {
         eventListeners.add(eventListener)

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
@@ -207,8 +207,7 @@ internal class GetAssertionExecutionTest {
         val setupConnection = ctapAuthenticator.createSession()
         makeCredential(setupConnection)
 
-        ctapAuthenticator.userPresence = userPresenceSetting
-        val connection = ctapAuthenticator.createSession()
+        val connection = ctapAuthenticator.copy(userPresence = userPresenceSetting).createSession()
 
         val clientDataHash = ByteArray(0)
         val allowList: List<PublicKeyCredentialDescriptor> = emptyList()
@@ -254,8 +253,7 @@ internal class GetAssertionExecutionTest {
         val setupConnection = ctapAuthenticator.createSession()
         makeCredential(setupConnection)
 
-        ctapAuthenticator.userVerification = userVerificationSetting
-        val connection = ctapAuthenticator.createSession()
+        val connection = ctapAuthenticator.copy(userVerification = userVerificationSetting).createSession()
 
         val clientDataHash = ByteArray(0)
         val allowList: List<PublicKeyCredentialDescriptor> = emptyList()

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
@@ -38,8 +38,7 @@ class GetNextAssertionExecutionTest {
 
     @Test
     suspend fun getNextAssertion_test() {
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
+        val ctapAuthenticator = CtapAuthenticator(credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM)
         val connection = ctapAuthenticator.createSession()
         makeCredential(connection, userId = byteArrayOf(0x01))
         makeCredential(connection, userId = byteArrayOf(0x02))
@@ -68,8 +67,7 @@ class GetNextAssertionExecutionTest {
 
     @Test
     suspend fun getNextAssertion_when_no_session_exist_test() {
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
+        val ctapAuthenticator = CtapAuthenticator(credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM)
         val connection = ctapAuthenticator.createSession()
         makeCredential(connection)
 
@@ -79,8 +77,7 @@ class GetNextAssertionExecutionTest {
 
     @Test
     suspend fun getNextAssertion_when_next_credential_does_not_exist_test() {
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
+        val ctapAuthenticator = CtapAuthenticator(credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM)
         val connection = ctapAuthenticator.createSession()
         makeCredential(connection, userId = byteArrayOf(0x01))
         makeCredential(connection, userId = byteArrayOf(0x02))
@@ -111,8 +108,7 @@ class GetNextAssertionExecutionTest {
     @Disabled("Mockito.mockStatic doesn't work with JDK 21")
     @Test
     suspend fun expiration_test() {
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM
+        val ctapAuthenticator = CtapAuthenticator(credentialSelector = CredentialSelectorSetting.CLIENT_PLATFORM)
         val connection = ctapAuthenticator.createSession()
         makeCredential(connection, userId = byteArrayOf(0x01))
         makeCredential(connection, userId = byteArrayOf(0x02))

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
@@ -75,15 +75,16 @@ internal class MakeCredentialExecutionTest {
 
     @Test
     suspend fun store_full_test() {
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.authenticatorPropertyStore = spy<InMemoryAuthenticatorPropertyStore> {
-            onGeneric {
-                createUserCredentialKey(
-                    any(),
-                    any()
-                )
-            } doThrow StoreFullException("AuthenticatorPropertyStore is full")
-        }
+        val ctapAuthenticator = CtapAuthenticator(
+            authenticatorPropertyStore = spy<InMemoryAuthenticatorPropertyStore> {
+                onGeneric {
+                    createUserCredentialKey(
+                        any(),
+                        any()
+                    )
+                } doThrow StoreFullException("AuthenticatorPropertyStore is full")
+            }
+        )
         val connection = ctapAuthenticator.createSession()
 
         val clientDataHash = ByteArray(0)
@@ -155,9 +156,10 @@ internal class MakeCredentialExecutionTest {
             pinUvAuthProtocol
         )
 
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.residentKey = residentKeySetting
-        ctapAuthenticator.makeCredUvNotRqd = MakeCredUvNotRqdSetting.UV_NOT_REQUIRED
+        val ctapAuthenticator = CtapAuthenticator(
+            residentKey = residentKeySetting,
+            makeCredUvNotRqd = MakeCredUvNotRqdSetting.UV_NOT_REQUIRED,
+        )
         val connection = ctapAuthenticator.createSession()
 
         val response = connection.makeCredential(command)
@@ -212,8 +214,7 @@ internal class MakeCredentialExecutionTest {
             pinUvAuthProtocol
         )
 
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.residentKey = residentKeySetting
+        val ctapAuthenticator = CtapAuthenticator(residentKey = residentKeySetting)
         val connection = ctapAuthenticator.createSession()
 
         val response = connection.makeCredential(command)
@@ -267,8 +268,7 @@ internal class MakeCredentialExecutionTest {
             pinUvAuthProtocol
         )
 
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.userVerification = userVerificationSetting
+        val ctapAuthenticator = CtapAuthenticator(userVerification = userVerificationSetting)
         val connection = ctapAuthenticator.createSession()
 
 
@@ -312,10 +312,11 @@ internal class MakeCredentialExecutionTest {
             pinUvAuthProtocol
         )
 
-        val ctapAuthenticator = CtapAuthenticator()
-        ctapAuthenticator.userPresence = userPresenceSetting
-        ctapAuthenticator.userVerification = UserVerificationSetting.NOT_SUPPORTED
-        ctapAuthenticator.clientPIN = ClientPINSetting.DISABLED
+        val ctapAuthenticator = CtapAuthenticator(
+            userPresence = userPresenceSetting,
+            userVerification = UserVerificationSetting.NOT_SUPPORTED,
+            clientPIN = ClientPINSetting.DISABLED,
+        )
         val connection = ctapAuthenticator.createSession()
 
         val response = connection.makeCredential(command)

--- a/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
+++ b/webauthn4j-ctap-core/src/test/kotlin/integration/usecase/testcase/IntegrationTestCaseBase.kt
@@ -97,7 +97,7 @@ abstract class IntegrationTestCaseBase {
                 }
             }.depends(clientPINParameter, algorithmsParameter)
         internal val ctapAuthenticatorParameter = TestParameter {
-            val ctapAuthenticator = CtapAuthenticator(
+            return@TestParameter CtapAuthenticator(
                 objectConverter = objectConverter,
                 attestationStatementProvider = attestationStatementGenerator,
                 fidoU2FBasicAttestationStatementGenerator = fidoU2FAttestationStatementGenerator,
@@ -109,20 +109,17 @@ abstract class IntegrationTestCaseBase {
                         return userVerificationSetting.toUserVerificationOption()
                     }
                 },
-                credentialSelectionHandler = credentialSelectionHandler
+                credentialSelectionHandler = credentialSelectionHandler,
+                aaguid = aaguid,
+                platform = platformSetting,
+                residentKey = residentKeySetting,
+                clientPIN = clientPINSetting,
+                resetProtection = resetProtectionSetting,
+                userPresence = userPresenceSetting,
+                userVerification = userVerificationSetting,
+                makeCredUvNotRqd = makeCredUvNotRqdSetting,
+                credentialSelector = credentialSelectorSetting,
             )
-            ctapAuthenticator.aaguid = aaguid
-            ctapAuthenticator.platform = platformSetting
-            ctapAuthenticator.platform = platformSetting
-            ctapAuthenticator.residentKey = residentKeySetting
-            ctapAuthenticator.clientPIN = clientPINSetting
-            ctapAuthenticator.resetProtection = resetProtectionSetting
-            ctapAuthenticator.userPresence = userPresenceSetting
-            ctapAuthenticator.userVerification = userVerificationSetting
-            ctapAuthenticator.makeCredUvNotRqd = makeCredUvNotRqdSetting
-            ctapAuthenticator.credentialSelector = credentialSelectorSetting
-
-            return@TestParameter ctapAuthenticator
         }.depends(
             attestationStatementGeneratorParameter,
             fidoU2FAttestationStatementGeneratorParameter,


### PR DESCRIPTION
- Convert all `var` properties on `CtapAuthenticator` to `val` constructor parameters
- Move 10 body `var` properties (`aaguid`, `platform`, `residentKey`, `clientPIN`, `resetProtection`, `userPresence`, `userVerification`, `alwaysUv`, `makeCredUvNotRqd`, `credentialSelector`) to constructor parameters
- Change existing constructor `var` parameters (`attestationStatementProvider`, `fidoU2FBasicAttestationStatementGenerator`, `authenticatorPropertyStore`, `credentialSelectionHandler`, `winkHandler`) to `val`
- Add `eventListeners` and `exceptionReporters` as constructor parameters (defaulting to empty lists)
- Add `copy()` method for creating modified instances, following the same pattern as Kotlin data class `copy()`
- Update all test code and `UniFIDOKeyUSBIP` to use constructor parameters instead of post-construction mutation