### PR TITLE
Fix PackedSelfAttestationStatementProvider to produce x5c=null

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedAttestationStatementProviderBase.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedAttestationStatementProviderBase.kt
@@ -35,6 +35,6 @@ abstract class PackedAttestationStatementProviderBase(
     }
 
     protected abstract fun sign(credentialKey: KeyPair, toBeSigned: ByteArray): ByteArray
-    protected abstract fun createAttestationCertificatePath(attestationStatementRequest: AttestationStatementRequest): AttestationCertificatePath
+    protected abstract fun createAttestationCertificatePath(attestationStatementRequest: AttestationStatementRequest): AttestationCertificatePath?
 
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedSelfAttestationStatementProvider.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/attestation/PackedSelfAttestationStatementProvider.kt
@@ -7,7 +7,6 @@ import com.webauthn4j.data.attestation.statement.AttestationCertificatePath
 import java.security.KeyPair
 
 class PackedSelfAttestationStatementProvider(
-    private val subjectDN: String,
     objectConverter: ObjectConverter
 ) : PackedAttestationStatementProviderBase(objectConverter) {
 
@@ -19,16 +18,7 @@ class PackedSelfAttestationStatementProvider(
         )
     }
 
-    override fun createAttestationCertificatePath(attestationStatementRequest: AttestationStatementRequest): AttestationCertificatePath {
-        val x509Certificate = AttestationCertificateBuilder(
-            subjectDN,
-            attestationStatementRequest.credentialKey.keyPair!!.public,
-            subjectDN,
-            attestationStatementRequest.credentialKey.keyPair!!.private,
-            SignatureAlgorithm.ES256
-        )
-            .aaguid(attestationStatementRequest.authenticatorData.attestedCredentialData!!.aaguid)
-            .build()
-        return AttestationCertificatePath(x509Certificate, emptyList())
+    override fun createAttestationCertificatePath(attestationStatementRequest: AttestationStatementRequest): AttestationCertificatePath? {
+        return null
     }
 }


### PR DESCRIPTION
PackedSelfAttestationStatementProvider incorrectly included a self-signed certificate in x5c, causing webauthn4j-core's PackedAttestationStatementVerifier to classify it as basic attestation instead of self attestation. Per the WebAuthn spec, self attestation means x5c=null with the signature made using the credential key.