### PR TITLE
Add canonical CBOR serializers for authenticatorSelection

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
@@ -18,6 +18,8 @@ import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorMakeCr
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorMakeCredentialResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorResetRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorResetResponseDataSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorSelectionRequestSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorSelectionResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.PinUvAuthTokenPermissionsSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialRpEntitySerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialUserEntitySerializer
@@ -33,6 +35,8 @@ import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorResetRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorResetResponseData
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponseData
 import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialRpEntity
 import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialUserEntity
 import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
@@ -98,6 +102,14 @@ class CtapCBORModule : SimpleModule("CtapCBORModule") {
         this.addSerializer(
             AuthenticatorResetResponseData::class.java,
             AuthenticatorResetResponseDataSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorSelectionRequest::class.java,
+            AuthenticatorSelectionRequestSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorSelectionResponseData::class.java,
+            AuthenticatorSelectionResponseDataSerializer()
         )
         this.addSerializer(
             CtapPublicKeyCredentialRpEntity::class.java,

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionRequestSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionRequestSerializer.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionRequest
+
+class AuthenticatorSelectionRequestSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorSelectionRequest>(
+        AuthenticatorSelectionRequest::class.java,
+        emptyList()
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorSelectionResponseDataSerializer.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponseData
+
+class AuthenticatorSelectionResponseDataSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorSelectionResponseData>(
+        AuthenticatorSelectionResponseData::class.java,
+        emptyList()
+    )


### PR DESCRIPTION
Add AuthenticatorSelectionRequestSerializer and AuthenticatorSelectionResponseDataSerializer and register them in CtapCBORModule, following the same pattern as the Reset command. Without these, Jackson's default serialization could produce non-canonical CBOR.