### PR TITLE
Fix FIDO conformance test failures and upgrade webauthn4j

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktor = "3.5.2"
 
 quarkus = "3.38.1"
 
-webauthn4j = "0.31.8.RELEASE"
+webauthn4j = "0.31.9.RELEASE"
 
 slf4j = "2.0.18"
 
@@ -44,9 +44,9 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
 
 # WebAuthn4J
-webauthn4j-core = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
-webauthn4j-metadata = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
-webauthn4j-test = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
+webauthn4j-core = { module = "com.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
+webauthn4j-metadata = { module = "com.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
+webauthn4j-test = { module = "com.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
 
 # Third-party libraries
 

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
@@ -148,7 +148,7 @@ class GenerateMetadataStatement : Runnable {
                 getInfo.uvModality,
                 getInfo.certifications,
                 getInfo.remainingDiscoverableCredentials?.toInt(),
-                getInfo.vendorPrototypeConfigCommands?.map { it.toInt() },
+                getInfo.vendorPrototypeConfigCommands,
                 getInfo.attestationFormats,
                 getInfo.uvCountSinceLastPinEntry?.toInt(),
                 getInfo.longTouchForReset,
@@ -158,7 +158,7 @@ class GenerateMetadataStatement : Runnable {
                 getInfo.pinComplexityPolicyURL,
                 getInfo.maxPINLength?.toInt(),
                 getInfo.encCredStoreState,
-                getInfo.authenticatorConfigCommands?.map { it.toInt() }
+                getInfo.authenticatorConfigCommands
             )
         }
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticator.kt
@@ -21,6 +21,7 @@ import com.webauthn4j.ctap.authenticator.data.settings.UserPresenceSetting
 import com.webauthn4j.ctap.authenticator.data.settings.UserVerificationSetting
 import com.webauthn4j.ctap.authenticator.extension.CredProtectExtensionProcessor
 import com.webauthn4j.ctap.authenticator.extension.ExtensionProcessor
+import com.webauthn4j.ctap.authenticator.extension.HMACSecretExtensionProcessor
 import com.webauthn4j.ctap.authenticator.store.AuthenticatorPropertyStore
 import com.webauthn4j.ctap.authenticator.store.InMemoryAuthenticatorPropertyStore
 import com.webauthn4j.ctap.core.converter.jackson.CtapCBORModule
@@ -37,7 +38,7 @@ class CtapAuthenticator(
     val fidoU2FBasicAttestationStatementGenerator: FIDOU2FAttestationStatementProvider = FIDOU2FBasicAttestationStatementProvider.createWithDemoAttestationKey(),
     transports: Set<AuthenticatorTransport> = setOf(),
     pinProtocols: Set<PinProtocolVersion> = setOf(PinProtocolVersion.VERSION_2, PinProtocolVersion.VERSION_1),
-    val extensionProcessors: List<ExtensionProcessor> = listOf(CredProtectExtensionProcessor()),
+    val extensionProcessors: List<ExtensionProcessor> = listOf(CredProtectExtensionProcessor(), HMACSecretExtensionProcessor()),
     val authenticatorPropertyStore: AuthenticatorPropertyStore = InMemoryAuthenticatorPropertyStore(),
     // Handlers
     val userVerificationCapabilityProvider: UserVerificationCapabilityProvider = object : UserVerificationCapabilityProvider {

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
@@ -18,6 +18,8 @@ import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorMakeCr
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorMakeCredentialResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorResetRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorResetResponseDataSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorSelectionRequestSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorSelectionResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.PinUvAuthTokenPermissionsSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialRpEntitySerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialUserEntitySerializer
@@ -33,6 +35,8 @@ import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorResetRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorResetResponseData
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponseData
 import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialRpEntity
 import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialUserEntity
 import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
@@ -98,6 +102,14 @@ class CtapCBORModule : SimpleModule("CtapCBORModule") {
         this.addSerializer(
             AuthenticatorResetResponseData::class.java,
             AuthenticatorResetResponseDataSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorSelectionRequest::class.java,
+            AuthenticatorSelectionRequestSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorSelectionResponseData::class.java,
+            AuthenticatorSelectionResponseDataSerializer()
         )
         this.addSerializer(
             CtapPublicKeyCredentialRpEntity::class.java,

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorClientPINResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorClientPINResponseDataSerializer.kt
@@ -7,6 +7,8 @@ class AuthenticatorClientPINResponseDataSerializer :
         AuthenticatorClientPINResponseData::class.java, listOf(
             FieldSerializationRule(1, AuthenticatorClientPINResponseData::keyAgreement),
             FieldSerializationRule(2, AuthenticatorClientPINResponseData::pinToken),
-            FieldSerializationRule(3, AuthenticatorClientPINResponseData::retries)
+            FieldSerializationRule(3, AuthenticatorClientPINResponseData::retries),
+            FieldSerializationRule(4, AuthenticatorClientPINResponseData::powerCycleState),
+            FieldSerializationRule(5, AuthenticatorClientPINResponseData::uvRetries)
         )
     )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetAssertionResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetAssertionResponseDataSerializer.kt
@@ -9,6 +9,7 @@ class AuthenticatorGetAssertionResponseDataSerializer :
             FieldSerializationRule(2, AuthenticatorGetAssertionResponseData::authData),
             FieldSerializationRule(3, AuthenticatorGetAssertionResponseData::signature),
             FieldSerializationRule(4, AuthenticatorGetAssertionResponseData::user),
-            FieldSerializationRule(5, AuthenticatorGetAssertionResponseData::numberOfCredentials)
+            FieldSerializationRule(5, AuthenticatorGetAssertionResponseData::numberOfCredentials),
+            FieldSerializationRule(6, AuthenticatorGetAssertionResponseData::userSelected)
         )
     )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionRequestSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionRequestSerializer.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionRequest
+
+class AuthenticatorSelectionRequestSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorSelectionRequest>(
+        AuthenticatorSelectionRequest::class.java,
+        emptyList()
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionResponseDataSerializer.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponseData
+
+class AuthenticatorSelectionResponseDataSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorSelectionResponseData>(
+        AuthenticatorSelectionResponseData::class.java,
+        emptyList()
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorGetInfoResponseData.kt
@@ -4,9 +4,12 @@ import com.webauthn4j.data.PinProtocolVersion
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.webauthn4j.ctap.core.data.options.*
+import com.webauthn4j.data.AuthenticatorConfigSubCommand
 import com.webauthn4j.data.AuthenticatorTransport
+import com.webauthn4j.data.CertificationType
 import com.webauthn4j.data.PublicKeyCredentialParameters
 import com.webauthn4j.data.UserVerificationMethod
+import com.webauthn4j.data.VendorCommandId
 import com.webauthn4j.data.attestation.authenticator.AAGUID
 
 // §6.4 authenticatorGetInfo (0x04)
@@ -37,7 +40,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
             @JsonProperty("18") uvModality: Set<UserVerificationMethod>?,
             @JsonProperty("19") certifications: Map<String, Any>?,
             @JsonProperty("20") remainingDiscoverableCredentials: Long?,
-            @JsonProperty("21") vendorPrototypeConfigCommands: List<Long>?,
+            @JsonProperty("21") vendorPrototypeConfigCommands: List<Number>?,
             @JsonProperty("22") attestationFormats: List<String>?,
             @JsonProperty("23") uvCountSinceLastPinEntry: Long?,
             @JsonProperty("24") longTouchForReset: Boolean?,
@@ -47,7 +50,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
             @JsonProperty("28") pinComplexityPolicyURL: String?,
             @JsonProperty("29") maxPINLength: Long?,
             @JsonProperty("30") encCredStoreState: String?,
-            @JsonProperty("31") authenticatorConfigCommands: List<Long>?
+            @JsonProperty("31") authenticatorConfigCommands: List<Number>?
         ): AuthenticatorGetInfoResponseData {
             return AuthenticatorGetInfoResponseData(
                 versions,
@@ -68,9 +71,9 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
                 maxRPIDsForSetMinPINLength?.toUInt(),
                 preferredPlatformUvAttempts?.toUInt(),
                 uvModality,
-                certifications,
+                certifications?.mapKeys { (k, _) -> CertificationType.create(k) }?.mapValues { (_, v) -> (v as Number).toInt() },
                 remainingDiscoverableCredentials?.toUInt(),
-                vendorPrototypeConfigCommands?.map { it.toUInt() },
+                vendorPrototypeConfigCommands?.map { VendorCommandId(it.toLong()) },
                 attestationFormats,
                 uvCountSinceLastPinEntry?.toUInt(),
                 longTouchForReset,
@@ -80,7 +83,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
                 pinComplexityPolicyURL,
                 maxPINLength?.toUInt(),
                 encCredStoreState,
-                authenticatorConfigCommands?.map { it.toUInt() }
+                authenticatorConfigCommands?.map { AuthenticatorConfigSubCommand.create(it.toInt()) }
             )
         }
     }
@@ -122,11 +125,11 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
     // §6.4 uvModality (0x12): Optional
     val uvModality: Set<UserVerificationMethod>?
     // §6.4 certifications (0x13): Optional
-    val certifications: Map<String, Any>?
+    val certifications: Map<CertificationType, Int>?
     // §6.4 remainingDiscoverableCredentials (0x14): Optional
     val remainingDiscoverableCredentials: UInt?
     // §6.4 vendorPrototypeConfigCommands (0x15): Optional
-    val vendorPrototypeConfigCommands: List<UInt>?
+    val vendorPrototypeConfigCommands: List<VendorCommandId>?
     // §6.4 attestationFormats (0x16): Optional
     val attestationFormats: List<String>?
     // §6.4 uvCountSinceLastPinEntry (0x17): Optional
@@ -146,7 +149,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
     // §6.4 encCredStoreState (0x1E): Optional
     val encCredStoreState: String?
     // §6.4 authenticatorConfigCommands (0x1F): Optional
-    val authenticatorConfigCommands: List<UInt>?
+    val authenticatorConfigCommands: List<AuthenticatorConfigSubCommand>?
 
     constructor(
         versions: List<CtapVersion>,
@@ -167,9 +170,9 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
         maxRPIDsForSetMinPINLength: UInt? = null,
         preferredPlatformUvAttempts: UInt? = null,
         uvModality: Set<UserVerificationMethod>? = null,
-        certifications: Map<String, Any>? = null,
+        certifications: Map<CertificationType, Int>? = null,
         remainingDiscoverableCredentials: UInt? = null,
-        vendorPrototypeConfigCommands: List<UInt>? = null,
+        vendorPrototypeConfigCommands: List<VendorCommandId>? = null,
         attestationFormats: List<String>? = null,
         uvCountSinceLastPinEntry: UInt? = null,
         longTouchForReset: Boolean? = null,
@@ -179,7 +182,7 @@ class AuthenticatorGetInfoResponseData : CtapResponseData {
         pinComplexityPolicyURL: String? = null,
         maxPINLength: UInt? = null,
         encCredStoreState: String? = null,
-        authenticatorConfigCommands: List<UInt>? = null
+        authenticatorConfigCommands: List<AuthenticatorConfigSubCommand>? = null
     ) {
         this.versions = versions.toList()
         this.extensions = extensions?.toList()

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
@@ -10,7 +10,7 @@ data class CtapVersion(@get:JsonValue val versionString: String, val major: Int,
         val FIDO_2_0 = CtapVersion("FIDO_2_0", 1, 0)
         val FIDO_2_1_PRE = CtapVersion("FIDO_2_1_PRE", 1, 0)
         val FIDO_2_1 = CtapVersion("FIDO_2_1", 1, 1)
-        val FIDO_2_3 = CtapVersion("FIDO_2_3", 1, 2)
+        val FIDO_2_3 = CtapVersion("FIDO_2_3", 1, 3)
 
         @JvmStatic
         @JsonCreator


### PR DESCRIPTION
Upgrade webauthn4j to 0.31.9.RELEASE (Maven Central) and fix multiple issues found during FIDO conformance testing.

## Dependency upgrade

- Upgrade webauthn4j from 0.31.8.RELEASE to 0.31.9.RELEASE to pick up the CBOR canonical serializer for `PublicKeyCredentialParameters` (fixes non-canonical `BF...FF` indefinite-length maps)
- Migrate from JitPack (`com.github.webauthn4j.webauthn4j`) to Maven Central (`com.webauthn4j`) coordinates

## Conformance fixes

- Fix CTAP 2.3 UPV from `(1, 2)` to `(1, 3)` per FIDO Metadata Statement spec v3.1.1
- Add `HMACSecretExtensionProcessor` to default extension processors — the implementation existed but was not registered, so `hmac-secret` was missing from GetInfo extensions
- Add missing `powerCycleState` (key 4) and `uvRetries` (key 5) to `AuthenticatorClientPINResponseDataSerializer` — `getUVRetries` responses were missing the uvRetries field
- Add missing `userSelected` (key 6) to `AuthenticatorGetAssertionResponseDataSerializer`
- Add canonical CBOR serializers for `authenticatorSelection` request/response and register in `CtapCBORModule`

## Value type adoption

- Use webauthn4j-core 0.31.9 value types in `AuthenticatorGetInfoResponseData`: `CertificationType`, `VendorCommandId`, `AuthenticatorConfigSubCommand` — aligns with webauthn4j/webauthn4j#1471