### PR TITLE
Fix CTAP 2.3 UPV to (1, 3) per MDS v3.1.1

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapVersion.kt
@@ -10,7 +10,7 @@ data class CtapVersion(@get:JsonValue val versionString: String, val major: Int,
         val FIDO_2_0 = CtapVersion("FIDO_2_0", 1, 0)
         val FIDO_2_1_PRE = CtapVersion("FIDO_2_1_PRE", 1, 0)
         val FIDO_2_1 = CtapVersion("FIDO_2_1", 1, 1)
-        val FIDO_2_3 = CtapVersion("FIDO_2_3", 1, 2)
+        val FIDO_2_3 = CtapVersion("FIDO_2_3", 1, 3)
 
         @JvmStatic
         @JsonCreator


### PR DESCRIPTION
The FIDO Metadata Statement spec v3.1.1 defines CTAP 2.3 UPV as major=1, minor=3 (minor=2 is reserved for the skipped CTAP 2.2). The value was incorrectly set to minor=2.