### PR TITLE
Document why CtapPublicKeyCredential entity wrappers exist

### DIFF
--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialRpEntity.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialRpEntity.kt
@@ -7,11 +7,16 @@ import java.io.Serializable
 
 
 /**
- * [CtapPublicKeyCredentialRpEntity] is a CTAP variant of [PublicKeyCredentialRpEntity]
- * Not like [PublicKeyCredentialRpEntity], id is non-null, and name is nullable
+ * CTAP variant of [PublicKeyCredentialRpEntity] with non-null id and nullable name.
  *
- * @see [§5.4.2. Relying Party Parameters for Credential Generation](https://www.w3.org/TR/webauthn-1/.dictdef-publickeycredentialrpentity)
- * @see [§5.1. authenticatorMakeCredential (0x01)](https://fidoalliance.org/specs/fido2/fido-client-to-authenticator-protocol-v2.1-rd-20191217.html#authenticatorMakeCredential) */
+ * In CTAP, the RP ID is always present (non-null) in authenticatorMakeCredential requests
+ * and authenticatorCredentialManagement responses, whereas WebAuthn's PublicKeyCredentialRpEntity
+ * treats id as optional. Additionally, CTAP allows name to be nullable (e.g., in credential
+ * management RP enumeration responses where only the id is required).
+ *
+ * @see [§5.4.2. Relying Party Parameters for Credential Generation](https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialrpentity)
+ * @see [§6.1 authenticatorMakeCredential](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorMakeCredential)
+ */
 class CtapPublicKeyCredentialRpEntity : Serializable {
 
     // ~ Instance fields

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialUserEntity.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialUserEntity.kt
@@ -8,11 +8,17 @@ import com.webauthn4j.util.ArrayUtil
 import java.io.Serializable
 
 /**
- * [CtapPublicKeyCredentialUserEntity] is a CTAP variant of [PublicKeyCredentialUserEntity]
+ * CTAP variant of [PublicKeyCredentialUserEntity] with nullable name and displayName.
  *
- * @see [
- * §5.4.3. User Account Parameters for Credential Generation
-](https://www.w3.org/TR/webauthn-1/.dictdef-publickeycredentialuserentity) */
+ * WebAuthn Level 3 defines name and displayName as required in PublicKeyCredentialUserEntity,
+ * but CTAP 2.3 §6.2 requires that "User identifiable information (name, DisplayName, icon)
+ * MUST NOT be returned if user verification is not done by the authenticator." This means the
+ * authenticator must be able to omit these fields from the CBOR response, which requires them
+ * to be nullable — something the webauthn4j-core type does not allow.
+ *
+ * @see [§5.4.3. User Account Parameters for Credential Generation](https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialuserentity)
+ * @see [§6.2 authenticatorGetAssertion](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorGetAssertion)
+ */
 class CtapPublicKeyCredentialUserEntity : Serializable {
 
     /**


### PR DESCRIPTION
Add detailed KDoc to `CtapPublicKeyCredentialUserEntity` and `CtapPublicKeyCredentialRpEntity` explaining why these CTAP-specific wrappers are needed instead of the webauthn4j-core types:

- **UserEntity**: CTAP 2.3 §6.2 requires `name`/`displayName` to be omitted from the CBOR response when user verification is not done. WebAuthn Level 3 defines these as `required`, so the webauthn4j-core type cannot represent the nullable case.
- **RpEntity**: CTAP requires non-null `id` and allows nullable `name`, which differs from WebAuthn's `PublicKeyCredentialRpEntity`.

Also update spec reference URLs to current versions.