### PR TITLE
Remove deprecated icon field from CTAP entity classes

### DIFF
--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetAssertionExecution.kt
@@ -818,14 +818,12 @@ internal class GetAssertionExecution :
                 true -> CtapPublicKeyCredentialUserEntity(
                     credential.userHandle,
                     null,
-                    null,
                     null
                 )
                 false -> CtapPublicKeyCredentialUserEntity(
                     credential.userHandle,
                     credential.username,
-                    credential.displayName,
-                    credential.icon
+                    credential.displayName
                 )
             }
             else -> null

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetNextAssertionExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetNextAssertionExecution.kt
@@ -85,14 +85,12 @@ internal class GetNextAssertionExecution(
                 true -> CtapPublicKeyCredentialUserEntity(
                     credential.userHandle,
                     null,
-                    null,
                     null
                 )
                 false -> CtapPublicKeyCredentialUserEntity(
                     credential.userHandle,
                     credential.username,
-                    credential.displayName,
-                    credential.icon
+                    credential.displayName
                 )
             }
             else -> null

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/MakeCredentialExecution.kt
@@ -143,10 +143,8 @@ internal class MakeCredentialExecution :
         userCredentialBuilder.userHandle(user.id)
         userCredentialBuilder.username(user.name)
         userCredentialBuilder.displayName(user.displayName)
-        userCredentialBuilder.icon(user.icon)
         userCredentialBuilder.rpId(rpId)
         userCredentialBuilder.rpName(rp.name)
