### PR TITLE
Add missing fields to CBOR serializers

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorClientPINResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorClientPINResponseDataSerializer.kt
@@ -7,6 +7,8 @@ class AuthenticatorClientPINResponseDataSerializer :
         AuthenticatorClientPINResponseData::class.java, listOf(
             FieldSerializationRule(1, AuthenticatorClientPINResponseData::keyAgreement),
             FieldSerializationRule(2, AuthenticatorClientPINResponseData::pinToken),
-            FieldSerializationRule(3, AuthenticatorClientPINResponseData::retries)
+            FieldSerializationRule(3, AuthenticatorClientPINResponseData::retries),
+            FieldSerializationRule(4, AuthenticatorClientPINResponseData::powerCycleState),
+            FieldSerializationRule(5, AuthenticatorClientPINResponseData::uvRetries)
         )
     )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetAssertionResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorGetAssertionResponseDataSerializer.kt
@@ -9,6 +9,7 @@ class AuthenticatorGetAssertionResponseDataSerializer :
             FieldSerializationRule(2, AuthenticatorGetAssertionResponseData::authData),
             FieldSerializationRule(3, AuthenticatorGetAssertionResponseData::signature),
             FieldSerializationRule(4, AuthenticatorGetAssertionResponseData::user),
-            FieldSerializationRule(5, AuthenticatorGetAssertionResponseData::numberOfCredentials)
+            FieldSerializationRule(5, AuthenticatorGetAssertionResponseData::numberOfCredentials),
+            FieldSerializationRule(6, AuthenticatorGetAssertionResponseData::userSelected)
         )
     )


### PR DESCRIPTION
AuthenticatorClientPINResponseDataSerializer was missing powerCycleState (key 4) and uvRetries (key 5), causing getUVRetries responses to omit the uvRetries field during conformance testing.

AuthenticatorGetAssertionResponseDataSerializer was missing userSelected (key 6), which was added in a prior commit but not reflected in the serializer.