### PR TITLE
Upgrade webauthn4j to 0.31.9.RELEASE and switch to Maven Central

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktor = "3.5.2"
 
 quarkus = "3.38.1"
 
-webauthn4j = "0.31.8.RELEASE"
+webauthn4j = "0.31.9.RELEASE"
 
 slf4j = "2.0.18"
 
@@ -44,9 +44,9 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 ktor-network = { group = "io.ktor", name = "ktor-network", version.ref = "ktor" }
 
 # WebAuthn4J
-webauthn4j-core = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
-webauthn4j-metadata = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
-webauthn4j-test = { module = "com.github.webauthn4j.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
+webauthn4j-core = { module = "com.webauthn4j:webauthn4j-core", version.ref = "webauthn4j" }
+webauthn4j-metadata = { module = "com.webauthn4j:webauthn4j-metadata", version.ref = "webauthn4j" }
+webauthn4j-test = { module = "com.webauthn4j:webauthn4j-test", version.ref = "webauthn4j" }
 
 # Third-party libraries
 

--- a/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
+++ b/unifidokey-usbip/src/main/kotlin/com/webauthn4j/unifidokey/usbip/GenerateMetadataStatement.kt
@@ -7,12 +7,15 @@ import com.webauthn4j.ctap.core.data.options.*
 import com.webauthn4j.data.AttachmentHint
 import com.webauthn4j.data.AuthenticationAlgorithm
 import com.webauthn4j.data.AuthenticatorAttestationType
+import com.webauthn4j.data.AuthenticatorConfigSubCommand
 import com.webauthn4j.data.AuthenticatorTransport
+import com.webauthn4j.data.CertificationType
 import com.webauthn4j.data.KeyProtectionType
 import com.webauthn4j.data.MatcherProtectionType
 import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.data.PublicKeyRepresentationFormat
 import com.webauthn4j.data.UserVerificationMethod
+import com.webauthn4j.data.VendorCommandId
 import com.webauthn4j.data.attestation.authenticator.AAGUID
 import com.webauthn4j.metadata.converter.jackson.WebAuthnMetadataJSONModule
 import com.webauthn4j.metadata.data.statement.AuthenticatorGetInfo
@@ -146,9 +149,9 @@ class GenerateMetadataStatement : Runnable {
                 getInfo.maxRPIDsForSetMinPINLength?.toInt(),
                 getInfo.preferredPlatformUvAttempts?.toInt(),
                 getInfo.uvModality,
-                getInfo.certifications,
+                getInfo.certifications?.mapKeys { (k, _) -> CertificationType.create(k) }?.mapValues { (_, v) -> (v as Number).toInt() },
                 getInfo.remainingDiscoverableCredentials?.toInt(),
-                getInfo.vendorPrototypeConfigCommands?.map { it.toInt() },
+                getInfo.vendorPrototypeConfigCommands?.map { VendorCommandId(it.toLong()) },
                 getInfo.attestationFormats,
                 getInfo.uvCountSinceLastPinEntry?.toInt(),
                 getInfo.longTouchForReset,
@@ -158,7 +161,7 @@ class GenerateMetadataStatement : Runnable {
                 getInfo.pinComplexityPolicyURL,
                 getInfo.maxPINLength?.toInt(),
                 getInfo.encCredStoreState,
-                getInfo.authenticatorConfigCommands?.map { it.toInt() }
+                getInfo.authenticatorConfigCommands?.map { AuthenticatorConfigSubCommand.create(it.toInt()) }
             )
         }
 


### PR DESCRIPTION
Upgrade from 0.31.8.RELEASE to 0.31.9.RELEASE to pick up the CBOR canonical serializer for PublicKeyCredentialParameters (fixes non-canonical indefinite-length maps). Also migrate from JitPack (com.github.webauthn4j.webauthn4j) to Maven Central (com.webauthn4j) coordinates.