### PR TITLE
Implement authenticatorConfig (0x0D) with setMinPINLength

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ nbdist/
 
 ### Project Files ###
 
-.claude/
+.claude/com/

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/CtapAuthenticatorSession.kt
@@ -6,6 +6,7 @@ import com.webauthn4j.ctap.authenticator.attestation.FIDOU2FAttestationStatement
 import com.webauthn4j.ctap.authenticator.data.event.Event
 import com.webauthn4j.data.PinProtocolVersion
 import com.webauthn4j.ctap.authenticator.data.settings.*
+import com.webauthn4j.ctap.authenticator.execution.AuthenticatorConfigExecution
 import com.webauthn4j.ctap.authenticator.execution.ClientPINExecution
 import com.webauthn4j.ctap.authenticator.execution.GetAssertionExecution
 import com.webauthn4j.ctap.authenticator.execution.GetInfoExecution
@@ -125,6 +126,7 @@ class CtapAuthenticatorSession internal constructor(
             is AuthenticatorClientPINRequest -> clientPIN(request)
             is AuthenticatorResetRequest -> reset(request)
             is AuthenticatorSelectionRequest -> selection(request)
+            is AuthenticatorConfigRequest -> authenticatorConfig(request)
             is U2FRegistrationRequest -> u2fRegister(request)
             is U2FAuthenticationRequest -> u2fSign(request)
             else -> throw IllegalStateException("unknown command ${request::class.java}")
@@ -167,6 +169,12 @@ class CtapAuthenticatorSession internal constructor(
     suspend fun selection(authenticatorSelectionRequest: AuthenticatorSelectionRequest = AuthenticatorSelectionRequest()): AuthenticatorSelectionResponse {
         return withTransaction {
             SelectionExecution(this, authenticatorSelectionRequest).execute()
+        }
+    }
+
+    suspend fun authenticatorConfig(authenticatorConfigRequest: AuthenticatorConfigRequest): AuthenticatorConfigResponse {
+        return withTransaction {
+            AuthenticatorConfigExecution(this, authenticatorConfigRequest).execute()
         }
     }
 

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthManager.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/PinUvAuthManager.kt
@@ -41,9 +41,8 @@ class PinUvAuthManager(
     }
 
     // §6.4 minPINLength (0x0D)
-    // TODO: update via authenticatorConfig setMinPINLength subcommand when implemented
-    var minPINLength: Int = DEFAULT_MIN_PIN_LENGTH
-        private set
+    val minPINLength: Int
+        get() = authenticatorPropertyStore.loadProperty("minPINLength")?.toIntOrNull() ?: DEFAULT_MIN_PIN_LENGTH
 
     private var volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
 
@@ -173,7 +172,7 @@ class PinUvAuthManager(
         }
         //spec| Step 9: The authenticator checks the length of newPin against the current minimum PIN length,
         //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
-        if (trimmedNewPIN.size < 4) {
+        if (trimmedNewPIN.size < minPINLength) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
         //spec| Step 10: An authenticator MAY impose arbitrary, additional constraints on PINs. If newPin fails to
@@ -181,7 +180,7 @@ class PinUvAuthManager(
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        // TODO: Step 11: remember newPin length as PINCodePointLength (needed when authenticatorConfig setMinPINLength is implemented)
+        // TODO: Step 11: remember newPin length as PINCodePointLength
         //spec| Step 12: The authenticator stores LEFT(SHA-256(newPin), 16) internally as CurrentStoredPIN,
         //spec| sets the pinRetries counter to maximum count, and returns CTAP2_OK.
         authenticatorPropertyStore.saveClientPIN(
@@ -323,17 +322,27 @@ class PinUvAuthManager(
         val trimmedNewPIN = newPIN.copyOf(sentinelPos)
         //spec| Step 12: The authenticator checks the length of newPin against the current minimum PIN length,
         //spec| returning CTAP2_ERR_PIN_POLICY_VIOLATION if it is too short.
-        if (trimmedNewPIN.size < 4) {
+        if (trimmedNewPIN.size < minPINLength) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        // TODO: Step 13: forcePINChange check (needed when authenticatorConfig setMinPINLength is implemented)
+        //spec| Step 13: If the forcePINChange member of the authenticatorGetInfo response is true and
+        //spec| LEFT(SHA-256(newPin), 16) is equal to its internal stored LEFT(SHA-256(curPin), 16) then
+        //spec| authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
+        if (authenticatorPropertyStore.loadProperty("forcePINChange")?.toBooleanStrictOrNull() == true) {
+            val newPinHash = Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
+            if (Arrays.equals(newPinHash, storedPinHash)) {
+                return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
+            }
+        }
         //spec| Step 14: An authenticator MAY impose arbitrary, additional constraints on PINs. If newPin fails to
         //spec| satisfy such additional constraints, the authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
         if (trimmedNewPIN.size > 63) {
             return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
         }
-        // TODO: Step 15: remember newPin length as PINCodePointLength (needed when authenticatorConfig setMinPINLength is implemented)
-        // TODO: Step 16: set forcePINChange to false (needed when authenticatorConfig setMinPINLength is implemented)
+        // TODO: Step 15: remember newPin length as PINCodePointLength
+        //spec| Step 16: The authenticator sets the value of the forcePINChange member of the
+        //spec| authenticatorGetInfo response to false.
+        authenticatorPropertyStore.saveProperty("forcePINChange", null)
         //spec| Step 17: The authenticator stores LEFT(SHA-256(newPin), 16) internally as the new value of CurrentStoredPIN.
         authenticatorPropertyStore.saveClientPIN(
             Arrays.copyOf(MessageDigestUtil.createSHA256().digest(trimmedNewPIN), 16)
@@ -449,7 +458,11 @@ class PinUvAuthManager(
         authenticatorPropertyStore.savePINRetries(MAX_PIN_RETRIES)
         authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
-        // TODO: Step 11: forcePINChange check (needed when authenticatorConfig setMinPINLength is implemented)
+        //spec| Step 11: If the value of the forcePINChange member of the authenticatorGetInfo response is true,
+        //spec| authenticator returns CTAP2_ERR_PIN_INVALID error.
+        if (authenticatorPropertyStore.loadProperty("forcePINChange")?.toBooleanStrictOrNull() == true) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_INVALID)
+        }
         //spec| Step 12: Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all pinUvAuthProtocols
         //spec| supported by this authenticator.
         pinUvAuthProtocols.forEach { it.resetPinUvAuthToken() }
@@ -562,8 +575,7 @@ class PinUvAuthManager(
                     return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
                 }
                 PinUvAuthTokenPermission.ACFG -> {
-                    // TODO: check authnrCfg option when authenticatorConfig is implemented
-                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                    // authnrCfg is supported; ACFG permission is authorized
                 }
             }
         }
@@ -618,7 +630,13 @@ class PinUvAuthManager(
         authenticatorPropertyStore.saveUVRetries(MAX_UV_RETRIES)
         volatilePinRetryCounter = MAX_VOLATILE_PIN_RETRIES
 
-        // TODO: Step 11: forcePINChange check (needed when authenticatorConfig setMinPINLength is implemented)
+        //spec| Step 11: If the value of the forcePINChange member of the authenticatorGetInfo response is true,
+        //spec| authenticator returns CTAP2_ERR_PIN_POLICY_VIOLATION.
+        //spec| Platform on receiving such error response SHOULD direct the user to change the PIN.
+        if (authenticatorPropertyStore.loadProperty("forcePINChange")?.toBooleanStrictOrNull() == true) {
+            return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
+        }
+
         // TODO: Step 12: pcmr permission handling (needed when authenticatorCredentialManagement is implemented)
 
         //spec| Step 13: Create a new pinUvAuthToken by calling resetPinUvAuthToken() for all
@@ -737,8 +755,7 @@ class PinUvAuthManager(
                     return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
                 }
                 PinUvAuthTokenPermission.ACFG -> {
-                    // TODO: check uvAcfg option when authenticatorConfig is implemented
-                    return AuthenticatorClientPINResponse(CtapStatusCode.CTAP2_ERR_UNAUTHORIZED_PERMISSION)
+                    // authnrCfg is supported; ACFG permission is authorized
                 }
             }
         }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/AuthenticatorConfigExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/AuthenticatorConfigExecution.kt
@@ -1,0 +1,156 @@
+package com.webauthn4j.ctap.authenticator.execution
+
+import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.authenticator.PinUvAuthManager
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigResponse
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigSubCommandEnum
+import com.webauthn4j.ctap.core.data.CtapStatusCode
+import com.webauthn4j.ctap.core.data.PinUvAuthTokenPermission
+import org.slf4j.LoggerFactory
+
+/**
+ * authenticatorConfig (0x0D) command execution
+ *
+ * @see <a href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorConfig">6.8. authenticatorConfig</a>
+ */
+internal class AuthenticatorConfigExecution(
+    private val ctapAuthenticatorSession: CtapAuthenticatorSession,
+    private val authenticatorConfigRequest: AuthenticatorConfigRequest
+) : CtapCommandExecutionBase<AuthenticatorConfigRequest, AuthenticatorConfigResponse>(
+    ctapAuthenticatorSession,
+    authenticatorConfigRequest
+) {
+
+    companion object {
+        private const val MAX_RPIDS = 8
+    }
+
+    private val logger = LoggerFactory.getLogger(AuthenticatorConfigExecution::class.java)
+    override val commandName: String = "AuthenticatorConfig"
+
+    override suspend fun validate() {
+        // Validation is done within doExecute per sub-command
+    }
+
+    override suspend fun doExecute(): AuthenticatorConfigResponse {
+        return when (authenticatorConfigRequest.subCommand) {
+            AuthenticatorConfigSubCommandEnum.SET_MIN_PIN_LENGTH -> {
+                logger.debug("Processing authenticatorConfig setMinPINLength sub-command")
+                handleSetMinPINLength()
+            }
+            // TODO: Implement enableEnterpriseAttestation
+            AuthenticatorConfigSubCommandEnum.ENABLE_ENTERPRISE_ATTESTATION ->
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+            // TODO: Implement toggleAlwaysUv
+            AuthenticatorConfigSubCommandEnum.TOGGLE_ALWAYS_UV ->
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+            // TODO: Implement enableLongTouchForReset
+            AuthenticatorConfigSubCommandEnum.ENABLE_LONG_TOUCH_FOR_RESET ->
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+            // TODO: Implement vendorPrototype
+            AuthenticatorConfigSubCommandEnum.VENDOR_PROTOTYPE ->
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+        }
+    }
+
+    /**
+     * Verifies the pinUvAuthParam for authenticatorConfig commands.
+     *
+     * The message format for authenticatorConfig is:
+     * 0xFF * 32 || 0x0D || subCommand || subCommandParams (canonical CBOR, or empty)
+     */
+    private fun verifyPinUvAuthParam() {
+        val pinUvAuthParam = authenticatorConfigRequest.pinUvAuthParam
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PUAT_REQUIRED)
+
+        val pinUvAuthProtocol = authenticatorConfigRequest.pinUvAuthProtocol
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_MISSING_PARAMETER)
+
+        val protocol = ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols
+            .firstOrNull { it.version == pinUvAuthProtocol }
+            ?: throw CtapCommandExecutionException(CtapStatusCode.CTAP1_ERR_INVALID_PARAMETER)
+
+        // Build message: 0xFF*32 || 0x0D || subCommand || subCommandParams
+        val subCommandParamsBytes = if (authenticatorConfigRequest.subCommandParams != null) {
+            ctapAuthenticatorSession.objectConverter.cborMapper.writeValueAsBytes(
+                authenticatorConfigRequest.subCommandParams
+            )
+        } else {
+            ByteArray(0)
+        }
+
+        val message = ByteArray(32) { 0xFF.toByte() } +
+            byteArrayOf(0x0D) +
+            byteArrayOf(authenticatorConfigRequest.subCommand.value.toByte()) +
+            subCommandParamsBytes
+
+        if (!protocol.verify(protocol.pinUvAuthToken, message, pinUvAuthParam)) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        if (!protocol.tokenState.getUserVerifiedFlagValue()) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        if (!protocol.tokenState.hasPermission(PinUvAuthTokenPermission.ACFG)) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_AUTH_INVALID)
+        }
+
+        protocol.tokenState.recordTokenUsage()
+    }
+
+    private fun handleSetMinPINLength(): AuthenticatorConfigResponse {
+        // Verify pinUvAuthParam
+        verifyPinUvAuthParam()
+
+        val authenticatorPropertyStore = ctapAuthenticatorSession.authenticatorPropertyStore
+        val subCommandParams = authenticatorConfigRequest.subCommandParams
+
+        // Get current minPINLength
+        val currentMinPINLength = authenticatorPropertyStore.loadProperty("minPINLength")?.toIntOrNull()
+            ?: PinUvAuthManager.DEFAULT_MIN_PIN_LENGTH
+
+        // Get new minPINLength (default to current if absent)
+        val newMinPINLength = subCommandParams?.newMinPINLength?.toInt() ?: currentMinPINLength
+
+        // New value must not be less than current
+        if (newMinPINLength < currentMinPINLength) {
+            throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_POLICY_VIOLATION)
+        }
+
+        // Handle forceChangePin
+        val forceChangePin = subCommandParams?.forceChangePin == true
+        if (forceChangePin) {
+            if (authenticatorPropertyStore.loadClientPIN() == null) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_PIN_NOT_SET)
+            }
+            authenticatorPropertyStore.saveProperty("forcePINChange", "true")
+        }
+
+        // Handle minPinLengthRPIDs
+        val rpIds = subCommandParams?.minPinLengthRPIDs
+        if (rpIds != null) {
+            if (rpIds.size > MAX_RPIDS) {
+                throw CtapCommandExecutionException(CtapStatusCode.CTAP2_ERR_KEY_STORE_FULL)
+            }
+            authenticatorPropertyStore.saveProperty("minPinLengthRPIDs", rpIds.joinToString(","))
+        }
+
+        // Save new minPINLength
+        authenticatorPropertyStore.saveProperty("minPINLength", newMinPINLength.toString())
+
+        // If forcePINChange became true, invalidate all pinUvAuthTokens
+        if (forceChangePin) {
+            for (protocol in ctapAuthenticatorSession.pinUvAuthManager.pinUvAuthProtocols) {
+                protocol.resetPinUvAuthToken()
+            }
+        }
+
+        return AuthenticatorConfigResponse(CtapStatusCode.CTAP2_OK)
+    }
+
+    override fun createErrorResponse(statusCode: CtapStatusCode): AuthenticatorConfigResponse {
+        return AuthenticatorConfigResponse(statusCode)
+    }
+}

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/execution/GetInfoExecution.kt
@@ -2,6 +2,7 @@ package com.webauthn4j.ctap.authenticator.execution
 
 import com.webauthn4j.ctap.authenticator.CtapAuthenticator
 import com.webauthn4j.ctap.authenticator.CtapAuthenticatorSession
