### PR TITLE
Use ECUtil.createKeyPair(ECParameterSpec) instead of seed-based overload

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/internal/KeyPairUtil.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/internal/KeyPairUtil.kt
@@ -9,9 +9,9 @@ object KeyPairUtil {
     @JvmStatic
     fun createCredentialKeyPair(alg: COSEAlgorithmIdentifier): KeyPair {
         return when (alg) {
-            COSEAlgorithmIdentifier.ES256 -> ECUtil.createKeyPair(null, ECUtil.P_256_SPEC)
-            COSEAlgorithmIdentifier.ES384 -> ECUtil.createKeyPair(null, ECUtil.P_384_SPEC)
-            COSEAlgorithmIdentifier.ES512 -> ECUtil.createKeyPair(null, ECUtil.P_521_SPEC)
+            COSEAlgorithmIdentifier.ES256 -> ECUtil.createKeyPair(ECUtil.P_256_SPEC)
+            COSEAlgorithmIdentifier.ES384 -> ECUtil.createKeyPair(ECUtil.P_384_SPEC)
+            COSEAlgorithmIdentifier.ES512 -> ECUtil.createKeyPair(ECUtil.P_521_SPEC)
             COSEAlgorithmIdentifier.RS1, COSEAlgorithmIdentifier.RS256, COSEAlgorithmIdentifier.RS384, COSEAlgorithmIdentifier.RS512 -> RSAUtil.createKeyPair()
             else -> throw IllegalArgumentException("algorithmIdentifier is not valid.")
         }


### PR DESCRIPTION
The seed-based `createKeyPair(byte[], ECParameterSpec)` is being removed from webauthn4j because it depends on the SUN provider-specific `SHA1PRNG`. Switch to `createKeyPair(ECParameterSpec)` which has identical behavior when seed is null.