-        userCredentialBuilder.rpIcon(rp.icon)
         userCredentialBuilder.counter(counter)
         userCredentialBuilder.otherUI(null)
     }

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/CtapClientTest.kt
@@ -79,8 +79,8 @@ internal class CtapClientTest {
 
     private suspend fun makeCredential(): AuthenticatorMakeCredentialResponse {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity(RP_ID, "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity(RP_ID, "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetAssertionExecutionTest.kt
@@ -282,8 +282,8 @@ internal class GetAssertionExecutionTest {
         uv: Boolean = true
     ) {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/GetNextAssertionExecutionTest.kt
@@ -157,8 +157,8 @@ class GetNextAssertionExecutionTest {
         userId: ByteArray = byteArrayOf(0x01, 0x23)
     ) {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(userId, "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(userId, "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,

--- a/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
+++ b/webauthn4j-ctap-authenticator/src/test/kotlin/com/webauthn4j/ctap/authenticator/MakeCredentialExecutionTest.kt
@@ -41,8 +41,8 @@ internal class MakeCredentialExecutionTest {
         val connection = ctapAuthenticator.createSession()
 
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,
@@ -88,8 +88,8 @@ internal class MakeCredentialExecutionTest {
         val connection = ctapAuthenticator.createSession()
 
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,
@@ -131,8 +131,8 @@ internal class MakeCredentialExecutionTest {
         createdResidentKeyCount: Int
     ) {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,
@@ -188,8 +188,8 @@ internal class MakeCredentialExecutionTest {
         createdResidentKeyCount: Int
     ) {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,
@@ -242,8 +242,8 @@ internal class MakeCredentialExecutionTest {
         statusCode: CtapStatusCode
     ) {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,
@@ -286,8 +286,8 @@ internal class MakeCredentialExecutionTest {
     )
     suspend fun userPresence_test(userPresenceSetting: UserPresenceSetting, statusCode: CtapStatusCode) {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,
@@ -327,8 +327,8 @@ internal class MakeCredentialExecutionTest {
     @Test
     suspend fun userConsent_false_test() {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,
@@ -368,8 +368,8 @@ internal class MakeCredentialExecutionTest {
     @Test
     suspend fun unsupported_alg_test() {
         val clientDataHash = ByteArray(0)
-        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example", "rpIcon")
-        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe", "icon")
+        val rp = CtapPublicKeyCredentialRpEntity("example.com", "example")
+        val user = CtapPublicKeyCredentialUserEntity(byteArrayOf(0x01, 0x23), "John.doe", "John Doe")
         val pubKeyCredParams = listOf(
             PublicKeyCredentialParameters(
                 PublicKeyCredentialType.PUBLIC_KEY,

--- a/webauthn4j-ctap-client/src/main/kotlin/com/webauthn4j/ctap/client/WebAuthnClient.kt
+++ b/webauthn4j-ctap-client/src/main/kotlin/com/webauthn4j/ctap/client/WebAuthnClient.kt
@@ -66,12 +66,11 @@ class WebAuthnClient(
         val rpId = publicKeyCredentialCreationOptions.rp.id ?: publicKeyCredentialCreationContext.origin.host
         ?: throw WebAuthnClientException("WebAuthn client must have origin.")
         val rp =
-            CtapPublicKeyCredentialRpEntity(rpId, publicKeyCredentialCreationOptions.rp.name, null)
+            CtapPublicKeyCredentialRpEntity(rpId, publicKeyCredentialCreationOptions.rp.name)
         val user = CtapPublicKeyCredentialUserEntity(
             publicKeyCredentialCreationOptions.user.id,
             publicKeyCredentialCreationOptions.user.name,
-            publicKeyCredentialCreationOptions.user.displayName,
-            null
+            publicKeyCredentialCreationOptions.user.displayName
         )
         val authenticatorExtensions: AuthenticationExtensionsAuthenticatorInputs<RegistrationExtensionAuthenticatorInput>? =
             null //TODO: implement extension handling

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/CtapPublicKeyCredentialRpEntitySerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/CtapPublicKeyCredentialRpEntitySerializer.kt
@@ -6,7 +6,6 @@ class CtapPublicKeyCredentialRpEntitySerializer :
     AbstractCtapCanonicalCborSerializer<CtapPublicKeyCredentialRpEntity>(
         CtapPublicKeyCredentialRpEntity::class.java, listOf(
             FieldSerializationRule("id", CtapPublicKeyCredentialRpEntity::id),
-            FieldSerializationRule("icon", CtapPublicKeyCredentialRpEntity::icon),
             FieldSerializationRule("name", CtapPublicKeyCredentialRpEntity::name)
         )
     )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/CtapPublicKeyCredentialUserEntitySerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/CtapPublicKeyCredentialUserEntitySerializer.kt
@@ -6,7 +6,6 @@ class CtapPublicKeyCredentialUserEntitySerializer :
     AbstractCtapCanonicalCborSerializer<CtapPublicKeyCredentialUserEntity>(
         CtapPublicKeyCredentialUserEntity::class.java, listOf(
             FieldSerializationRule("id", CtapPublicKeyCredentialUserEntity::id),
-            FieldSerializationRule("icon", CtapPublicKeyCredentialUserEntity::icon),
             FieldSerializationRule("name", CtapPublicKeyCredentialUserEntity::name),
             FieldSerializationRule("displayName", CtapPublicKeyCredentialUserEntity::displayName)
         )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialRpEntity.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialRpEntity.kt
@@ -19,37 +19,25 @@ import java.io.Serializable
  */
 class CtapPublicKeyCredentialRpEntity : Serializable {
 
-    // ~ Instance fields
-    // ================================================================================================
     val id: String
     val name: String?
-    val icon: String?
 
-    // ~ Constructor
-    // ========================================================================================================
-    /**
-     * @param id   id
-     * @param name name
-     */
     @JsonCreator
     constructor(
         @JsonProperty("id") id: String,
-        @JsonProperty("name") name: String?,
-        @JsonProperty("icon") icon: String?
+        @JsonProperty("name") name: String?
     ) {
         this.id = id
         this.name = name
-        this.icon = icon
     }
 
     constructor(id: String) {
         this.id = id
         this.name = null
-        this.icon = null
     }
 
     override fun toString(): String {
-        return "PublicKeyCredentialRpEntity(id=${id}, name=$name, icon=$icon)"
+        return "CtapPublicKeyCredentialRpEntity(id=$id, name=$name)"
     }
 
     override fun equals(other: Any?): Boolean {
@@ -58,7 +46,6 @@ class CtapPublicKeyCredentialRpEntity : Serializable {
 
         if (id != other.id) return false
         if (name != other.name) return false
-        if (icon != other.icon) return false
 
         return true
     }
@@ -66,9 +53,6 @@ class CtapPublicKeyCredentialRpEntity : Serializable {
     override fun hashCode(): Int {
         var result = id.hashCode()
         result = 31 * result + (name?.hashCode() ?: 0)
-        result = 31 * result + (icon?.hashCode() ?: 0)
         return result
     }
-
-
 }

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialUserEntity.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapPublicKeyCredentialUserEntity.kt
@@ -21,36 +21,24 @@ import java.io.Serializable
  */
 class CtapPublicKeyCredentialUserEntity : Serializable {
 
-    /**
-     * @param id          id
-     * @param name        name
-     * @param displayName displayName
-     * @param icon        icon
-     */
     @JsonCreator
     constructor(
         @JsonProperty("id") id: ByteArray,
         @JsonProperty("name") name: String?,
-        @JsonProperty("displayName") displayName: String?,
-        @JsonProperty("icon") icon: String?
+        @JsonProperty("displayName") displayName: String?
     ) {
         this.id = ArrayUtil.clone(id)
         this.name = name
         this.displayName = displayName
-        this.icon = icon
     }
 
-    // ~ Instance fields
-    // ================================================================================================
     val id: ByteArray
         get() = ArrayUtil.clone(field)
     val name: String?
     val displayName: String?
-    val icon: String?
-
 
     override fun toString(): String {
-        return "PublicKeyCredentialUserEntity(id=${HexUtil.encodeToString(id)}, name=$name, displayName=$displayName, icon=$icon)"
+        return "CtapPublicKeyCredentialUserEntity(id=${HexUtil.encodeToString(id)}, name=$name, displayName=$displayName)"
     }
 
     override fun equals(other: Any?): Boolean {
@@ -60,7 +48,6 @@ class CtapPublicKeyCredentialUserEntity : Serializable {
         if (!id.contentEquals(other.id)) return false
         if (name != other.name) return false
         if (displayName != other.displayName) return false
-        if (icon != other.icon) return false
 
         return true
     }
@@ -69,9 +56,6 @@ class CtapPublicKeyCredentialUserEntity : Serializable {
         var result = id.contentHashCode()
         result = 31 * result + (name?.hashCode() ?: 0)
         result = 31 * result + (displayName?.hashCode() ?: 0)
-        result = 31 * result + (icon?.hashCode() ?: 0)
         return result
     }
-
-
 }


### PR DESCRIPTION
Remove the `icon` field from `CtapPublicKeyCredentialRpEntity`, `CtapPublicKeyCredentialUserEntity`, and their CBOR serializers.

The `icon` field was deprecated in WebAuthn Level 2 and is not part of the CTAP 2.3 specification.