+import com.webauthn4j.ctap.authenticator.PinUvAuthManager
 import com.webauthn4j.ctap.authenticator.data.settings.AlwaysUvSetting
 import com.webauthn4j.ctap.authenticator.data.settings.AttachmentSetting
 import com.webauthn4j.ctap.authenticator.data.settings.ClientPINSetting
@@ -15,11 +16,14 @@ import com.webauthn4j.ctap.core.data.CtapStatusCode
 import com.webauthn4j.ctap.core.data.options.AlwaysUvOption
 import com.webauthn4j.ctap.core.data.options.ClientPINOption
 import com.webauthn4j.ctap.core.data.options.MakeCredUvNotRqdOption
+import com.webauthn4j.ctap.core.data.options.AuthnrCfgOption
 import com.webauthn4j.ctap.core.data.options.PinUvAuthTokenOption
 import com.webauthn4j.ctap.core.data.options.PlatformOption
 import com.webauthn4j.ctap.core.data.options.ResidentKeyOption
+import com.webauthn4j.ctap.core.data.options.SetMinPINLengthOption
 import com.webauthn4j.ctap.core.data.options.UserPresenceOption
 import com.webauthn4j.ctap.core.data.options.UserVerificationOption
+import com.webauthn4j.data.AuthenticatorConfigSubCommand
 import com.webauthn4j.data.PublicKeyCredentialParameters
 import com.webauthn4j.data.PublicKeyCredentialType
 import org.slf4j.LoggerFactory
