### PR TITLE
Implement authenticatorCredentialManagement (0x0A)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://jitpack.io")
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
     }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktor = "3.5.2"
 
 quarkus = "3.38.1"
 
-webauthn4j = "0.31.9.RELEASE"
+webauthn4j = "0.31.10-SNAPSHOT"
 
 slf4j = "2.0.18"
 

--- a/unifidokey-usbip/build.gradle.kts
+++ b/unifidokey-usbip/build.gradle.kts
@@ -8,7 +8,7 @@ description = "Sample application demonstrating CTAP USB-IP server"
 repositories {
     mavenLocal()
     mavenCentral()
-    maven(url = "https://jitpack.io")
+    maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
 }
 
 dependencies {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CredentialManagementSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CredentialManagementSession.kt
@@ -1,0 +1,62 @@
+package com.webauthn4j.ctap.authenticator
+
+import java.time.Instant
+
+// Holds the state for an ongoing credential management enumeration flow.
+// Used by both enumerateRPs and enumerateCredentials subcommands.
+// The session expires after 30 seconds of inactivity, matching the
+// CTAP2.3 specification timer requirements.
+class CredentialManagementSession<T>(private val items: List<T>) {
+
+    // Zero-based index into items
+    private var index = 0
+
+    // Timer for session expiration (30 seconds)
+    private var instant: Instant = Instant.now()
+
+    /**
+     * Total number of items in this enumeration session
+     */
+    val totalItems: Int get() = items.size
+
+    /**
+     * Return the current item at the current index
+     */
+    fun current(): T {
+        if (index >= items.size) {
+            throw NoSuchElementException()
+        }
+        return items[index]
+    }
+
+    /**
+     * Check whether there are more items after the current one
+     */
+    fun hasNext(): Boolean = index + 1 < items.size
+
+    /**
+     * Advance to the next item and return it. Resets the session timer.
+     */
+    fun next(): T {
+        if (!hasNext()) {
+            throw NoSuchElementException()
+        }
+        index++
+        resetTimer()
+        return items[index]
+    }
+
+    /**
+     * Check whether this session has expired (30 seconds since last access)
+     */
+    fun isExpired(): Boolean {
+        return Instant.now().epochSecond - instant.epochSecond >= 30
+    }
+
+    /**
+     * Reset the session timer to the current time
+     */
+    fun resetTimer() {
+        instant = Instant.now()
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -6,7 +6,9 @@ import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FAttestationStatement
 import com.webauthn4j.ctap.authenticator.data.event.Event
 import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.authenticator.data.settings.*
+import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.execution.ClientPINExecution
+import com.webauthn4j.ctap.authenticator.execution.CredentialManagementExecution
 import com.webauthn4j.ctap.authenticator.execution.GetAssertionExecution
 import com.webauthn4j.ctap.authenticator.execution.GetInfoExecution
 import com.webauthn4j.ctap.authenticator.execution.GetNextAssertionExecution
@@ -94,6 +96,8 @@ class CtapAuthenticatorSession internal constructor(
 
 
     var onGoingGetAssertionSession: GetAssertionSession? = null
+    var onGoingCredentialManagementRpSession: CredentialManagementSession<String>? = null
+    var onGoingCredentialManagementCredentialSession: CredentialManagementSession<ResidentUserCredential>? = null
 
     // The Job of the currently executing command, used by cancelOnGoingTransaction() to cancel it.
     // Set after mutex acquisition to avoid race conditions; cleared in finally.
@@ -123,6 +127,7 @@ class CtapAuthenticatorSession internal constructor(
             is AuthenticatorGetNextAssertionRequest -> getNextAssertion(request)
             is AuthenticatorGetInfoRequest -> getInfo(request)
             is AuthenticatorClientPINRequest -> clientPIN(request)
+            is AuthenticatorCredentialManagementRequest -> credentialManagement(request)
             is AuthenticatorResetRequest -> reset(request)
             is AuthenticatorSelectionRequest -> selection(request)
             is U2FRegistrationRequest -> u2fRegister(request)
@@ -160,6 +165,12 @@ class CtapAuthenticatorSession internal constructor(
     suspend fun clientPIN(authenticatorClientPINCommand: AuthenticatorClientPINRequest): AuthenticatorClientPINResponse {
         return withTransaction {
             ClientPINExecution(this, authenticatorClientPINCommand).execute()
+        }
+    }
+
+    suspend fun credentialManagement(authenticatorCredentialManagementRequest: AuthenticatorCredentialManagementRequest): AuthenticatorCredentialManagementResponse {
+        return withTransaction {
+            CredentialManagementExecution(this, authenticatorCredentialManagementRequest).execute()
         }
     }
 
@@ -216,6 +227,8 @@ class CtapAuthenticatorSession internal constructor(
         logger.debug("Cancel ongoing transaction requested")
         activeTransaction?.cancelAndJoin()
         onGoingGetAssertionSession = null
+        onGoingCredentialManagementRpSession = null
+        onGoingCredentialManagementCredentialSession = null
     }
 
     internal fun publishEvent(event: Event) {

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthManager.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthManager.kt
@@ -550,8 +550,7 @@ class PinUvAuthManager(
                     // Always authorized for PIN-based token issuance
                 }
                 PinUvAuthTokenPermission.CM -> {
-                    // TODO: check credMgmt option when authenticatorCredentialManagement is implemented
-                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                    // credMgmt is supported; CM permission is authorized
                 }
                 PinUvAuthTokenPermission.BE -> {
                     // TODO: check bioEnroll option when authenticatorBioEnrollment is implemented
@@ -619,7 +618,7 @@ class PinUvAuthManager(
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
 
         // TODO: Step 11: forcePINChange check (needed when authenticatorConfig setMinPINLength is implemented)
-        // TODO: Step 12: pcmr permission handling (needed when authenticatorCredentialManagement is implemented)
+        // TODO: Step 12: pcmr permission handling
 
         //spec| Step 13: Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
         //spec| pinUvAuthProtocols supported by this authenticator.
@@ -725,8 +724,7 @@ class PinUvAuthManager(
                     // Always authorized for UV-based token issuance
                 }
                 PinUvAuthTokenPermission.CM -> {
-                    // TODO: check credMgmt option when authenticatorCredentialManagement is implemented
-                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                    // credMgmt is supported; CM permission is authorized
                 }
                 PinUvAuthTokenPermission.BE -> {
                     // TODO: check uvBioEnroll option when authenticatorBioEnrollment is implemented
@@ -780,7 +778,7 @@ class PinUvAuthManager(
         // From the client's perspective, the result is identical — the credential is
         // created with the UV bit set, and UV is performed before any key operation.
 
-        // TODO: Step 11: pcmr permission handling (needed when authenticatorCredentialManagement is implemented)
+        // TODO: Step 11: pcmr permission handling
 
         //spec| Step 12: Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
         //spec| pinUvAuthProtocols supported by this authenticator.

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/CredentialManagementExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/CredentialManagementExecution.kt
@@ -1,0 +1,448 @@
+package com.webauthn4j.ctap.authenticator.execution
+
+import com.webauthn4j.ctap.authenticator.CredentialManagementSession
+import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.authenticator.PinUvAuthProtocol
+import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementResponse
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementResponseData
+import com.webauthn4j.ctap.core.data.CredentialManagementSubCommand
+import com.webauthn4j.ctap.core.data.CtapStatusCode
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialRpEntity
+import com.webauthn4j.data.PublicKeyCredentialType
+import com.webauthn4j.data.PublicKeyCredentialUserEntity
+import com.webauthn4j.data.attestation.authenticator.COSEKey
+import com.webauthn4j.data.attestation.authenticator.EC2COSEKey
+import com.webauthn4j.data.attestation.authenticator.RSACOSEKey
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.util.MessageDigestUtil
+import org.slf4j.LoggerFactory
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPublicKey
+
+/**
+ * authenticatorCredentialManagement (0x0A) command execution
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorCredentialManagement">CTAP 2.3 §6.8 authenticatorCredentialManagement</a>
+ */
+internal class CredentialManagementExecution(
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession,
+    private val request: AuthenticatorCredentialManagementRequest
+) : CtapCommandExecutionBase<AuthenticatorCredentialManagementRequest, AuthenticatorCredentialManagementResponse>(
+    ctapAuthenticatorSession,
+    request
+) {
+
+    private val logger = LoggerFactory.getLogger(CredentialManagementExecution::class.java)
+    override val commandName: String = "CredentialManagement"
+
+    override suspend fun validate() {
+        // Validation is done within each subcommand handler
+    }
+
+    override suspend fun doExecute(): AuthenticatorCredentialManagementResponse {
+        return when (request.subCommand) {
+            CredentialManagementSubCommand.GET_CREDS_METADATA -> {
+                logger.debug("Processing credentialManagement getCredsMetadata sub-command")
+                handleGetCredsMetadata()
+            }
+            CredentialManagementSubCommand.ENUMERATE_RPS_BEGIN -> {
+                logger.debug("Processing credentialManagement enumerateRPsBegin sub-command")
+                handleEnumerateRPsBegin()
+            }
+            CredentialManagementSubCommand.ENUMERATE_RPS_GET_NEXT_RP -> {
+                logger.debug("Processing credentialManagement enumerateRPsGetNextRP sub-command")
+                handleEnumerateRPsGetNextRP()
+            }
+            CredentialManagementSubCommand.ENUMERATE_CREDENTIALS_BEGIN -> {
+                logger.debug("Processing credentialManagement enumerateCredentialsBegin sub-command")
+                handleEnumerateCredentialsBegin()
+            }
+            CredentialManagementSubCommand.ENUMERATE_CREDENTIALS_GET_NEXT_CREDENTIAL -> {
+                logger.debug("Processing credentialManagement enumerateCredentialsGetNextCredential sub-command")
+                handleEnumerateCredentialsGetNextCredential()
+            }
+            CredentialManagementSubCommand.DELETE_CREDENTIAL -> {
+                logger.debug("Processing credentialManagement deleteCredential sub-command")
+                handleDeleteCredential()
+            }
+            CredentialManagementSubCommand.UPDATE_USER_INFORMATION -> {
+                logger.debug("Processing credentialManagement updateUserInformation sub-command")
+                handleUpdateUserInformation()
+            }
+        }
+    }
+
+    override fun createErrorResponse(statusCode: CtapStatusCode): AuthenticatorCredentialManagementResponse {
+        return AuthenticatorCredentialManagementResponse(statusCode)
+    }
+
+    // ========================================================================
+    // Subcommand: getCredsMetadata (0x01)
+    // ========================================================================
+
+    private fun handleGetCredsMetadata(): AuthenticatorCredentialManagementResponse {
+        // Verify pinUvAuthParam with message = subCommand byte only
+        val message = byteArrayOf(request.subCommand.value.toByte())
+        verifyPinUvAuthParam(message, requireNoPermissionsRpId = true)
+
+        val count = ctapAuthenticatorSession.authenticatorPropertyStore.countAllUserCredentials()
+        val responseData = AuthenticatorCredentialManagementResponseData(
+            existingResidentCredentialsCount = count.toUInt(),
+            maxPossibleRemainingResidentCredentialsCount = Int.MAX_VALUE.toUInt(),
+            rp = null,
+            rpIDHash = null,
+            totalRPs = null,
+            user = null,
+            credentialID = null,
+            publicKey = null,
+            totalCredentials = null,
+            credProtect = null
+        )
+        return AuthenticatorCredentialManagementResponse(CtapStatusCode.CTAP2_OK, responseData)
+    }
+
+    // ========================================================================
+    // Subcommand: enumerateRPsBegin (0x02)
+    // ========================================================================
+
+    private fun handleEnumerateRPsBegin(): AuthenticatorCredentialManagementResponse {
+        // Verify pinUvAuthParam with message = subCommand byte only
+        val message = byteArrayOf(request.subCommand.value.toByte())
+        verifyPinUvAuthParam(message, requireNoPermissionsRpId = true)
+
+        val rpIds = ctapAuthenticatorSession.authenticatorPropertyStore.loadAllRpIds().toList()
+        if (rpIds.isEmpty()) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
+        }
+
+        val session = CredentialManagementSession(rpIds)
+        ctapAuthenticatorSession.onGoingCredentialManagementRpSession = session
+
+        val rpId = session.current()
+        return buildRpResponse(rpId, session.totalItems.toUInt())
+    }
+
+    // ========================================================================
+    // Subcommand: enumerateRPsGetNextRP (0x03)
+    // ========================================================================
+
+    private fun handleEnumerateRPsGetNextRP(): AuthenticatorCredentialManagementResponse {
+        val session = ctapAuthenticatorSession.onGoingCredentialManagementRpSession
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+
+        if (session.isExpired()) {
+            ctapAuthenticatorSession.onGoingCredentialManagementRpSession = null
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+        }
+
+        if (!session.hasNext()) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+        }
+
+        val rpId = session.next()
+        // No totalRPs for subsequent responses
+        return buildRpResponse(rpId, null)
+    }
+
+    // ========================================================================
+    // Subcommand: enumerateCredentialsBegin (0x04)
+    // ========================================================================
+
+    private fun handleEnumerateCredentialsBegin(): AuthenticatorCredentialManagementResponse {
+        val subCommandParams = request.subCommandParams
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        val subCommandParamsBytes = ctapAuthenticatorSession.objectConverter.cborMapper
+            .writeValueAsBytes(subCommandParams)
+        val message = byteArrayOf(request.subCommand.value.toByte()) + subCommandParamsBytes
+        verifyPinUvAuthParam(message, requireNoPermissionsRpId = true)
+
+        val rpIDHash = subCommandParams.rpIDHash
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        // Find the RP ID by matching rpIDHash against all known RPs
+        val allRpIds = ctapAuthenticatorSession.authenticatorPropertyStore.loadAllRpIds()
+        val rpId = allRpIds.firstOrNull { id ->
+            MessageDigestUtil.createSHA256().digest(id.toByteArray()).contentEquals(rpIDHash)
+        } ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
+
+        val credentials = ctapAuthenticatorSession.authenticatorPropertyStore.loadUserCredentials(rpId)
+        if (credentials.isEmpty()) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
+        }
+
+        val session = CredentialManagementSession(credentials)
+        ctapAuthenticatorSession.onGoingCredentialManagementCredentialSession = session
+
+        val credential = session.current()
+        return buildCredentialResponse(credential, session.totalItems.toUInt())
+    }
+
+    // ========================================================================
+    // Subcommand: enumerateCredentialsGetNextCredential (0x05)
+    // ========================================================================
+
+    private fun handleEnumerateCredentialsGetNextCredential(): AuthenticatorCredentialManagementResponse {
+        val session = ctapAuthenticatorSession.onGoingCredentialManagementCredentialSession
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+
+        if (session.isExpired()) {
+            ctapAuthenticatorSession.onGoingCredentialManagementCredentialSession = null
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+        }
+
+        if (!session.hasNext()) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NOT_ALLOWED)
+        }
+
+        val credential = session.next()
+        // No totalCredentials for subsequent responses
+        return buildCredentialResponse(credential, null)
+    }
+
+    // ========================================================================
+    // Subcommand: deleteCredential (0x06)
+    // ========================================================================
+
+    private fun handleDeleteCredential(): AuthenticatorCredentialManagementResponse {
+        val subCommandParams = request.subCommandParams
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        val subCommandParamsBytes = ctapAuthenticatorSession.objectConverter.cborMapper
+            .writeValueAsBytes(subCommandParams)
+        val message = byteArrayOf(request.subCommand.value.toByte()) + subCommandParamsBytes
+        verifyPinUvAuthParam(message, requireNoPermissionsRpId = false)
+
+        val credentialID = subCommandParams.credentialID
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        val credential = findCredentialById(credentialID.id)
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
+
+        // If permissionsRpId is set, it must match the RP ID of the target credential
+        val protocol = resolveProtocol()
+        val tokenRpId = protocol.tokenState.permissionsRpId
+        if (tokenRpId != null && tokenRpId != credential.rpId) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        ctapAuthenticatorSession.authenticatorPropertyStore.removeUserCredential(credential.credentialId)
+
+        return AuthenticatorCredentialManagementResponse(CtapStatusCode.CTAP2_OK)
+    }
+
+    // ========================================================================
+    // Subcommand: updateUserInformation (0x07)
+    // ========================================================================
+
+    private fun handleUpdateUserInformation(): AuthenticatorCredentialManagementResponse {
+        val subCommandParams = request.subCommandParams
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        val subCommandParamsBytes = ctapAuthenticatorSession.objectConverter.cborMapper
+            .writeValueAsBytes(subCommandParams)
+        val message = byteArrayOf(request.subCommand.value.toByte()) + subCommandParamsBytes
+        verifyPinUvAuthParam(message, requireNoPermissionsRpId = false)
+
+        val credentialID = subCommandParams.credentialID
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        val user = subCommandParams.user
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        val credential = findCredentialById(credentialID.id)
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_NO_CREDENTIALS)
+
+        // If permissionsRpId is set, it must match the RP ID of the target credential
+        val protocol = resolveProtocol()
+        val tokenRpId = protocol.tokenState.permissionsRpId
+        if (tokenRpId != null && tokenRpId != credential.rpId) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        // The user.id must match the existing credential's userHandle
+        if (!user.id.contentEquals(credential.userHandle)) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+        }
+
+        // Create updated credential with new user information
+        val updatedCredential = ResidentUserCredential(
+            credentialId = credential.credentialId,
+            credentialKey = credential.credentialKey,
+            userHandle = credential.userHandle,
+            username = user.name,
+            displayName = user.displayName,
+            icon = credential.icon,
+            rpId = credential.rpId,
+            rpName = credential.rpName,
+            rpIcon = credential.rpIcon,
+            counter = credential.counter,
+            createdAt = credential.createdAt,
+            otherUI = credential.otherUI,
+            details = credential.details
+        )
+
+        ctapAuthenticatorSession.authenticatorPropertyStore.saveUserCredential(updatedCredential)
+
+        return AuthenticatorCredentialManagementResponse(CtapStatusCode.CTAP2_OK)
+    }
+
+    // ========================================================================
+    // PIN/UV Auth Verification Helper
+    // ========================================================================
+
+    /**
+     * Verifies the pinUvAuthParam against the given message.
+     * Checks CM permission and optionally requires no permissionsRpId restriction.
+     *
+     * @param message the message to verify the pinUvAuthParam against
+     * @param requireNoPermissionsRpId if true, permissionsRpId must be null
+     */
+    private fun verifyPinUvAuthParam(message: ByteArray, requireNoPermissionsRpId: Boolean) {
+        val pinUvAuthParam = request.pinUvAuthParam
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+
+        // TODO: Support persistentPinUvAuthToken with pcmr permission for read-only operations (§6.8)
+
+        val protocol = resolveProtocol()
+
+        // Verify the pinUvAuthParam
+        if (!protocol.verify(protocol.pinUvAuthToken, message, pinUvAuthParam)) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        // Check userVerifiedFlagValue
+        if (!protocol.tokenState.getUserVerifiedFlagValue()) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        // Check CM permission
+        if (!protocol.tokenState.hasPermission(PinUvAuthTokenPermission.CM)) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        // For some subcommands, permissionsRpId must be null (no RP ID restriction)
+        if (requireNoPermissionsRpId && protocol.tokenState.permissionsRpId != null) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        protocol.tokenState.recordTokenUsage()
+    }
+
+    /**
+     * Resolve the PinUvAuthProtocol matching the request's pinUvAuthProtocol.
+     */
+    private fun resolveProtocol(): PinUvAuthProtocol {
+        val pinUvAuthProtocol = request.pinUvAuthProtocol
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        return ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols
+            .firstOrNull { it.version == pinUvAuthProtocol }
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+    }
+
+    // ========================================================================
+    // Response Building Helpers
+    // ========================================================================
+
+    /**
+     * Build response for an RP entry.
+     */
+    private fun buildRpResponse(rpId: String, totalRPs: UInt?): AuthenticatorCredentialManagementResponse {
+        val rp = PublicKeyCredentialRpEntity(rpId, rpId)
+        val rpIDHash = MessageDigestUtil.createSHA256().digest(rpId.toByteArray())
+
+        val responseData = AuthenticatorCredentialManagementResponseData(
+            existingResidentCredentialsCount = null,
+            maxPossibleRemainingResidentCredentialsCount = null,
+            rp = rp,
+            rpIDHash = rpIDHash,
+            totalRPs = totalRPs,
+            user = null,
+            credentialID = null,
+            publicKey = null,
+            totalCredentials = null,
+            credProtect = null
+        )
+        return AuthenticatorCredentialManagementResponse(CtapStatusCode.CTAP2_OK, responseData)
+    }
+
+    /**
+     * Build response for a credential entry.
+     */
+    private fun buildCredentialResponse(
+        credential: ResidentUserCredential,
+        totalCredentials: UInt?
+    ): AuthenticatorCredentialManagementResponse {
+        val user = PublicKeyCredentialUserEntity(
+            credential.userHandle,
+            credential.username ?: "",
+            credential.displayName ?: ""
+        )
+
+        val credentialID = PublicKeyCredentialDescriptor(
+            PublicKeyCredentialType.PUBLIC_KEY,
+            credential.credentialId,
+            null
+        )
+
+        val publicKey = extractPublicCOSEKey(credential)
+
+        // Extract credProtect value from credential details (default: level 1 = userVerificationOptional)
+        val credProtect = credential.details["credProtect"]?.toUIntOrNull() ?: 1u
+
+        val responseData = AuthenticatorCredentialManagementResponseData(
+            existingResidentCredentialsCount = null,
+            maxPossibleRemainingResidentCredentialsCount = null,
+            rp = null,
+            rpIDHash = null,
+            totalRPs = null,
+            user = user,
+            credentialID = credentialID,
+            publicKey = publicKey,
+            totalCredentials = totalCredentials,
+            credProtect = credProtect
+        )
+        return AuthenticatorCredentialManagementResponse(CtapStatusCode.CTAP2_OK, responseData)
+    }
+
+    /**
+     * Extract the public COSEKey from a credential's key pair.
+     */
+    private fun extractPublicCOSEKey(credential: ResidentUserCredential): COSEKey {
+        val keyPair = credential.credentialKey.keyPair
+            ?: throw IllegalStateException("Credential key pair must not be null")
+        val alg = credential.credentialKey.alg
+            ?: throw IllegalStateException("Credential algorithm must not be null")
+        val coseAlg = COSEAlgorithmIdentifier.create(alg)
+
+        return when (val publicKey = keyPair.public) {
+            is ECPublicKey -> EC2COSEKey.create(publicKey, coseAlg)
+            is RSAPublicKey -> RSACOSEKey.create(publicKey, coseAlg)
+            else -> throw IllegalArgumentException("Unsupported key type: ${keyPair.public.javaClass}")
+        }
+    }
+
+    // ========================================================================
+    // Credential Lookup Helper
+    // ========================================================================
+
+    /**
+     * Find a resident credential by its credential ID across all RPs.
+     */
+    private fun findCredentialById(credentialId: ByteArray): ResidentUserCredential? {
+        val allRpIds = ctapAuthenticatorSession.authenticatorPropertyStore.loadAllRpIds()
+        for (rpId in allRpIds) {
+            val credentials = ctapAuthenticatorSession.authenticatorPropertyStore.loadUserCredentials(rpId)
+            val found = credentials.firstOrNull { it.credentialId.contentEquals(credentialId) }
+            if (found != null) {
+                return found
+            }
+        }
+        return null
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -14,6 +14,7 @@ import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponseData
 import com.webauthn4j.ctap.core.data.CtapStatusCode
 import com.webauthn4j.ctap.core.data.options.AlwaysUvOption
 import com.webauthn4j.ctap.core.data.options.ClientPINOption
+import com.webauthn4j.ctap.core.data.options.CredMgmtOption
 import com.webauthn4j.ctap.core.data.options.MakeCredUvNotRqdOption
 import com.webauthn4j.ctap.core.data.options.PinUvAuthTokenOption
 import com.webauthn4j.ctap.core.data.options.PlatformOption
@@ -99,7 +100,6 @@ internal class GetInfoExecution(
         // TODO: §6.4 uvBioEnroll — depends on bioEnroll, not yet implemented
         // TODO: §6.4 authnrCfg — authenticatorConfig command not yet implemented
         // TODO: §6.4 uvAcfg — depends on authnrCfg, not yet implemented
-        // TODO: §6.4 credMgmt — authenticatorCredentialManagement command not yet implemented
         // TODO: §6.4 perCredMgmtRO — depends on credMgmt, not yet implemented
         // TODO: §6.4 credentialMgmtPreview — FIDO_2_1_PRE prototype, not yet implemented
         // TODO: §6.4 setMinPINLength — depends on authnrCfg, not yet implemented
@@ -141,7 +141,7 @@ internal class GetInfoExecution(
                     null, // uvBioEnroll
                     null, // authnrCfg
                     null, // uvAcfg
-                    null, // credMgmt
+                    CredMgmtOption.SUPPORTED, // credMgmt
                     null, // perCredMgmtRO
                     null, // credentialMgmtPreview
                     null, // setMinPINLength

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/AuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/AuthenticatorPropertyStore.kt
@@ -83,5 +83,19 @@ interface AuthenticatorPropertyStore {
      */
     fun clear()
 
+    /**
+     * Load all RP IDs that have at least one stored credential
+     *
+     * @return set of RP IDs
+     */
+    fun loadAllRpIds(): Set<String> = emptySet()
+
+    /**
+     * Count all stored user credentials across all RPs
+     *
+     * @return total number of user credentials
+     */
+    fun countAllUserCredentials(): Int = 0
+
     var algorithms: Set<COSEAlgorithmIdentifier>
 }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
@@ -70,14 +70,24 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
         return map[rpId]?.values?.toList() ?: emptyList()
     }
 
+    override fun loadAllRpIds(): Set<String> {
+        return map.keys.filter { map[it]?.isNotEmpty() == true }.toSet()
+    }
+
+    override fun countAllUserCredentials(): Int {
+        return map.values.sumOf { it.size }
+    }
+
     override fun removeUserCredential(credentialId: ByteArray) {
-        map.keys.forEach(Consumer { rpId: String ->
-            val userCredentials =
-                map[rpId] ?: throw RelyingPartyNotFoundException("Relying party not found")
-            userCredentials[credentialId]
-                ?: throw CredentialNotFoundException("Credential not found")
-            userCredentials.remove(credentialId)
-        })
+        for (rpId in map.keys) {
+            val userCredentials = map[rpId] ?: continue
+            val key = userCredentials.keys.firstOrNull { it.contentEquals(credentialId) }
+            if (key != null) {
+                userCredentials.remove(key)
+                return
+            }
+        }
+        throw CredentialNotFoundException("Credential not found")
     }
 
     override fun supports(alg: COSEAlgorithmIdentifier): Boolean {

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
@@ -36,6 +36,10 @@ class CtapRequestConverter(objectConverter: ObjectConverter) {
             )!!
             CtapCommand.RESET.value.toUByte() -> AuthenticatorResetRequest()
             CtapCommand.GET_NEXT_ASSERTION.value.toUByte() -> AuthenticatorGetNextAssertionRequest()
+            CtapCommand.CREDENTIAL_MANAGEMENT.value.toUByte() -> cborMapper.readValue(
+                commandParameters,
+                AuthenticatorCredentialManagementRequest::class.java
+            )!!
             CtapCommand.SELECTION.value.toUByte() -> AuthenticatorSelectionRequest()
             else -> throw IllegalArgumentException(
                 String.format(

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverter.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverter.kt
@@ -4,6 +4,8 @@ package com.webauthn4j.ctap.core.converter
 import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINResponseData
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementResponse
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoResponse
@@ -78,6 +80,13 @@ class CtapResponseConverter(objectConverter: ObjectConverter) {
                     AuthenticatorGetNextAssertionResponseData::class.java
                 )
                 AuthenticatorGetNextAssertionResponse(statusCode, responseData)
+            }
+            AuthenticatorCredentialManagementResponse::class.java -> {
+                val responseData = cborMapper.readValue(
+                    responseDataBytes,
+                    AuthenticatorCredentialManagementResponseData::class.java
+                )
+                AuthenticatorCredentialManagementResponse(statusCode, responseData)
             }
             else -> throw IllegalArgumentException("Unsupported response type is provided.")
         }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
@@ -5,6 +5,9 @@ import com.webauthn4j.ctap.core.converter.jackson.deserializer.CoercionLessByteA
 import com.webauthn4j.ctap.core.converter.jackson.deserializer.PinUvAuthTokenPermissionsDeserializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorClientPINRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorClientPINResponseDataSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorCredentialManagementRequestSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorCredentialManagementRequestSubCommandParamsSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorCredentialManagementResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorGetAssertionRequestOptionsSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorGetAssertionRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorGetAssertionResponseDataSerializer
@@ -21,10 +24,10 @@ import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorResetR
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorSelectionRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorSelectionResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.PinUvAuthTokenPermissionsSerializer
-import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialRpEntitySerializer
-import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialUserEntitySerializer
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINResponseData
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoRequest
@@ -37,8 +40,6 @@ import com.webauthn4j.ctap.core.data.AuthenticatorResetRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorResetResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorSelectionRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponseData
-import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialRpEntity
-import com.webauthn4j.ctap.core.data.CtapPublicKeyCredentialUserEntity
 import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermissions
 
 class CtapCBORModule : SimpleModule("CtapCBORModule") {
@@ -50,6 +51,18 @@ class CtapCBORModule : SimpleModule("CtapCBORModule") {
         this.addSerializer(
             AuthenticatorClientPINResponseData::class.java,
             AuthenticatorClientPINResponseDataSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorCredentialManagementRequest::class.java,
+            AuthenticatorCredentialManagementRequestSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorCredentialManagementRequest.SubCommandParams::class.java,
+            AuthenticatorCredentialManagementRequestSubCommandParamsSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorCredentialManagementResponseData::class.java,
+            AuthenticatorCredentialManagementResponseDataSerializer()
         )
         this.addSerializer(
             AuthenticatorGetAssertionRequest::class.java,
@@ -111,15 +124,6 @@ class CtapCBORModule : SimpleModule("CtapCBORModule") {
             AuthenticatorSelectionResponseData::class.java,
             AuthenticatorSelectionResponseDataSerializer()
         )
-        this.addSerializer(
-            CtapPublicKeyCredentialRpEntity::class.java,
-            CtapPublicKeyCredentialRpEntitySerializer()
-        )
-        this.addSerializer(
-            CtapPublicKeyCredentialUserEntity::class.java,
-            CtapPublicKeyCredentialUserEntitySerializer()
-        )
-
         this.addSerializer(PinUvAuthTokenPermissions::class.java, PinUvAuthTokenPermissionsSerializer())
 
         this.addDeserializer(ByteArray::class.java, CoercionLessByteArrayDeserializer())

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorCredentialManagementRequestSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorCredentialManagementRequestSerializer.kt
@@ -1,0 +1,13 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementRequest
+
+class AuthenticatorCredentialManagementRequestSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorCredentialManagementRequest>(
+        AuthenticatorCredentialManagementRequest::class.java, listOf(
+            FieldSerializationRule(1, AuthenticatorCredentialManagementRequest::subCommand),
+            FieldSerializationRule(2, AuthenticatorCredentialManagementRequest::subCommandParams),
+            FieldSerializationRule(3, AuthenticatorCredentialManagementRequest::pinUvAuthProtocol),
+            FieldSerializationRule(4, AuthenticatorCredentialManagementRequest::pinUvAuthParam)
+        )
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorCredentialManagementRequestSubCommandParamsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorCredentialManagementRequestSubCommandParamsSerializer.kt
@@ -1,0 +1,12 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementRequest
+
+class AuthenticatorCredentialManagementRequestSubCommandParamsSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorCredentialManagementRequest.SubCommandParams>(
+        AuthenticatorCredentialManagementRequest.SubCommandParams::class.java, listOf(
+            FieldSerializationRule(1, AuthenticatorCredentialManagementRequest.SubCommandParams::rpIDHash),
+            FieldSerializationRule(2, AuthenticatorCredentialManagementRequest.SubCommandParams::credentialID),
+            FieldSerializationRule(3, AuthenticatorCredentialManagementRequest.SubCommandParams::user)
+        )
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorCredentialManagementResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorCredentialManagementResponseDataSerializer.kt
@@ -1,0 +1,19 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorCredentialManagementResponseData
+
+class AuthenticatorCredentialManagementResponseDataSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorCredentialManagementResponseData>(
+        AuthenticatorCredentialManagementResponseData::class.java, listOf(
+            FieldSerializationRule(1, AuthenticatorCredentialManagementResponseData::existingResidentCredentialsCount),
+            FieldSerializationRule(2, AuthenticatorCredentialManagementResponseData::maxPossibleRemainingResidentCredentialsCount),
+            FieldSerializationRule(3, AuthenticatorCredentialManagementResponseData::rp),
+            FieldSerializationRule(4, AuthenticatorCredentialManagementResponseData::rpIDHash),
+            FieldSerializationRule(5, AuthenticatorCredentialManagementResponseData::totalRPs),
+            FieldSerializationRule(6, AuthenticatorCredentialManagementResponseData::user),
+            FieldSerializationRule(7, AuthenticatorCredentialManagementResponseData::credentialID),
+            FieldSerializationRule(8, AuthenticatorCredentialManagementResponseData::publicKey),
+            FieldSerializationRule(9, AuthenticatorCredentialManagementResponseData::totalCredentials),
+            FieldSerializationRule(10, AuthenticatorCredentialManagementResponseData::credProtect)
+        )
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorCredentialManagementRequest.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorCredentialManagementRequest.kt
@@ -1,0 +1,98 @@
+package com.webauthn4j.ctap.core.data
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.webauthn4j.ctap.core.util.internal.HexUtil
+import com.webauthn4j.data.PinProtocolVersion
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialUserEntity
+import com.webauthn4j.util.ArrayUtil
+
+@Suppress("CanBePrimaryConstructorProperty")
+class AuthenticatorCredentialManagementRequest @JsonCreator constructor(
+    @JsonProperty("1") subCommand: CredentialManagementSubCommand,
+    @JsonProperty("2") subCommandParams: SubCommandParams?,
+    @JsonProperty("3") pinUvAuthProtocol: PinProtocolVersion?,
+    @JsonProperty("4") pinUvAuthParam: ByteArray?
+) : CtapRequest {
+
+    override val command: CtapCommand = CtapCommand.CREDENTIAL_MANAGEMENT
+
+    val subCommand: CredentialManagementSubCommand = subCommand
+    val subCommandParams: SubCommandParams? = subCommandParams
+    val pinUvAuthProtocol: PinProtocolVersion? = pinUvAuthProtocol
+    val pinUvAuthParam: ByteArray? = ArrayUtil.clone(pinUvAuthParam)
+        get() = ArrayUtil.clone(field)
+
+    @Suppress("CanBePrimaryConstructorProperty")
+    class SubCommandParams @JsonCreator constructor(
+        @JsonProperty("1") rpIDHash: ByteArray?,
+        @JsonProperty("2") credentialID: PublicKeyCredentialDescriptor?,
+        @JsonProperty("3") user: PublicKeyCredentialUserEntity?
+    ) {
+
+        val rpIDHash: ByteArray? = ArrayUtil.clone(rpIDHash)
+            get() = ArrayUtil.clone(field)
+        val credentialID: PublicKeyCredentialDescriptor? = credentialID
+        val user: PublicKeyCredentialUserEntity? = user
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as SubCommandParams
+
+            if (rpIDHash != null) {
+                if (other.rpIDHash == null) return false
+                if (!rpIDHash.contentEquals(other.rpIDHash)) return false
+            } else if (other.rpIDHash != null) return false
+            if (credentialID != other.credentialID) return false
+            if (user != other.user) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = rpIDHash?.contentHashCode() ?: 0
+            result = 31 * result + (credentialID?.hashCode() ?: 0)
+            result = 31 * result + (user?.hashCode() ?: 0)
+            return result
+        }
+
+        override fun toString(): String {
+            return "SubCommandParams(rpIDHash=${HexUtil.encodeToString(rpIDHash)}, credentialID=$credentialID, user=$user)"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AuthenticatorCredentialManagementRequest
+
+        if (subCommand != other.subCommand) return false
+        if (subCommandParams != other.subCommandParams) return false
+        if (pinUvAuthProtocol != other.pinUvAuthProtocol) return false
+        if (pinUvAuthParam != null) {
+            if (other.pinUvAuthParam == null) return false
+            if (!pinUvAuthParam.contentEquals(other.pinUvAuthParam)) return false
+        } else if (other.pinUvAuthParam != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = subCommand.hashCode()
+        result = 31 * result + (subCommandParams?.hashCode() ?: 0)
+        result = 31 * result + (pinUvAuthProtocol?.hashCode() ?: 0)
+        result = 31 * result + (pinUvAuthParam?.contentHashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "AuthenticatorCredentialManagementRequest(subCommand=$subCommand, subCommandParams=$subCommandParams, pinUvAuthProtocol=$pinUvAuthProtocol, pinUvAuthParam=${
+            HexUtil.encodeToString(pinUvAuthParam)
+        })"
+    }
+
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorCredentialManagementResponse.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorCredentialManagementResponse.kt
@@ -1,0 +1,17 @@
+package com.webauthn4j.ctap.core.data
+
+class AuthenticatorCredentialManagementResponse : AbstractCtapResponse<AuthenticatorCredentialManagementResponseData> {
+    constructor(
+        statusCode: CtapStatusCode,
+        responseData: AuthenticatorCredentialManagementResponseData?
+    ) : super(
+        statusCode,
+        responseData
+    )
+
+    constructor(statusCode: CtapStatusCode) : super(statusCode, null)
+
+    override fun toString(): String {
+        return "AuthenticatorCredentialManagementResponse(statusCode=$statusCode, responseData=$responseData)"
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorCredentialManagementResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorCredentialManagementResponseData.kt
@@ -1,0 +1,81 @@
+package com.webauthn4j.ctap.core.data
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.webauthn4j.ctap.core.util.internal.HexUtil
+import com.webauthn4j.data.PublicKeyCredentialDescriptor
+import com.webauthn4j.data.PublicKeyCredentialRpEntity
+import com.webauthn4j.data.PublicKeyCredentialUserEntity
+import com.webauthn4j.data.attestation.authenticator.COSEKey
+import com.webauthn4j.util.ArrayUtil
+
+@Suppress("CanBePrimaryConstructorProperty")
+class AuthenticatorCredentialManagementResponseData @JsonCreator constructor(
+    @JsonProperty("1") existingResidentCredentialsCount: UInt?,
+    @JsonProperty("2") maxPossibleRemainingResidentCredentialsCount: UInt?,
+    @JsonProperty("3") rp: PublicKeyCredentialRpEntity?,
+    @JsonProperty("4") rpIDHash: ByteArray?,
+    @JsonProperty("5") totalRPs: UInt?,
+    @JsonProperty("6") user: PublicKeyCredentialUserEntity?,
+    @JsonProperty("7") credentialID: PublicKeyCredentialDescriptor?,
+    @JsonProperty("8") publicKey: COSEKey?,
+    @JsonProperty("9") totalCredentials: UInt?,
+    @JsonProperty("10") credProtect: UInt?
+) : CtapResponseData {
+
+    val existingResidentCredentialsCount: UInt? = existingResidentCredentialsCount
+    val maxPossibleRemainingResidentCredentialsCount: UInt? = maxPossibleRemainingResidentCredentialsCount
+    val rp: PublicKeyCredentialRpEntity? = rp
+    val rpIDHash: ByteArray? = ArrayUtil.clone(rpIDHash)
+        get() = ArrayUtil.clone(field)
+    val totalRPs: UInt? = totalRPs
+    val user: PublicKeyCredentialUserEntity? = user
+    val credentialID: PublicKeyCredentialDescriptor? = credentialID
+    val publicKey: COSEKey? = publicKey
+    val totalCredentials: UInt? = totalCredentials
+    val credProtect: UInt? = credProtect
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AuthenticatorCredentialManagementResponseData
+
+        if (existingResidentCredentialsCount != other.existingResidentCredentialsCount) return false
+        if (maxPossibleRemainingResidentCredentialsCount != other.maxPossibleRemainingResidentCredentialsCount) return false
+        if (rp != other.rp) return false
+        if (rpIDHash != null) {
+            if (other.rpIDHash == null) return false
+            if (!rpIDHash.contentEquals(other.rpIDHash)) return false
+        } else if (other.rpIDHash != null) return false
+        if (totalRPs != other.totalRPs) return false
+        if (user != other.user) return false
+        if (credentialID != other.credentialID) return false
+        if (publicKey != other.publicKey) return false
+        if (totalCredentials != other.totalCredentials) return false
+        if (credProtect != other.credProtect) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = existingResidentCredentialsCount?.hashCode() ?: 0
+        result = 31 * result + (maxPossibleRemainingResidentCredentialsCount?.hashCode() ?: 0)
+        result = 31 * result + (rp?.hashCode() ?: 0)
+        result = 31 * result + (rpIDHash?.contentHashCode() ?: 0)
+        result = 31 * result + (totalRPs?.hashCode() ?: 0)
+        result = 31 * result + (user?.hashCode() ?: 0)
+        result = 31 * result + (credentialID?.hashCode() ?: 0)
+        result = 31 * result + (publicKey?.hashCode() ?: 0)
+        result = 31 * result + (totalCredentials?.hashCode() ?: 0)
+        result = 31 * result + (credProtect?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "AuthenticatorCredentialManagementResponseData(existingResidentCredentialsCount=$existingResidentCredentialsCount, maxPossibleRemainingResidentCredentialsCount=$maxPossibleRemainingResidentCredentialsCount, rp=$rp, rpIDHash=${
+            HexUtil.encodeToString(rpIDHash)
+        }, totalRPs=$totalRPs, user=$user, credentialID=$credentialID, publicKey=$publicKey, totalCredentials=$totalCredentials, credProtect=$credProtect)"
+    }
+
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CredentialManagementSubCommand.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CredentialManagementSubCommand.kt
@@ -1,0 +1,32 @@
+package com.webauthn4j.ctap.core.data
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class CredentialManagementSubCommand(@get:JsonValue val value: UInt) {
+
+    GET_CREDS_METADATA(0x01u),
+    ENUMERATE_RPS_BEGIN(0x02u),
+    ENUMERATE_RPS_GET_NEXT_RP(0x03u),
+    ENUMERATE_CREDENTIALS_BEGIN(0x04u),
+    ENUMERATE_CREDENTIALS_GET_NEXT_CREDENTIAL(0x05u),
+    DELETE_CREDENTIAL(0x06u),
+    UPDATE_USER_INFORMATION(0x07u);
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun create(value: UInt): CredentialManagementSubCommand {
+            return when (value) {
+                0x01u -> GET_CREDS_METADATA
+                0x02u -> ENUMERATE_RPS_BEGIN
+                0x03u -> ENUMERATE_RPS_GET_NEXT_RP
+                0x04u -> ENUMERATE_CREDENTIALS_BEGIN
+                0x05u -> ENUMERATE_CREDENTIALS_GET_NEXT_CREDENTIAL
+                0x06u -> DELETE_CREDENTIAL
+                0x07u -> UPDATE_USER_INFORMATION
+                else -> throw IllegalArgumentException("value '$value' is out of range")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
@@ -9,6 +9,7 @@ data class CtapCommand(val value: Byte) {
         val GET_INFO = CtapCommand(0x04)
         val CLIENT_PIN = CtapCommand(0x06)
         val RESET = CtapCommand(0x07)
+        val CREDENTIAL_MANAGEMENT = CtapCommand(0x0A)
         val SELECTION = CtapCommand(0x0B)
     }
 
@@ -20,6 +21,7 @@ data class CtapCommand(val value: Byte) {
             GET_INFO -> "GET_INFO"
             CLIENT_PIN -> "CLIENT_PIN"
             RESET -> "RESET"
+            CREDENTIAL_MANAGEMENT -> "CREDENTIAL_MANAGEMENT"
             SELECTION -> "SELECTION"
             else -> "UNKNOWN_%02X".format(value)
         }


### PR DESCRIPTION
Add the CTAP 2.3 authenticatorCredentialManagement command with all 7 subcommands:

- **getCredsMetadata** (0x01) — returns credential count and remaining capacity
- **enumerateRPsBegin/GetNextRP** (0x02/0x03) — enumerate stored RPs with 30-second session timeout
- **enumerateCredentialsBegin/GetNextCredential** (0x04/0x05) — enumerate credentials per RP
- **deleteCredential** (0x06) — delete a credential by ID
- **updateUserInformation** (0x07) — update user name/displayName

Key changes:
- Extend \`AuthenticatorPropertyStore\` with \`loadAllRpIds()\` and \`countAllUserCredentials()\`
- Fix \`InMemoryAuthenticatorPropertyStore.removeUserCredential()\` ByteArray key comparison
- Set \`credMgmt=true\` in GetInfo options
- Allow CM permission in \`PinUvAuthManager\` token requests
- \`persistentPinUvAuthToken\` / \`pcmr\` permission is not yet implemented (TODO)