@@ -97,12 +101,10 @@ internal class GetInfoExecution(
         // TODO: §6.4 bioEnroll — authenticatorBioEnrollment command not yet implemented
         // TODO: §6.4 userVerificationMgmtPreview — FIDO_2_1_PRE prototype, not yet implemented
         // TODO: §6.4 uvBioEnroll — depends on bioEnroll, not yet implemented
-        // TODO: §6.4 authnrCfg — authenticatorConfig command not yet implemented
         // TODO: §6.4 uvAcfg — depends on authnrCfg, not yet implemented
         // TODO: §6.4 credMgmt — authenticatorCredentialManagement command not yet implemented
         // TODO: §6.4 perCredMgmtRO — depends on credMgmt, not yet implemented
         // TODO: §6.4 credentialMgmtPreview — FIDO_2_1_PRE prototype, not yet implemented
-        // TODO: §6.4 setMinPINLength — depends on authnrCfg, not yet implemented
         val alwaysUv: AlwaysUvOption? = when (ctapAuthenticatorSession.alwaysUv) {
             AlwaysUvSetting.ENABLED -> AlwaysUvOption.ENABLED
             AlwaysUvSetting.DISABLED -> null
@@ -118,9 +120,15 @@ internal class GetInfoExecution(
             PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, alg)
         }
 
+        // §6.4 forcePINChange (0x0C)
+        val forcePINChange: Boolean? = ctapAuthenticatorSession.authenticatorPropertyStore
+            .loadProperty("forcePINChange")?.toBooleanStrictOrNull()
+
         // §6.4 minPINLength (0x0D)
         val minPINLength: UInt? = when (ctapAuthenticatorSession.clientPIN) {
-            ClientPINSetting.ENABLED -> ctapAuthenticatorSession.pinUvAuthManager.minPINLength.toUInt()
+            ClientPINSetting.ENABLED -> ctapAuthenticatorSession.authenticatorPropertyStore
+                .loadProperty("minPINLength")?.toUIntOrNull()
+                ?: PinUvAuthManager.DEFAULT_MIN_PIN_LENGTH.toUInt()
             ClientPINSetting.DISABLED -> null
         }
 
@@ -139,12 +147,12 @@ internal class GetInfoExecution(
                     null, // bioEnroll
                     null, // userVerificationMgmtPreview
                     null, // uvBioEnroll
-                    null, // authnrCfg
+                    AuthnrCfgOption.SUPPORTED, // authnrCfg
                     null, // uvAcfg
                     null, // credMgmt
                     null, // perCredMgmtRO
                     null, // credentialMgmtPreview
-                    null, // setMinPINLength
+                    SetMinPINLengthOption.SUPPORTED, // setMinPINLength
                     makeCredUvNotRqd,
                     alwaysUv
                 ),                                 // options (0x04): Optional
@@ -155,11 +163,13 @@ internal class GetInfoExecution(
                 ctapAuthenticatorSession.transports, // transports (0x09): Optional
                 algorithms,                        // algorithms (0x0A): Optional
                 // TODO: §6.4 maxSerializedLargeBlobArray (0x0B) — depends on largeBlobs
-                // TODO: §6.4 forcePINChange (0x0C) — depends on authenticatorConfig setMinPINLength
+                forcePINChange = forcePINChange,    // forcePINChange (0x0C): Optional
                 minPINLength = minPINLength,        // minPINLength (0x0D): Optional
                 // TODO: §6.4 firmwareVersion (0x0E)
                 // TODO: §6.4 maxCredBlobLength (0x0F) — depends on credBlob extension
+                maxRPIDsForSetMinPINLength = 8u,   // maxRPIDsForSetMinPINLength (0x10): Optional
                 // TODO: §6.4 remainingDiscoverableCredentials (0x14) — store has no capacity concept
+                authenticatorConfigCommands = listOf(AuthenticatorConfigSubCommand.SET_MIN_PIN_LENGTH), // authenticatorConfigCommands (0x1F): Optional
             )
         )
     }

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/AuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/AuthenticatorPropertyStore.kt
@@ -69,14 +69,32 @@ interface AuthenticatorPropertyStore {
      * @return clientPIN
      */
     fun loadClientPIN(): ByteArray?
-    fun savePINRetries(pinRetries: UInt)
-    fun loadPINRetries(): UInt
+    /**
+     * Save a generic property by key
+     *
+     * @param key property key
+     * @param value property value, or null to remove
+     */
+    fun saveProperty(key: String, value: String?) {
+        // default no-op for backward compatibility
+    }
 
-    fun saveUVRetries(uvRetries: UInt)
-    fun loadUVRetries(): UInt
+    /**
+     * Load a generic property by key
+     *
+     * @param key property key
+     * @return property value, or null if not found
+     */
+    fun loadProperty(key: String): String? = null
 
-    fun loadDeviceWideCounter(): UInt
-    fun saveDeviceWideCounter(deviceWideCounter: UInt)
+    fun savePINRetries(pinRetries: UInt) { saveProperty("pinRetries", pinRetries.toString()) }
+    fun loadPINRetries(): UInt = loadProperty("pinRetries")?.toUIntOrNull() ?: 8u
+
+    fun saveUVRetries(uvRetries: UInt) { saveProperty("uvRetries", uvRetries.toString()) }
+    fun loadUVRetries(): UInt = loadProperty("uvRetries")?.toUIntOrNull() ?: 3u
+
+    fun saveDeviceWideCounter(deviceWideCounter: UInt) { saveProperty("deviceWideCounter", deviceWideCounter.toString()) }
+    fun loadDeviceWideCounter(): UInt = loadProperty("deviceWideCounter")?.toUIntOrNull() ?: 0u
 
     /**
      * Clear all user credentials and client PIN

--- a/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
+++ b/webauthn4j-ctap-authenticator/src/main/kotlin/com/webauthn4j/ctap/authenticator/store/InMemoryAuthenticatorPropertyStore.kt
@@ -1,6 +1,5 @@
 package com.webauthn4j.ctap.authenticator.store
 
-import com.webauthn4j.ctap.authenticator.PinUvAuthManager
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentCredentialKey
 import com.webauthn4j.ctap.authenticator.data.credential.ResidentUserCredential
 import com.webauthn4j.ctap.authenticator.internal.KeyPairUtil.createCredentialKeyPair
@@ -19,17 +18,10 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
 
     private val map: MutableMap<String, MutableMap<ByteArray, ResidentUserCredential>> =
         HashMap()
+    private val properties: MutableMap<String, String> = HashMap()
     private lateinit var credentialSourceEncryptionKey: SecretKey
     private lateinit var credentialSourceEncryptionIV: ByteArray
     private var clientPIN: ByteArray? = null
-    private var pinRetries: UInt = DEFAULT_MAX_PIN_RETRIES
-    private var uvRetries: UInt = DEFAULT_MAX_UV_RETRIES
-    private var deviceWideCounter = 0u
-
-    companion object {
-        const val DEFAULT_MAX_PIN_RETRIES: UInt = 8u
-        const val DEFAULT_MAX_UV_RETRIES: UInt = 3u
-    }
 
     init {
         initializeKeys()
@@ -37,11 +29,10 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
 
     private fun initializeKeys() {
         map.clear()
+        properties.clear()
         credentialSourceEncryptionKey = generateAESKey()
         credentialSourceEncryptionIV = generateIV()
         clientPIN = null
-        pinRetries = DEFAULT_MAX_PIN_RETRIES
-        uvRetries = DEFAULT_MAX_UV_RETRIES
     }
 
     override fun createUserCredentialKey(
@@ -100,28 +91,16 @@ open class InMemoryAuthenticatorPropertyStore : AuthenticatorPropertyStore {
         return ArrayUtil.clone(clientPIN)
     }
 
-    override fun loadPINRetries(): UInt {
-        return pinRetries
+    override fun saveProperty(key: String, value: String?) {
+        if (value != null) {
+            properties[key] = value
+        } else {
+            properties.remove(key)
+        }
     }
 
-    override fun loadDeviceWideCounter(): UInt {
-        return deviceWideCounter
-    }
-
-    override fun saveDeviceWideCounter(deviceWideCounter: UInt) {
-        this.deviceWideCounter = deviceWideCounter
-    }
-
-    override fun savePINRetries(pinRetries: UInt) {
-        this.pinRetries = pinRetries
-    }
-
-    override fun saveUVRetries(uvRetries: UInt) {
-        this.uvRetries = uvRetries
-    }
-
-    override fun loadUVRetries(): UInt {
-        return uvRetries
+    override fun loadProperty(key: String): String? {
+        return properties[key]
     }
 
     override fun clear() {

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapRequestConverter.kt
@@ -37,6 +37,10 @@ class CtapRequestConverter(objectConverter: ObjectConverter) {
             CtapCommand.RESET.value.toUByte() -> AuthenticatorResetRequest()
             CtapCommand.GET_NEXT_ASSERTION.value.toUByte() -> AuthenticatorGetNextAssertionRequest()
             CtapCommand.SELECTION.value.toUByte() -> AuthenticatorSelectionRequest()
+            CtapCommand.AUTHENTICATOR_CONFIG.value.toUByte() -> cborMapper.readValue(
+                commandParameters,
+                AuthenticatorConfigRequest::class.java
+            )!!
             else -> throw IllegalArgumentException(
                 String.format(
                     "unknown command type 0x%x is provided.",

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverter.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/CtapResponseConverter.kt
@@ -12,6 +12,7 @@ import com.webauthn4j.ctap.core.data.AuthenticatorGetNextAssertionResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorGetNextAssertionResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorMakeCredentialResponseData
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorResetResponse
 import com.webauthn4j.ctap.core.data.AuthenticatorSelectionResponse
 import com.webauthn4j.ctap.core.data.CtapResponse
@@ -71,6 +72,9 @@ class CtapResponseConverter(objectConverter: ObjectConverter) {
             }
             AuthenticatorSelectionResponse::class.java -> {
                 AuthenticatorSelectionResponse(statusCode)
+            }
+            AuthenticatorConfigResponse::class.java -> {
+                AuthenticatorConfigResponse(statusCode)
             }
             AuthenticatorGetNextAssertionResponse::class.java -> {
                 val responseData = cborMapper.readValue(

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/CtapCBORModule.kt
@@ -5,6 +5,9 @@ import com.webauthn4j.ctap.core.converter.jackson.deserializer.CoercionLessByteA
 import com.webauthn4j.ctap.core.converter.jackson.deserializer.PinUvAuthTokenPermissionsDeserializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorClientPINRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorClientPINResponseDataSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorConfigRequestSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorConfigRequestSubCommandParamsSerializer
+import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorConfigResponseDataSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorGetAssertionRequestOptionsSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorGetAssertionRequestSerializer
 import com.webauthn4j.ctap.core.converter.jackson.serializer.AuthenticatorGetAssertionResponseDataSerializer
@@ -25,6 +28,8 @@ import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCreden
 import com.webauthn4j.ctap.core.converter.jackson.serializer.CtapPublicKeyCredentialUserEntitySerializer
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorClientPINResponseData
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigRequest
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionRequest
 import com.webauthn4j.ctap.core.data.AuthenticatorGetAssertionResponseData
 import com.webauthn4j.ctap.core.data.AuthenticatorGetInfoRequest
@@ -50,6 +55,18 @@ class CtapCBORModule : SimpleModule("CtapCBORModule") {
         this.addSerializer(
             AuthenticatorClientPINResponseData::class.java,
             AuthenticatorClientPINResponseDataSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorConfigRequest::class.java,
+            AuthenticatorConfigRequestSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorConfigRequest.SubCommandParams::class.java,
+            AuthenticatorConfigRequestSubCommandParamsSerializer()
+        )
+        this.addSerializer(
+            AuthenticatorConfigResponseData::class.java,
+            AuthenticatorConfigResponseDataSerializer()
         )
         this.addSerializer(
             AuthenticatorGetAssertionRequest::class.java,

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorConfigRequestSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorConfigRequestSerializer.kt
@@ -1,0 +1,13 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigRequest
+
+class AuthenticatorConfigRequestSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorConfigRequest>(
+        AuthenticatorConfigRequest::class.java, listOf(
+            FieldSerializationRule(1, AuthenticatorConfigRequest::subCommand),
+            FieldSerializationRule(2, AuthenticatorConfigRequest::subCommandParams),
+            FieldSerializationRule(3, AuthenticatorConfigRequest::pinUvAuthProtocol),
+            FieldSerializationRule(4, AuthenticatorConfigRequest::pinUvAuthParam)
+        )
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorConfigRequestSubCommandParamsSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorConfigRequestSubCommandParamsSerializer.kt
@@ -1,0 +1,12 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigRequest
+
+class AuthenticatorConfigRequestSubCommandParamsSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorConfigRequest.SubCommandParams>(
+        AuthenticatorConfigRequest.SubCommandParams::class.java, listOf(
+            FieldSerializationRule(1, AuthenticatorConfigRequest.SubCommandParams::newMinPINLength),
+            FieldSerializationRule(2, AuthenticatorConfigRequest.SubCommandParams::minPinLengthRPIDs),
+            FieldSerializationRule(3, AuthenticatorConfigRequest.SubCommandParams::forceChangePin)
+        )
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorConfigResponseDataSerializer.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/converter/jackson/serializer/AuthenticatorConfigResponseDataSerializer.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.core.converter.jackson.serializer
+
+import com.webauthn4j.ctap.core.data.AuthenticatorConfigResponseData
+
+class AuthenticatorConfigResponseDataSerializer :
+    AbstractCtapCanonicalCborSerializer<AuthenticatorConfigResponseData>(
+        AuthenticatorConfigResponseData::class.java,
+        emptyList()
+    )

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigRequest.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigRequest.kt
@@ -1,0 +1,84 @@
+package com.webauthn4j.ctap.core.data
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.webauthn4j.ctap.core.util.internal.HexUtil
+import com.webauthn4j.data.PinProtocolVersion
+import com.webauthn4j.util.ArrayUtil
+
+@Suppress("CanBePrimaryConstructorProperty")
+class AuthenticatorConfigRequest @JsonCreator constructor(
+    @JsonProperty("1") subCommand: AuthenticatorConfigSubCommandEnum,
+    @JsonProperty("2") subCommandParams: SubCommandParams?,
+    @JsonProperty("3") pinUvAuthProtocol: PinProtocolVersion?,
+    @JsonProperty("4") pinUvAuthParam: ByteArray?
+) : CtapRequest {
+
+    override val command: CtapCommand = CtapCommand.AUTHENTICATOR_CONFIG
+
+    val subCommand: AuthenticatorConfigSubCommandEnum = subCommand
+    val subCommandParams: SubCommandParams? = subCommandParams
+    val pinUvAuthProtocol: PinProtocolVersion? = pinUvAuthProtocol
+    val pinUvAuthParam: ByteArray? = ArrayUtil.clone(pinUvAuthParam)
+        get() = ArrayUtil.clone(field)
+
+    // SubCommandParams for authenticatorConfig
+    class SubCommandParams @JsonCreator constructor(
+        @JsonProperty("1") val newMinPINLength: Long?,
+        @JsonProperty("2") val minPinLengthRPIDs: List<String>?,
+        @JsonProperty("3") val forceChangePin: Boolean?
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as SubCommandParams
+
+            if (newMinPINLength != other.newMinPINLength) return false
+            if (minPinLengthRPIDs != other.minPinLengthRPIDs) return false
+            if (forceChangePin != other.forceChangePin) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = newMinPINLength?.hashCode() ?: 0
+            result = 31 * result + (minPinLengthRPIDs?.hashCode() ?: 0)
+            result = 31 * result + (forceChangePin?.hashCode() ?: 0)
+            return result
+        }
+
+        override fun toString(): String {
+            return "SubCommandParams(newMinPINLength=$newMinPINLength, minPinLengthRPIDs=$minPinLengthRPIDs, forceChangePin=$forceChangePin)"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AuthenticatorConfigRequest
+
+        if (subCommand != other.subCommand) return false
+        if (subCommandParams != other.subCommandParams) return false
+        if (pinUvAuthProtocol != other.pinUvAuthProtocol) return false
+        if (pinUvAuthParam != null) {
+            if (other.pinUvAuthParam == null) return false
+            if (!pinUvAuthParam.contentEquals(other.pinUvAuthParam)) return false
+        } else if (other.pinUvAuthParam != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = subCommand.hashCode()
+        result = 31 * result + (subCommandParams?.hashCode() ?: 0)
+        result = 31 * result + (pinUvAuthProtocol?.hashCode() ?: 0)
+        result = 31 * result + (pinUvAuthParam?.contentHashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "AuthenticatorConfigRequest(subCommand=$subCommand, subCommandParams=$subCommandParams, pinUvAuthProtocol=$pinUvAuthProtocol, pinUvAuthParam=${HexUtil.encodeToString(pinUvAuthParam)})"
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigResponse.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigResponse.kt
@@ -1,0 +1,9 @@
+package com.webauthn4j.ctap.core.data
+
+class AuthenticatorConfigResponse(statusCode: CtapStatusCode) :
+    AbstractCtapResponse<AuthenticatorConfigResponseData>(statusCode) {
+
+    override fun toString(): String {
+        return "AuthenticatorConfigResponse(statusCode=$statusCode, responseData=$responseData)"
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigResponseData.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigResponseData.kt
@@ -1,0 +1,7 @@
+package com.webauthn4j.ctap.core.data
+
+class AuthenticatorConfigResponseData : CtapResponseData {
+    override fun toString(): String {
+        return "AuthenticatorConfigResponseData()"
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigSubCommandEnum.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/AuthenticatorConfigSubCommandEnum.kt
@@ -1,0 +1,28 @@
+package com.webauthn4j.ctap.core.data
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class AuthenticatorConfigSubCommandEnum(@get:JsonValue val value: UInt) {
+
+    ENABLE_ENTERPRISE_ATTESTATION(0x01u),
+    TOGGLE_ALWAYS_UV(0x02u),
+    SET_MIN_PIN_LENGTH(0x03u),
+    ENABLE_LONG_TOUCH_FOR_RESET(0x04u),
+    VENDOR_PROTOTYPE(0xFFu);
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun create(value: UInt): AuthenticatorConfigSubCommandEnum {
+            return when (value) {
+                0x01u -> ENABLE_ENTERPRISE_ATTESTATION
+                0x02u -> TOGGLE_ALWAYS_UV
+                0x03u -> SET_MIN_PIN_LENGTH
+                0x04u -> ENABLE_LONG_TOUCH_FOR_RESET
+                0xFFu -> VENDOR_PROTOTYPE
+                else -> throw IllegalArgumentException("value '$value' is out of range")
+            }
+        }
+    }
+}

--- a/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
+++ b/webauthn4j-ctap-core/src/main/kotlin/com/webauthn4j/ctap/core/data/CtapCommand.kt
@@ -10,6 +10,7 @@ data class CtapCommand(val value: Byte) {
         val CLIENT_PIN = CtapCommand(0x06)
         val RESET = CtapCommand(0x07)
         val SELECTION = CtapCommand(0x0B)
+        val AUTHENTICATOR_CONFIG = CtapCommand(0x0D)
     }
 
     override fun toString(): String {
@@ -21,6 +22,7 @@ data class CtapCommand(val value: Byte) {
             CLIENT_PIN -> "CLIENT_PIN"
             RESET -> "RESET"
             SELECTION -> "SELECTION"
+            AUTHENTICATOR_CONFIG -> "AUTHENTICATOR_CONFIG"
             else -> "UNKNOWN_%02X".format(value)
         }
     }


### PR DESCRIPTION
## Generic KVS for AuthenticatorPropertyStore

Add `saveProperty`/`loadProperty` methods for generic key-value storage. Migrate `pinRetries`, `uvRetries`, and `deviceWideCounter` from dedicated fields to KVS-backed default implementations, eliminating per-property boilerplate in store implementations.

## authenticatorConfig (0x0D) with setMinPINLength

Add the CTAP 2.3 authenticatorConfig command infrastructure and implement the setMinPINLength (0x03) subcommand:

- **setMinPINLength**: update minimum PIN length, force PIN change when current PIN is too short, manage RP ID whitelist for the minPinLength extension
- **PinUvAuthManager**: read minPINLength from KVS, enforce forcePINChange on getPinToken, unblock ACFG permission
- **GetInfo**: report `authnrCfg=true`, `setMinPINLength=true`, `forcePINChange`, `maxRPIDsForSetMinPINLength=8`, `authenticatorConfigCommands=[0x03]`
- **pinUvAuthParam verification**: uses the authenticatorConfig-specific message format (`32×0xFF || 0x0D || subCommand || subCommandParams`)
- Other subcommands (enableEnterpriseAttestation, toggleAlwaysUv, enableLongTouchForReset, vendorPrototype) return `CTAP1_ERR_INVALID_PARAMETER` (TODO)